### PR TITLE
Remove the report failure step in `test-plugin.yml`

### DIFF
--- a/.github/workflows/test-plugin.yml
+++ b/.github/workflows/test-plugin.yml
@@ -82,25 +82,3 @@ jobs:
           echo "Coult not find '${LIT_TEST_DIR}'" ; exit -1
         fi
         lit -v "${LIT_TEST_DIR}"
-        
-    - name: Report Failure
-      if: ${{ inputs.notify-on-failure && failure() }}
-      run: |
-        issues=$(gh --repo microsoft/triton-shared issue list --label nightly-build-failure --state open)
-        build_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-        notificiation_list="@microsoft/aifx-compilers"
-        repo=microsoft/triton-shared #"${{ github.repository }}"
-        if [ -z "$issues" ]; then
-          gh --repo $repo issue create  \
-              --title "Nightly Build Failure $(date +'%Y-%m-%d')" \
-              --label "nightly-build-failure" \
-              --body "cc $notificiation_list
-                      The nightly build has failed. See: $build_url"
-        else
-          issue_number=$(echo "$issues" | head -n 1 | awk '{print $1}')
-          gh --repo $repo issue comment $issue_number \
-              --body "cc $notificiation_list
-                      The nightly build has failed again. See: $build_url"
-        fi
-      env:
-        GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
"Report failure" is not working in `test-plugin.yml` because we don't have `inputs.notify-on-failure` defined in the file. But we don't need this step in `test-plugin.yml` because the only two workflows that include it are `integration-tests.yml` and `nightly-tests.yml`; `integration-tests.yml` run on pull requests and merges to main, so there's no need to report failures. `nightly-tests.yml` on the other hand already has the report failure job in it.