### PR TITLE
Fix nightly workflow

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -25,7 +25,7 @@ jobs:
   report-failure:
     runs-on: ubuntu-latest
     needs: [call-workflow]
-    if: ${{ always() && inputs.notify-on-failure && needs.call-workflow.result == 'failure' }}
+    if: ${{ always() && contains(inputs.notify-on-failure, 'true') && needs.call-workflow.result == 'failure' }}
     steps:
       - name: Report Failure
         run: |

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -3,14 +3,14 @@ name: Nightly Tests
 on:
   schedule:
     - cron: '23 10 * * *'  # random time in the middle of the night PT
-  workflow_dispatch:
-    inputs:
-      notify-on-failure:
-        default: false
-        type: boolean
-      force-failure:
-        default: false
-        type: boolean
+  # workflow_dispatch:
+  #   inputs:
+  #     notify-on-failure:
+  #       default: false
+  #       type: boolean
+  #     force-failure:
+  #       default: false
+  #       type: boolean
   workflow_call:
     inputs:
       notify-on-failure:

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -3,15 +3,7 @@ name: Nightly Tests
 on:
   schedule:
     - cron: '23 10 * * *'  # random time in the middle of the night PT
-  # workflow_dispatch:
-  #   inputs:
-  #     notify-on-failure:
-  #       default: false
-  #       type: boolean
-  #     force-failure:
-  #       default: false
-  #       type: boolean
-  workflow_call:
+  workflow_dispatch:
     inputs:
       notify-on-failure:
         default: false
@@ -26,7 +18,10 @@ jobs:
     with:
         triton-ref: 'main'
         triton-shared-ref: 'main'
-        force-failure: ${{ inputs.force-failure }}
+        # `inputs` variable is not available when the workflow is automatically triggered by a schedule.
+        # In such case, `inputs.force-failure` is an empty string which breaks the workflow. As a workaround,
+        # use the `contains` function to check if we really want to force failure.
+        force-failure: ${{ contains(inputs.force-failure, 'true') }}
   report-failure:
     runs-on: ubuntu-latest
     needs: [call-workflow]

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -20,8 +20,8 @@ jobs:
         triton-shared-ref: 'main'
         # The `inputs` variable is not available when the workflow is automatically triggered by a schedule.
         # In such case, `inputs.force-failure` is an empty string which breaks the workflow. As a workaround,
-        # compare the user provided input with `true` instead of using it directly.
-        force-failure: ${{ inputs.force-failure == 'true' }}
+        # check the user provided input if it contains `true` instead of using the value directly.
+        force-failure: ${{ contains(inputs.force-failure, 'true') }}
   report-failure:
     runs-on: ubuntu-latest
     needs: [call-workflow]

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -11,6 +11,14 @@ on:
       force-failure:
         default: false
         type: boolean
+  workflow_call:
+    inputs:
+      notify-on-failure:
+        default: false
+        type: boolean
+      force-failure:
+        default: false
+        type: boolean
 
 jobs:
   call-workflow:

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -18,7 +18,7 @@ jobs:
     with:
         triton-ref: 'main'
         triton-shared-ref: 'main'
-        # `inputs` variable is not available when the workflow is automatically triggered by a schedule.
+        # The `inputs` variable is not available when the workflow is automatically triggered by a schedule.
         # In such case, `inputs.force-failure` is an empty string which breaks the workflow. As a workaround,
         # use the `contains` function to check if we really want to force failure.
         force-failure: ${{ contains(inputs.force-failure, 'true') }}

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -25,7 +25,7 @@ jobs:
   report-failure:
     runs-on: ubuntu-latest
     needs: [call-workflow]
-    if: ${{ always() && contains(inputs.notify-on-failure, 'true') && needs.call-workflow.result == 'failure' }}
+    if: ${{ always() && (github.event_name == 'schedule' || contains(inputs.notify-on-failure, 'true')) && needs.call-workflow.result == 'failure' }}
     steps:
       - name: Report Failure
         run: |

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -20,8 +20,8 @@ jobs:
         triton-shared-ref: 'main'
         # The `inputs` variable is not available when the workflow is automatically triggered by a schedule.
         # In such case, `inputs.force-failure` is an empty string which breaks the workflow. As a workaround,
-        # use the `contains` function to check if we really want to force failure.
-        force-failure: ${{ contains(inputs.force-failure, 'true') }}
+        # compare the user provided input with `true` instead of using it directly.
+        force-failure: ${{ inputs.force-failure == 'true' }}
   report-failure:
     runs-on: ubuntu-latest
     needs: [call-workflow]

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -25,7 +25,8 @@ jobs:
   report-failure:
     runs-on: ubuntu-latest
     needs: [call-workflow]
-    if: ${{ always() && (github.event_name == 'schedule' || contains(inputs.notify-on-failure, 'true')) && needs.call-workflow.result == 'failure' }}
+    # Always report failure if the workflow is triggered by a schedule.
+    if: ${{ always() && (github.event_name == 'schedule' || inputs.notify-on-failure) && needs.call-workflow.result == 'failure' }}
     steps:
       - name: Report Failure
         run: |


### PR DESCRIPTION
The nightly workflow is broken because GitHub doesn't populate the default values for the `inputs` variable, resulting in us passing in an empty string for a boolean input. As a workaround, I check if the user-provided input contains the `true` string instead (Github automatically converts the boolean to a string representation when using the `contains` function). Comparing with `true` directly is cumbersome according to this: https://github.com/actions/runner/issues/1483