### PR TITLE
Add `TritonTilingExt` dialect to support ops not representable in linalg

### DIFF
--- a/include/triton-shared/CMakeLists.txt
+++ b/include/triton-shared/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(Conversion)
+add_subdirectory(Dialect)

--- a/include/triton-shared/Dialect/CMakeLists.txt
+++ b/include/triton-shared/Dialect/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(TritonTilingExt)

--- a/include/triton-shared/Dialect/TritonTilingExt/CMakeLists.txt
+++ b/include/triton-shared/Dialect/TritonTilingExt/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(IR)

--- a/include/triton-shared/Dialect/TritonTilingExt/IR/CMakeLists.txt
+++ b/include/triton-shared/Dialect/TritonTilingExt/IR/CMakeLists.txt
@@ -1,0 +1,11 @@
+set(LLVM_TARGET_DEFINITIONS TritonTilingExtOps.td)
+mlir_tablegen(TritonTilingExtOpsDialect.h.inc -gen-dialect-decls -dialect=ttx)
+mlir_tablegen(TritonTilingExtOpsDialect.cpp.inc -gen-dialect-defs -dialect=ttx)
+mlir_tablegen(TritonTilingExtOps.h.inc -gen-op-decls)
+mlir_tablegen(TritonTilingExtOps.cpp.inc -gen-op-defs)
+add_public_tablegen_target(TritonTilingExtOpsIncGen)
+
+set(LLVM_TARGET_DEFINITIONS TritonTilingExtInterfaces.td)
+mlir_tablegen(TritonTilingExtInterfaces.h.inc -gen-op-interface-decls)
+mlir_tablegen(TritonTilingExtInterfaces.cpp.inc -gen-op-interface-defs)
+add_public_tablegen_target(TritonTilingExtInterfacesIncGen)

--- a/include/triton-shared/Dialect/TritonTilingExt/IR/TritonTilingExtDialect.h
+++ b/include/triton-shared/Dialect/TritonTilingExt/IR/TritonTilingExtDialect.h
@@ -1,0 +1,107 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_DIALECT_TRITON_TILING_EXT_IR_TRITON_TILING_EXT_DIALECT_H_
+#define MLIR_DIALECT_TRITON_TILING_EXT_IR_TRITON_TILING_EXT_DIALECT_H_
+
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Dialect.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/SymbolTable.h"
+#include "mlir/IR/TypeSupport.h"
+#include "mlir/IR/Types.h"
+#include "mlir/Interfaces/DestinationStyleOpInterface.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Interfaces/TilingInterface.h"
+
+//===----------------------------------------------------------------------===//
+// TritonTilingExt Operations
+//===----------------------------------------------------------------------===//
+
+#include "triton-shared/Dialect/TritonTilingExt/IR/TritonTilingExtOpsDialect.h.inc"
+
+// Include the generated interface declarations.
+#include "triton-shared/Dialect/TritonTilingExt/IR/TritonTilingExtInterfaces.h.inc"
+
+// Include the auto-generated header file containing the declarations of the
+// TritonTilingExt operations.
+#define GET_OP_CLASSES
+#include "triton-shared/Dialect/TritonTilingExt/IR/TritonTilingExtOps.h.inc"
+
+namespace mlir {
+
+namespace ttx {
+
+// -----------------------------------------------------------------------------
+// BufferizableOpInterface
+// -----------------------------------------------------------------------------
+// All TritonTilingExtOps need to support bufferization: the process of
+// allocating buffers for tensors, thereby converting inputs and outputs of
+// tensor type to memref. This process is done by implementing the
+// "BufferizableOpInterface". We implement the interface for TritonTilingExtOps
+// through an external model instead of directly in TritonTilingExtOps.td to be
+// consistent with other ops in the mlir project. See some examples here:
+// - mlir/lib/Dialect/Linalg/Transforms/BufferizableOpInterfaceImpl.cpp
+// - mlir/lib/Dialect/SCF/Transforms/BufferizableOpInterfaceImpl.cpp
+void registerBufferizableOpInterfaceExternalModels(DialectRegistry &registry);
+
+// -----------------------------------------------------------------------------
+// TilingInterface
+// -----------------------------------------------------------------------------
+// The three methods `getTiledImplementation`, `getResultTilePosition`, and
+// `generateResultTileValue` are implemented as part of the TilingInterface.
+// (see TilingInterface.td). These three methods are re-used across
+// all TritonTilingExtOps, while others method are implemented individually by
+// each operator depending on their use cases.
+template <typename TritonTilingExtOpTy>
+FailureOr<TilingResult> getTiledImplementation(TritonTilingExtOpTy op,
+                                               OpBuilder &b,
+                                               ArrayRef<OpFoldResult> offsets,
+                                               ArrayRef<OpFoldResult> sizes);
+
+template <typename TritonTilingExtOpTy>
+LogicalResult getResultTilePosition(TritonTilingExtOpTy op, OpBuilder &b,
+                                    unsigned resultNumber,
+                                    ArrayRef<OpFoldResult> offsets,
+                                    ArrayRef<OpFoldResult> sizes,
+                                    SmallVector<OpFoldResult> &resultOffsets,
+                                    SmallVector<OpFoldResult> &resultSizes);
+
+template <typename TritonTilingExtOpTy>
+FailureOr<TilingResult>
+generateResultTileValue(TritonTilingExtOpTy op, OpBuilder &b,
+                        unsigned resultNumber, ArrayRef<OpFoldResult> offsets,
+                        ArrayRef<OpFoldResult> sizes);
+
+// -----------------------------------------------------------------------------
+// MemoryEffectsOpInterface
+// -----------------------------------------------------------------------------
+// Implementation of the MemoryEffectsOpInterface for TritonTilingExtOps.
+// This allows DCE pass to determine if a TritonTilingExtOp is safe to be
+// removed. see TritonTilingExtOps.td for more details.
+template <typename TritonTilingExtOpTy>
+void getEffects(
+    TritonTilingExtOpTy op,
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects);
+
+// -----------------------------------------------------------------------------
+// Utilities
+// -----------------------------------------------------------------------------
+// Utility method to extract a slice from the input source using either
+// tensor::ExtractSlice or memref::SubView
+Value getSlice(OpBuilder &b, Location loc, Value source,
+               ArrayRef<OpFoldResult> offsets, ArrayRef<OpFoldResult> sizes,
+               ArrayRef<OpFoldResult> strides);
+
+} // namespace ttx
+} // namespace mlir
+
+#endif // MLIR_DIALECT_TRITON_TILING_EXT_IR_TRITON_TILING_EXT_DIALECT_H_

--- a/include/triton-shared/Dialect/TritonTilingExt/IR/TritonTilingExtInterfaces.td
+++ b/include/triton-shared/Dialect/TritonTilingExt/IR/TritonTilingExtInterfaces.td
@@ -1,0 +1,102 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_TRITON_TILING_EXT_DIALECT_INTERFACES
+#define MLIR_TRITON_TILING_EXT_DIALECT_INTERFACES
+
+include "mlir/IR/OpBase.td"
+
+//
+// Linalg operators require providing affine maps that define how input / output
+// buffers are accessed together with a region that defines how each output
+// element is computed; this requirement doesn't work well for operations such as
+// `scan`.
+//
+// Fortunately, the introduction of the TilingInterface allows us to add tiling
+// and fusion support to operations that don't fit into the linalg dialect.
+// This fits our purpose perfectly: our `scan` operators can be treated as an
+// "opaque" / "completely abstract" operation that can be tiled on the batch
+// dimensions -- we don't need to provide any associated body together with it.
+//
+// However, this doesn't mean that we entirely forgo the "indexing map" concept.
+// For example, consider the following:
+//
+//  - ttx.scan ins(%1 : tensor<128x768xbf16>)
+//                 outs(%2 : tensor<128x768xbf16>) -> tensor<128x768xbf16>
+//
+// Tiling the batch dimension gives us:
+//
+//  for (i = 0 to 128) {
+//    %sliceIn = extract slice from input: tensor<1x768xbf16>
+//    %sliceOut = extract slice from output: tensor<1x768xbf16>
+//    %res = ttx.scan ins(slice : tensor<1x768xbf16>)
+//                 outs(%2 : tensor<1x768xbf16>) -> tensor<1x768xbf16>
+//    insert %res into output
+//  }
+//
+// Now our `scan` op has the semantic of running `scan` on a rank-1 tensor and
+// can be lowered further to other hardware-specific ops or external library
+// calls.
+//
+// This tiling pattern is essentially the same as tiling a linalg.generic op
+// with an identity map. The only difference is we don't need a body associated
+// with our `scan` op.
+//
+// With this idea in mind, the TritonTilingExtInterface exposes methods
+// that will be implemented individually by each TritonTilingExtOp, providing
+// the indexing map for each input / output that can then be used to generate
+// the correct slices during tiling and fusion.
+//
+// There might be other ops in the future that won't fit in this "indexing map"
+// approach; we will consider making TritonTilingExtInterface an optional
+// interface for such ops.
+//
+
+def TritonTilingExtInterface : OpInterface<"TritonTilingExtInterface"> {
+  let cppNamespace = "::mlir::ttx";
+  let methods = [
+    InterfaceMethod<
+      /*desc=*/[{
+        Return the indexing map for the input operand with the given `index`.
+        The `tileSizes` input indicates the requested tile size during tiling
+        in case the indexing map for the operator is dependent on it.
+      }],
+      /*retTy=*/"AffineMap",
+      /*methodName=*/"getInputIndexingMap",
+      /*args=*/(ins "MLIRContext*":$context,
+                    "unsigned int":$index,
+                    "ArrayRef<OpFoldResult>":$tileSizes)
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Return the indexing map for the output operand with the given `index`.
+        The `tileSizes` input indicates the requested tile size during tiling
+        in case the indexing map for the operator is dependent on it.
+      }],
+      /*retTy=*/"AffineMap",
+      /*methodName=*/"getOutputIndexingMap",
+      /*args=*/(ins "MLIRContext*":$context,
+                    "unsigned int":$index,
+                    "ArrayRef<OpFoldResult>":$tileSizes)
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Return the indexing map for the operand with the given `index`.
+        This method returns the operand in order of inputs followed by outputs.
+        The `tileSizes` input indicates the requested tile size during tiling
+        in case the indexing map for the operator is dependent on it.
+      }],
+      /*retTy=*/"AffineMap",
+      /*methodName=*/"getIndexingMap",
+      /*args=*/(ins "MLIRContext*":$context,
+                    "unsigned int":$index,
+                    "ArrayRef<OpFoldResult>":$tileSizes)
+    >
+  ];
+}
+
+#endif

--- a/include/triton-shared/Dialect/TritonTilingExt/IR/TritonTilingExtOps.td
+++ b/include/triton-shared/Dialect/TritonTilingExt/IR/TritonTilingExtOps.td
@@ -1,0 +1,242 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TRITON_TILING_EXT_BASE
+#define TRITON_TILING_EXT_BASE
+
+include "mlir/IR/EnumAttr.td"
+include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/OpBase.td"
+include "mlir/IR/BuiltinAttributes.td"
+include "mlir/IR/SymbolInterfaces.td"
+include "mlir/Interfaces/CallInterfaces.td"
+include "mlir/Interfaces/DestinationStyleOpInterface.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
+include "mlir/Interfaces/TilingInterface.td"
+include "mlir/Dialect/Linalg/IR/LinalgBase.td"
+include "mlir/Dialect/Linalg/IR/LinalgInterfaces.td"
+
+include "triton-shared/Dialect/TritonTilingExt/IR/TritonTilingExtInterfaces.td"
+
+
+//===----------------------------------------------------------------------===//
+// TritonTilingExt dialect definition
+//===----------------------------------------------------------------------===//
+
+def TritonTilingExt_Dialect : Dialect {
+  let name = "ttx";
+  let cppNamespace = "::mlir::ttx";
+}
+
+//===----------------------------------------------------------------------===//
+// TritonTilingExt op definitions
+//===----------------------------------------------------------------------===//
+
+// Base class for TritonTilingExt dialect ops.
+class TritonTilingExt_Op<string mnemonic, list<Trait> traits = []>
+    : Op<TritonTilingExt_Dialect, mnemonic, traits> {
+}
+
+class TritonTilingExt_TilingOp<string mnemonic> : Op<TritonTilingExt_Dialect, mnemonic, [
+  // All TritonTilingExtOps have to implement the tiling interface.
+  DeclareOpInterfaceMethods<TilingInterface, [
+    "getLoopIteratorTypes",
+    "getIterationDomain",
+    "getTiledImplementation",
+    "getResultTilePosition",
+    "generateResultTileValue"
+  ]>,
+  // All TritonTilingExtOps implement TritonTilingExtInterface, which provides a standardized
+  // way of providing indexing maps for input and output operands.
+  DeclareOpInterfaceMethods<TritonTilingExtInterface>,
+
+  // MemoryEffectsOpInterface provides analysis passes such as DCE to determine
+  // whether an operation has no memory side effects and therefore is safe to
+  // be deleted. This interface is important during tile and fuse where we
+  // create copies of TilingInterface ops with smaller tile sizes but leave the
+  // original ops intact.
+  DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+
+  // DestinationStyleOpInterface describes ops that have similar semantics to
+  // linalg ops, with a separate ins (input) and outs (output) operand groups.
+  // Implementing this op gives us access to a wide variety of useful methods
+  // to query the inputs and outputs of an op.
+  DestinationStyleOpInterface,
+
+  // AttrSizedOperandSegments supports having multiple groups of operands.
+  // For example, linalg ops (as well as TritonTilingExtOps) all look like this:
+  // ttx.some_op ins(%1) outs(%2) -> resultType
+  AttrSizedOperandSegments
+]>
+{
+  let results = (outs Variadic<AnyRankedTensor>:$result_tensors);
+
+  let hasCustomAssemblyFormat = 1;
+
+  code baseClassDecls = [{
+    // Implemented as part of DestinationStyleOpInterface
+    MutableOperandRange getDpsInitsMutable() { return getOutputsMutable(); }
+  }];
+
+  // Custom print() and parse() methods to make the TritonTilingExt ops have similar looks
+  // to the linalg ops.
+  // Borrowed from llvm-project/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
+  let extraClassDefinition = [{
+    void $cppClass::print(OpAsmPrinter &p) {
+      p.printOptionalAttrDict(this->getOperation()->getAttrs(),
+                              /*elidedAttrs=*/{"operand_segment_sizes"});
+
+      if (!getInputs().empty())
+        p << " ins(" << getInputs() << " : " << getInputs().getTypes() << ")";
+      if (!getOutputs().empty())
+        p << " outs(" << getOutputs() << " : " << getOutputs().getTypes() << ")";
+
+      if (!getResultTypes().empty())
+        p.printOptionalArrowTypeList(getResultTypes());
+    }
+
+    ParseResult $cppClass::parse(OpAsmParser &parser,
+                                              OperationState &result) {
+      SmallVector<Type> inputTypes;
+      SmallVector<Type> outputTypes;
+      SMLoc inputsOperandsLoc, outputsOperandsLoc;
+      SmallVector<OpAsmParser::UnresolvedOperand, 4> inputsOperands,
+          outputsOperands;
+      if (parser.parseOptionalAttrDict(result.attributes))
+        return failure();
+
+      if (succeeded(parser.parseOptionalKeyword("ins"))) {
+        if (parser.parseLParen())
+          return failure();
+
+        inputsOperandsLoc = parser.getCurrentLocation();
+        if (parser.parseOperandList(inputsOperands) ||
+            parser.parseColonTypeList(inputTypes) || parser.parseRParen())
+          return failure();
+      }
+
+      if (succeeded(parser.parseOptionalKeyword("outs"))) {
+        outputsOperandsLoc = parser.getCurrentLocation();
+        if (parser.parseLParen() || parser.parseOperandList(outputsOperands) ||
+            parser.parseColonTypeList(outputTypes) || parser.parseRParen())
+          return failure();
+      }
+
+      if (parser.resolveOperands(inputsOperands, inputTypes, inputsOperandsLoc,
+                                result.operands) ||
+          parser.resolveOperands(outputsOperands, outputTypes,
+                                outputsOperandsLoc, result.operands))
+        return failure();
+
+      result.addAttribute("operand_segment_sizes",
+                          parser.getBuilder().getDenseI32ArrayAttr(
+                              {static_cast<int32_t>(inputsOperands.size()),
+                              static_cast<int32_t>(outputsOperands.size())}));
+
+      SmallVector<Type, 1> resultTypes;
+      if (parser.parseOptionalArrowTypeList(resultTypes))
+        return failure();
+      result.addTypes(resultTypes);
+
+      return success();
+    }
+
+    AffineMap $cppClass::getIndexingMap(MLIRContext *context,
+                             unsigned int index,
+                             ArrayRef<OpFoldResult> sizes) {
+      assert(index < this->getNumOperands());
+      if (index < getNumDpsInputs()) {
+        return getInputIndexingMap(context, index, sizes);
+      }
+      return getOutputIndexingMap(context, index - getNumDpsInputs(), sizes);
+    }
+
+    // Forward each of the implementation to the shared implementation
+    FailureOr<TilingResult> $cppClass::getTiledImplementation(
+      OpBuilder &b,
+      ArrayRef<OpFoldResult> offsets,
+      ArrayRef<OpFoldResult> sizes
+    ) {
+      return mlir::ttx::getTiledImplementation<$cppClass>(
+        *this, b, offsets, sizes
+      );
+    }
+
+    // Forward each of the implementation to the shared implementation
+    LogicalResult $cppClass::getResultTilePosition(
+      OpBuilder &b,
+      unsigned resultNumber,
+      ArrayRef<OpFoldResult> offsets,
+      ArrayRef<OpFoldResult> sizes,
+      SmallVector<OpFoldResult> &resultOffsets,
+      SmallVector<OpFoldResult> &resultSizes
+    ) {
+      return mlir::ttx::getResultTilePosition<$cppClass>(
+        *this, b, resultNumber, offsets, sizes, resultOffsets, resultSizes
+      );
+    }
+
+    // Forward each of the implementation to the shared implementation
+    FailureOr<TilingResult> $cppClass::generateResultTileValue(
+      OpBuilder &b,
+      unsigned resultNumber,
+      ArrayRef<OpFoldResult> offsets,
+      ArrayRef<OpFoldResult> sizes
+    ) {
+      return mlir::ttx::generateResultTileValue<$cppClass>(
+        *this, b, resultNumber, offsets, sizes
+      );
+    }
+
+    // Implemented as part of MemoryEffectsOpInterface
+    void $cppClass::getEffects(
+      SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects
+    ) {
+      return mlir::ttx::getEffects<$cppClass>(*this, effects);
+    }
+  }];
+}
+
+def TritonTilingExt_CumSumOp : TritonTilingExt_TilingOp<"cumsum"> {
+  let arguments = (ins
+    Variadic<AnyType>:$inputs,
+    Variadic<AnyType>:$outputs,
+    UI32Attr:$axis
+  );
+
+  let hasVerifier = 1;
+
+  let skipDefaultBuilders = 1;
+
+  let builders = [
+    OpBuilder<(ins
+      "Value":$input,
+      "IntegerAttr":$axis,
+      "Value":$output,
+      CArg<"ArrayRef<NamedAttribute>", "{}">:$attributes
+    )>
+  ];
+
+  let extraClassDeclaration = baseClassDecls # [{
+    int64_t getRank() {
+      return getInput().getType().cast<ShapedType>().getRank();
+    }
+
+    Value getInput() {
+      return getInputs()[0];
+    }
+
+    Value getOutput() {
+      return getOutputs()[0];
+    }
+
+    static StringRef getAxisAttrStrName() { return "axis"; }
+  }];
+}
+
+#endif // TRITON_TILING_EXT_BASE

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(Analysis)
 add_subdirectory(Conversion)
+add_subdirectory(Dialect)

--- a/lib/Conversion/TritonToLinalg/CMakeLists.txt
+++ b/lib/Conversion/TritonToLinalg/CMakeLists.txt
@@ -15,6 +15,7 @@ add_mlir_conversion_library(TritonToLinalg
   Core
 
   LINK_LIBS PUBLIC
+  TritonTilingExtIR
   MLIRArithDialect
   MLIRDialectUtils
   MLIRIR

--- a/lib/Conversion/TritonToLinalg/TritonToLinalgPass.cpp
+++ b/lib/Conversion/TritonToLinalg/TritonToLinalgPass.cpp
@@ -7,6 +7,7 @@
 
 #include "triton-shared/Analysis/UseAnalysis.h"
 #include "triton-shared/Conversion/TritonToLinalg/TritonToLinalg.h"
+#include "triton-shared/Dialect/TritonTilingExt/IR/TritonTilingExtDialect.h"
 
 #include "triton/Dialect/Triton/IR/Dialect.h"
 
@@ -90,7 +91,7 @@ public:
         .insert<func::FuncDialect, arith::ArithDialect, math::MathDialect,
                 linalg::LinalgDialect, affine::AffineDialect, scf::SCFDialect,
                 tensor::TensorDialect, bufferization::BufferizationDialect,
-                memref::MemRefDialect>();
+                memref::MemRefDialect, ttx::TritonTilingExtDialect>();
   }
 
   void runOnOperation() override {
@@ -114,12 +115,12 @@ public:
     ConversionTarget target(getContext());
     TritonTypeConverter tritonTypeConverter;
 
-    target.addLegalDialect<func::FuncDialect, arith::ArithDialect,
-                           math::MathDialect, linalg::LinalgDialect,
-                           affine::AffineDialect, scf::SCFDialect,
-                           cf::ControlFlowDialect, tensor::TensorDialect,
-                           bufferization::BufferizationDialect,
-                           memref::MemRefDialect>();
+    target.addLegalDialect<
+        func::FuncDialect, arith::ArithDialect, math::MathDialect,
+        linalg::LinalgDialect, affine::AffineDialect, scf::SCFDialect,
+        cf::ControlFlowDialect, tensor::TensorDialect,
+        bufferization::BufferizationDialect, memref::MemRefDialect,
+        ttx::TritonTilingExtDialect>();
 
     target.addLegalOp<ModuleOp>();
 

--- a/lib/Dialect/CMakeLists.txt
+++ b/lib/Dialect/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(TritonTilingExt)

--- a/lib/Dialect/TritonTilingExt/CMakeLists.txt
+++ b/lib/Dialect/TritonTilingExt/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(IR)

--- a/lib/Dialect/TritonTilingExt/IR/BufferizableOpInterfaceImpl.cpp
+++ b/lib/Dialect/TritonTilingExt/IR/BufferizableOpInterfaceImpl.cpp
@@ -1,0 +1,134 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Linalg/Transforms/BufferizableOpInterfaceImpl.h"
+#include "mlir/Dialect/Bufferization/IR/BufferizableOpInterface.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/Bufferization/IR/DstBufferizableOpInterfaceImpl.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/Dialect.h"
+#include "mlir/IR/Operation.h"
+
+#include "triton-shared/Dialect/TritonTilingExt/IR/TritonTilingExtDialect.h"
+
+using namespace mlir;
+using namespace linalg;
+using namespace mlir::bufferization;
+
+//
+// This file implements the bufferizable interface for TritonTilingExtOps.
+// The interface is required for bufferization (i.e: converting from tensors to
+// memrefs).
+// Since the bufferization semantics of TritonTilingExtOps are identical to
+// linalg ops, the implementation was borrowed almost verbatim from
+// mlir/lib/Dialect/Linalg/Transforms/BufferizableOpInterfaceImpl.cpp
+// with the exception that the code to handle linalg's region has been removed.
+// (the original implementation is in an anonymous namespace, so we cannot
+// reuse)
+//
+namespace {
+
+/// Generic conversion for any DestinationStyleOpInterface on tensors.
+static LogicalResult bufferizeTritonTilingExtDestinationStyleOpInterface(
+    RewriterBase &rewriter, DestinationStyleOpInterface op,
+    const BufferizationOptions &options) {
+  // Take a guard before anything else.
+  OpBuilder::InsertionGuard g(rewriter);
+  rewriter.setInsertionPoint(op);
+
+  // Nothing to do. This op is already bufferized.
+  if (op.hasBufferSemantics())
+    return success();
+
+  // Ensure op has only tensors. Allow mixed tensor-buffer mode on a per-need
+  // basis.
+  if (!op.hasTensorSemantics())
+    return op->emitError() << "op does not have tensor semantics";
+
+  // New input operands for the cloned op.
+  SmallVector<Value> newInputBuffers;
+  newInputBuffers.reserve(op.getNumDpsInputs());
+  for (OpOperand *opOperand : op.getDpsInputOperands()) {
+    if (op.isScalar(opOperand)) {
+      newInputBuffers.push_back(opOperand->get());
+      continue;
+    }
+    FailureOr<Value> buffer = getBuffer(rewriter, opOperand->get(), options);
+    if (failed(buffer))
+      return failure();
+    newInputBuffers.push_back(*buffer);
+  }
+
+  // New output operands for the cloned op.
+  SmallVector<Value> newOutputBuffers;
+  for (OpResult opResult : op->getOpResults()) {
+    OpOperand *opOperand = op.getDpsInitOperand(opResult.getResultNumber());
+    FailureOr<Value> resultBuffer =
+        getBuffer(rewriter, opOperand->get(), options);
+    if (failed(resultBuffer))
+      return failure();
+    newOutputBuffers.push_back(*resultBuffer);
+  }
+
+  // Merge input/output operands.
+  SmallVector<Value> newOperands = newInputBuffers;
+  newOperands.append(newOutputBuffers.begin(), newOutputBuffers.end());
+
+  // Set insertion point now that potential alloc/dealloc are introduced.
+  rewriter.setInsertionPoint(op);
+  // Clone the op, but use the new operands. Move the existing block into the
+  // new op. Since the new op does not have any tensor results, it does not
+  // return anything.
+  clone(rewriter, op, /*resultTypes=*/TypeRange{}, newOperands);
+
+  // Replace the results of the old op with the new output buffers.
+  replaceOpWithBufferizedValues(rewriter, op, newOutputBuffers);
+
+  return success();
+}
+
+template <typename OpTy>
+struct TritonTilingExtOpInterface
+    : public DstBufferizableOpInterfaceExternalModel<
+          TritonTilingExtOpInterface<OpTy>, OpTy> {
+  bool bufferizesToMemoryRead(Operation *op, OpOperand &opOperand,
+                              const AnalysisState &state) const {
+    // Operand is read if it is used in the computation.
+    return cast<DestinationStyleOpInterface>(op).isDpsInput(&opOperand);
+  }
+
+  bool bufferizesToMemoryWrite(Operation *op, OpOperand &opOperand,
+                               const AnalysisState &state) const {
+    // Operand is written to if it is not an input/init.
+    return cast<DestinationStyleOpInterface>(op).isDpsInit(&opOperand);
+  }
+
+  LogicalResult bufferize(Operation *op, RewriterBase &rewriter,
+                          const BufferizationOptions &options) const {
+    return bufferizeTritonTilingExtDestinationStyleOpInterface(
+        rewriter, cast<DestinationStyleOpInterface>(op), options);
+  }
+};
+
+template <typename... Ops> struct TritonTilingExtOpInterfaceHelper {
+  static void registerOpInterface(MLIRContext *ctx) {
+    (Ops::template attachInterface<TritonTilingExtOpInterface<Ops>>(*ctx), ...);
+  }
+};
+} // namespace
+
+void mlir::ttx::registerBufferizableOpInterfaceExternalModels(
+    DialectRegistry &registry) {
+  // clang-format off
+  registry.addExtension(+[](MLIRContext *ctx, ttx::TritonTilingExtDialect *dialect) {
+    TritonTilingExtOpInterfaceHelper<
+      ttx::CumSumOp
+    >::registerOpInterface(ctx);
+  });
+  // clang-format on
+}

--- a/lib/Dialect/TritonTilingExt/IR/CMakeLists.txt
+++ b/lib/Dialect/TritonTilingExt/IR/CMakeLists.txt
@@ -1,0 +1,17 @@
+add_mlir_dialect_library(TritonTilingExtIR
+  BufferizableOpInterfaceImpl.cpp
+  CumSum.cpp
+  TritonTilingExtDialect.cpp
+
+  DEPENDS
+  TritonTilingExtInterfacesIncGen
+  TritonTilingExtOpsIncGen
+
+  LINK_LIBS PUBLIC
+  TritonIR
+  MLIRAffineAnalysis
+  MLIRFuncDialect
+  MLIRIR
+  MLIRLinalgDialect
+  MLIRLinalgUtils
+  )

--- a/lib/Dialect/TritonTilingExt/IR/CumSum.cpp
+++ b/lib/Dialect/TritonTilingExt/IR/CumSum.cpp
@@ -1,0 +1,112 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+//===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+// This file implements cumulative sum (CumSum) using the TilingInterface. Only
+// supports tensors of rank 1 & 2 and axis == rank - 1 (i.e: we can split the
+// computation of each row and compute them independently). The semantics of
+// tiling for other axes are more complex and require working with
+// non-contiguous memory.
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+
+#include "triton-shared/Dialect/TritonTilingExt/IR/TritonTilingExtDialect.h"
+
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "ttx-cumsum"
+
+using namespace mlir;
+using namespace mlir::ttx;
+
+void ttx::CumSumOp::build(OpBuilder &odsBuilder, OperationState &odsState,
+                          Value input, IntegerAttr axis, Value output,
+                          ArrayRef<NamedAttribute> attributes) {
+  SmallVector<Value> inputs{input};
+  SmallVector<Value> outputs{output};
+  odsState.addOperands(inputs);
+  odsState.addOperands(outputs);
+  odsState.addAttribute(
+      "operand_segment_sizes",
+      odsBuilder.getDenseI32ArrayAttr({static_cast<int32_t>(inputs.size()),
+                                       static_cast<int32_t>(outputs.size())}));
+
+  odsState.addAttribute(getAxisAttrStrName(), axis);
+  odsState.addAttributes(attributes);
+  odsState.addTypes(SmallVector<Type>{output.getType()});
+}
+
+mlir::LogicalResult ttx::CumSumOp::verify() {
+  auto inputType = getInput().getType();
+  if (!inputType.isa<RankedTensorType>() && !inputType.isa<MemRefType>()) {
+    return emitOpError(
+        "CumSum op expects input to be either tensor or memref.");
+  }
+
+  auto outputType = getOutput().getType();
+  if (!outputType.isa<RankedTensorType>() && !outputType.isa<MemRefType>()) {
+    return emitOpError(
+        "CumSum op expects output to be either tensor or memref.");
+  }
+
+  if (inputType.dyn_cast<ShapedType>().getShape() !=
+      outputType.dyn_cast<ShapedType>().getShape()) {
+    return emitOpError("Input and output types must be the same.");
+  }
+
+  int64_t rank = getRank();
+  if (rank != 1 && rank != 2) {
+    return emitOpError("CumSum op only takes tensors of rank 1 & 2.");
+  }
+
+  int64_t axis = getAxis();
+  if (axis != rank - 1) {
+    return emitOpError("CumSum computation only supports axis == rank - 1");
+  }
+
+  return success();
+}
+
+AffineMap ttx::CumSumOp::getInputIndexingMap(MLIRContext *context,
+                                             unsigned int index,
+                                             ArrayRef<OpFoldResult> sizes) {
+  assert(index == 0);
+  return AffineMap::getMultiDimIdentityMap(getRank(), context);
+}
+
+AffineMap ttx::CumSumOp::getOutputIndexingMap(MLIRContext *context,
+                                              unsigned int index,
+                                              ArrayRef<OpFoldResult> sizes) {
+  assert(index == 0);
+  return AffineMap::getMultiDimIdentityMap(getRank(), context);
+}
+
+SmallVector<utils::IteratorType> ttx::CumSumOp::getLoopIteratorTypes() {
+  SmallVector<utils::IteratorType> iterators;
+  iterators.append(getRank() - 1, utils::IteratorType::parallel);
+  iterators.push_back(utils::IteratorType::reduction);
+  return iterators;
+}
+
+SmallVector<Range> ttx::CumSumOp::getIterationDomain(OpBuilder &b) {
+  OpBuilder::InsertionGuard g(b);
+  b.setInsertionPoint(*this);
+  auto loc = getLoc();
+  auto zero = b.getIndexAttr(0);
+  auto one = b.getIndexAttr(1);
+  SmallVector<Range> iterationDomain;
+
+  // Return the bounds for all dimensions. The caller is responsible for not
+  // tiling the inner most dimension, otherwise the semantic of the resulting op
+  // is incorrect.
+  for (auto i = 0; i < getRank(); i++) {
+    OpFoldResult upperbound = linalg::createFoldedDimOp(b, loc, getInput(), i);
+    iterationDomain.push_back(Range{zero, upperbound, one});
+  }
+  return iterationDomain;
+}

--- a/lib/Dialect/TritonTilingExt/IR/TritonTilingExtDialect.cpp
+++ b/lib/Dialect/TritonTilingExt/IR/TritonTilingExtDialect.cpp
@@ -1,0 +1,397 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
+#include "mlir/Dialect/Linalg/Utils/Utils.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+
+#include "triton-shared/Dialect/TritonTilingExt/IR/TritonTilingExtDialect.h"
+
+#include "llvm/ADT/TypeSwitch.h"
+
+using namespace mlir;
+using namespace mlir::ttx;
+using namespace mlir::linalg;
+
+namespace mlir {
+namespace ttx {
+
+Value getSlice(OpBuilder &b, Location loc, Value source,
+               ArrayRef<OpFoldResult> offsets, ArrayRef<OpFoldResult> sizes,
+               ArrayRef<OpFoldResult> strides) {
+  return TypeSwitch<Type, Value>(source.getType())
+      .Case<RankedTensorType>([&](RankedTensorType t) -> Value {
+        return b.create<tensor::ExtractSliceOp>(loc, source, offsets, sizes,
+                                                strides);
+      })
+      .Case<MemRefType>([&](MemRefType type) -> Value {
+        return b.create<memref::SubViewOp>(loc, source, offsets, sizes,
+                                           strides);
+      })
+      .Default([&](Type t) { return nullptr; });
+}
+
+//
+// getTiledImplementation
+//
+// Given an array of offsets and sizes, return the corresponding tiled version
+// of the current op.
+//
+// This method is responsible for creating the extract slice ops for each
+// operand of the op (including input and output operand).
+//
+// As an example, assuming we tile a linalg.matmul ins(%0, %1) out(%out)
+//
+// This method then generate:
+//
+// %in_slice_0 = extract_slice from %0
+// %in_slice_1 = extract_slice from %1
+// %out_slice = extract_slice from %out
+// %tile = linalg.matmul ins(%in_slice_0, %in_slice_1) out(%out_slice)
+//
+// To generate these extract slice, we go over each operand, get the
+// corresponding affine map to compute the correct offsets and sizes.
+//
+// Now let's describe how we compute the correct offsets and sizes from
+// an affine map.
+//
+// - Offsets:
+// An affine map describes how to access a tensor (i.e: the indicies into a
+// tensor), so getting the offsets (also indices) from an affine map is just
+// simply "applying" the sub-map on the offset (calling
+// makeComposedFoldedAffineApply which also does constant folding
+// automatically).
+//
+// For example:
+// Let's assume we have the following nested loops:
+// for i in range(0, 10):
+//   for j in range(0, 20):
+//      for k in range(0, 30):
+//         dst[i][j][k] = src[i * 2][j + k]
+//
+// Assume that we describe the iteration space based on dst. So:
+// - dst's affine map is (d0, d1, d2) -> (d0, d1, d2)
+// - src's affine map is (d0, d1, d2) -> (d0 * 2, d1 + d2)
+//
+// Now let's say we want to tile the operator with offset (0, 1, 2).
+//
+// For dst, we apply this (0, 1, 2) to its affine map and get (0, 1, 2)
+//
+// For src, we have to plug in the offsets into the affine map to get:
+//
+// (0 * 2, 1 + 2) = (0, 3)
+//
+// This is exactly what the implementation does as well.
+// The call to getSubMap gets the i'th result expression, then the call to
+// makeComposedFoldedAffineApply apply the `offsets` array to the i'th result
+// expression in the affine map.
+//
+//
+// - Sizes:
+// Size is slightly more complex, notice that there are 3 steps to compute
+// sizes:
+//
+// 1) call linalg::computeTileSizes on the provided `sizes`
+// 2) apply the affine map
+// 3) add 1 to the result
+//
+// The reason for this complexity is because the affine maps describe indices
+// iteration space with a half open interval (i.e.: we always from 0 until right
+// before the upper bound). So if we simply apply the affine map on the sizes,
+// we will have incorrect results.
+//
+// Consider this snippet again:
+//  for i in range(0, 16):
+//    for j in range(0, 32):
+//      for k in range(0, 64):
+//         dst[i][j][k] = src[i * 2][j + k]
+//
+// Assume we want the operator to have a tile size of (16, 32, 64) -- so no
+// tiling at all. If we apply the affine map of src (d0, d1, d2) -> (d0 * 2, d1
+// + d2), we have
+//
+// (16 * 2, 32 + 64) -> (32, 96)
+//
+// However, consider the second dimension of source:
+//   - j goes from 0 till 31 inclusive
+//   - k goes from 0 till 63 inclusive
+//
+// So the max index of src's second dimension is 31 + 63 = 94. Since index
+// starts from 0, this means the second dimension has 95 elements. But the
+// formula gives us a tile size of 96!!! The same argument can be applied for
+// the first dimension as well, the number of elements is 15 * 2 + 1 = 31, but
+// computed tile size is 32.
+//
+// So simply applying the indexing map to compute tile size is INCORRECT!!
+// This happens because the indexing map operates on [0, size), while tile sizes
+// are inclusive.
+//
+// The correct formula is:
+// ((d0 - 1) * 2 + 1), (d1 - 1) + (d2 - 1) + 1 which gives
+// (15 * 2 + 1, 32 - 1 + 64 - 1 + 1) -> (31, 95)
+//
+// So again, the steps are:
+// - Subtract 1 from the sizes (what linalg::computeTileSizes does)
+// - Apply the affine map
+// - Add 1 to the result
+//
+template <typename TritonTilingExtOpTy>
+FailureOr<TilingResult> getTiledImplementation(TritonTilingExtOpTy op,
+                                               OpBuilder &b,
+                                               ArrayRef<OpFoldResult> offsets,
+                                               ArrayRef<OpFoldResult> sizes) {
+  Location loc = op->getLoc();
+  SmallVector<Value> valuesToTile = op->getOperands();
+  SmallVector<Value> tiledValues;
+  auto oneAttr = b.getI64IntegerAttr(1);
+
+  for (OpOperand &opOperand : op->getOpOperands()) {
+    unsigned int index = opOperand.getOperandNumber();
+    auto val = valuesToTile[index];
+    auto type = val.getType().dyn_cast<ShapedType>();
+
+    if (!type) {
+      tiledValues.push_back(val);
+      continue;
+    }
+
+    auto rank = type.getRank();
+    SmallVector<OpFoldResult> newOffsets;
+    SmallVector<OpFoldResult> newSizes;
+    SmallVector<OpFoldResult> newStrides(rank, oneAttr);
+
+    llvm::SmallVector<mlir::OpFoldResult> composedTileSizes =
+        linalg::computeTileSizes(b, loc, sizes, {});
+
+    AffineMap map = op.getIndexingMap(b.getContext(), index, sizes);
+    for (int64_t i = 0; i < rank; i++) {
+      AffineMap m = map.getSubMap(i);
+      {
+        OpFoldResult upperboundClosed =
+            affine::makeComposedFoldedAffineApply(b, loc, m, composedTileSizes);
+        AffineExpr s0 = getAffineSymbolExpr(0, b.getContext());
+        OpFoldResult size = affine::makeComposedFoldedAffineApply(
+            b, loc, s0 + 1, upperboundClosed);
+        newSizes.push_back(size);
+      }
+      {
+        OpFoldResult offset =
+            affine::makeComposedFoldedAffineApply(b, loc, m, offsets);
+        newOffsets.push_back(offset);
+      }
+    }
+
+    tiledValues.push_back(
+        getSlice(b, loc, val, newOffsets, newSizes, newStrides));
+  }
+
+  SmallVector<Type> resultTensorTypes = llvm::to_vector(
+      llvm::map_range(op.getDpsInitsMutable(), [&](OpOperand &opOperand) {
+        return tiledValues[opOperand.getOperandNumber()].getType();
+      }));
+
+  Operation *tiledOp = clone(b, op, resultTensorTypes, tiledValues);
+
+  return TilingResult{{tiledOp}, SmallVector<Value>(tiledOp->getResults())};
+}
+
+//
+// getResultTilePosition
+// This method returns the resultOffsets and resultSizes through references
+// for the tiled operator. While `getTiledImplementation` is responsible for
+// generating the extract slice for all operands, `getResultTilePosition` is
+// responsible for returning the offsets and sizes which the tiling engine will
+// then use to generate the corresponding insert_slice ops.
+//
+// Because the slice we insert back to the output tensor is the same as the
+// slice that we extracted from the output tensor, this method just repeats the
+// offset and size computation in `getTiledImplementation`.
+//
+template <typename TritonTilingExtOpTy>
+LogicalResult getResultTilePosition(TritonTilingExtOpTy op, OpBuilder &b,
+                                    unsigned resultNumber,
+                                    ArrayRef<OpFoldResult> offsets,
+                                    ArrayRef<OpFoldResult> sizes,
+                                    SmallVector<OpFoldResult> &resultOffsets,
+                                    SmallVector<OpFoldResult> &resultSizes) {
+  Location loc = op.getLoc();
+
+  AffineMap outputMap =
+      op.getOutputIndexingMap(b.getContext(), resultNumber, sizes);
+
+  Value result = op.getDpsInitOperand(resultNumber)->get();
+  auto rank = result.getType().dyn_cast<ShapedType>().getRank();
+
+  llvm::SmallVector<mlir::OpFoldResult> composedTileSizes =
+      linalg::computeTileSizes(b, loc, sizes, {});
+  for (int64_t i = 0; i < rank; i++) {
+    AffineMap m = outputMap.getSubMap(i);
+    {
+      OpFoldResult upperboundClosed =
+          affine::makeComposedFoldedAffineApply(b, loc, m, composedTileSizes);
+      AffineExpr s0 = getAffineSymbolExpr(0, b.getContext());
+      OpFoldResult size = affine::makeComposedFoldedAffineApply(
+          b, loc, s0 + 1, upperboundClosed);
+      resultSizes.push_back(size);
+    }
+    {
+      OpFoldResult offset =
+          affine::makeComposedFoldedAffineApply(b, loc, m, offsets);
+      resultOffsets.push_back(offset);
+    }
+  }
+
+  return success();
+}
+
+// This method is borrowed verbatim from
+// mlir/lib/Dialect/Linalg/Transforms/TilingInterfaceImpl.cpp
+//
+// This is invoked when the current op produces a result that is used
+// as an input to another op that is being tiled. The method essentially handles
+// producing a new op where the result matches the given offsets and sizes.
+// If the method succeeds, the two new operators will be fused in the same loop.
+//
+// As an example, consider the following IR where the linalg.generic is being
+// tiled (unnecessary detailed omitted for brevity):
+//
+// clang-format: off
+//
+// func.func @some_op_1(
+//     %arg0: tensor<8x2x256x512xbf16>,
+//     %arg1: tensor<8x256x1024xbf16>
+// ) -> tensor<8x256x1024xbf16>
+//     %1 = linalg.init_tensor [8, 256, 1024] : tensor<8x256x1024xbf16>
+//     %2 = linalg.init_tensor [8, 256, 1024] : tensor<8x256x1024xbf16>
+//     %3 = ttx.some_op
+//             ins(%arg0 : tensor<8x2x256x512xbf16>)
+//             outs(%1 : tensor<8x256x1024xbf16>) -> tensor<8x256x1024xbf16>
+//     %4 = linalg.generic
+//         ins(%3, %arg1 : tensor<8x256x1024xbf16>, tensor<8x256x1024xbf16>)
+//         outs(%2 : tensor<8x256x1024xbf16>) {
+//     ^bb0(%arg2: bf16, %arg3: bf16, %arg4: bf16):
+//       %add = arith.addf %arg2, %arg3 : bf16
+//       linalg.yield %add : bf16
+//     } -> tensor<8x256x1024xbf16>
+//     return %4 : tensor<8x256x1024xbf16>
+// }
+//
+// clang-format: on
+//
+// We tile linalg.generic, but one of its inputs is %3 which is the result of
+// ttx.some_op. So the tiling engine will invoke
+// generateResultTileValue of ttx.some_op to determine if it's
+// possible to create a tiled version of it, thereby making it possible to fuse
+// both operators together in a loop.
+template <typename TritonTilingExtOpTy>
+FailureOr<TilingResult>
+generateResultTileValue(TritonTilingExtOpTy op, OpBuilder &b,
+                        unsigned resultNumber, ArrayRef<OpFoldResult> offsets,
+                        ArrayRef<OpFoldResult> sizes) {
+
+  // Check that the indexing map used for the output is a projected
+  // permutation. This could be relaxed with a more general approach that can
+  // map the offsets and sizes from the result to iteration space tiles
+  // (filling in full extent for dimensions not used to access the result).
+  AffineMap indexingMap = op.getOutputIndexingMap(b.getContext(), 0, sizes);
+  if (!indexingMap.isProjectedPermutation()) {
+    return op.emitOpError(
+        "unhandled tiled implementation generation when result is not "
+        "accessed using a permuted projection");
+  }
+
+  auto numLoops = op.getLoopIteratorTypes().size();
+  SmallVector<OpFoldResult> iterationTileOffsets(numLoops),
+      iterationTileSizes(numLoops);
+  if (!indexingMap.isPermutation()) {
+    SmallVector<Range> iterationDomain = op.getIterationDomain(b);
+    for (auto range : llvm::enumerate(iterationDomain)) {
+      iterationTileOffsets[range.index()] = range.value().offset;
+      iterationTileSizes[range.index()] = range.value().size;
+    }
+  }
+  for (auto resultExpr : llvm::enumerate(indexingMap.getResults())) {
+    assert(resultExpr.value().getKind() == AffineExprKind::DimId);
+    // HACK: LLVM casting utilities do not work here for out-of-tree builds,
+    // as there is no template specialization for this cast in the base
+    // build.
+    AffineDimExpr affineDimExpr(static_cast<AffineExpr::ImplType *>(
+        const_cast<void *>(resultExpr.value().getAsOpaquePointer())));
+    unsigned dimPosition = affineDimExpr.getPosition();
+    iterationTileOffsets[dimPosition] = offsets[resultExpr.index()];
+    iterationTileSizes[dimPosition] = sizes[resultExpr.index()];
+  }
+
+  FailureOr<TilingResult> tilingResult =
+      op.getTiledImplementation(b, iterationTileOffsets, iterationTileSizes);
+  if (tilingResult->tiledOps.size() != 1)
+    return op.emitOpError("failed to generate tiled implementation");
+
+  return TilingResult{
+      tilingResult->tiledOps,
+      SmallVector<Value>{tilingResult->tiledValues[resultNumber]}};
+}
+
+// This method is borrowed directly from linalg.generic's implementation
+// in mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
+// This marks all operands that are part of the input group to have read
+// effect, while all other operands that are part of the output group
+// to have both read and write effects.
+static void getTritonTilingExtEffectsImpl(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects,
+    ValueRange results, const ValueRange inputOperands,
+    ValueRange outputOperands) {
+  for (auto operand : inputOperands) {
+    if (!llvm::isa<MemRefType>(operand.getType()))
+      continue;
+    effects.emplace_back(MemoryEffects::Read::get(), operand,
+                         SideEffects::DefaultResource::get());
+  }
+  for (auto operand : outputOperands) {
+    if (!llvm::isa<MemRefType>(operand.getType()))
+      continue;
+    effects.emplace_back(MemoryEffects::Read::get(), operand,
+                         SideEffects::DefaultResource::get());
+    effects.emplace_back(MemoryEffects::Write::get(), operand,
+                         SideEffects::DefaultResource::get());
+  }
+}
+
+template <typename TritonTilingExtOpTy>
+void getEffects(
+    TritonTilingExtOpTy op,
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  getTritonTilingExtEffectsImpl(effects, op.getOperation()->getResults(),
+                                op.getDpsInputs(), op.getDpsInits());
+}
+
+} // namespace ttx
+} // namespace mlir
+
+/// Dialect creation, the instance will be owned by the context. This is the
+/// point of registration of custom types and operations for the dialect.
+void TritonTilingExtDialect::initialize() {
+  addOperations<
+#define GET_OP_LIST
+#include "triton-shared/Dialect/TritonTilingExt/IR/TritonTilingExtOps.cpp.inc"
+      >();
+}
+
+//===----------------------------------------------------------------------===//
+// TableGen'd op method definitions
+//===----------------------------------------------------------------------===//
+
+#include "triton-shared/Dialect/TritonTilingExt/IR/TritonTilingExtInterfaces.cpp.inc"
+
+#define GET_OP_CLASSES
+#include "triton-shared/Dialect/TritonTilingExt/IR/TritonTilingExtOps.cpp.inc"
+
+#include "triton-shared/Dialect/TritonTilingExt/IR/TritonTilingExtOpsDialect.cpp.inc"

--- a/test/Conversion/TritonToLinalg/cumsum.mlir
+++ b/test/Conversion/TritonToLinalg/cumsum.mlir
@@ -1,0 +1,68 @@
+// RUN: triton-shared-opt --triton-to-linalg %s | FileCheck %s
+
+// @triton.jit
+// def test_cumsum_op(
+//     input_ptr, output_ptr, n_columns
+// ):
+//     row = tl.program_id(axis=0)
+//     row_start = row * n_columns
+//     columns = tl.arange(0, 4096)
+//     offsets = row_start + columns
+//     data = tl.load(input_ptr + offsets)
+//     result = tl.cumsum(data, axis=0)
+//     tl.store(output_ptr + offsets, result)
+//
+// ret = triton.compiler.compile(
+//     test_cumsum_op,
+//     signature=" *fp32,*i32,i32",
+//     print_triton_ir_only=True,
+// )
+// print(ret.asm["ttir"])
+
+module {
+  tt.func public @test_cumsum_op_012(%arg0: !tt.ptr<f32, 1>, %arg1: !tt.ptr<i32, 1>, %arg2: i32) attributes {noinline = false} {
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %arg2 : i32
+    %2 = tt.make_range {end = 4096 : i32, start = 0 : i32} : tensor<4096xi32>
+    %3 = tt.splat %1 : (i32) -> tensor<4096xi32>
+    %4 = arith.addi %3, %2 : tensor<4096xi32>
+    %5 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<4096x!tt.ptr<f32, 1>>
+    %6 = tt.addptr %5, %4 : tensor<4096x!tt.ptr<f32, 1>>, tensor<4096xi32>
+    %7 = tt.load %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<4096xf32>
+    %8 = "tt.scan"(%7) <{axis = 0 : i32}> ({
+    ^bb0(%arg3: f32, %arg4: f32):
+      %12 = arith.addf %arg3, %arg4 : f32
+      tt.scan.return %12 : f32
+    }) : (tensor<4096xf32>) -> tensor<4096xf32>
+    %9 = tt.splat %arg1 : (!tt.ptr<i32, 1>) -> tensor<4096x!tt.ptr<i32, 1>>
+    %10 = tt.addptr %9, %4 : tensor<4096x!tt.ptr<i32, 1>>, tensor<4096xi32>
+    %11 = arith.fptosi %8 : tensor<4096xf32> to tensor<4096xi32>
+    tt.store %10, %11 {cache = 1 : i32, evict = 1 : i32} : tensor<4096xi32>
+    tt.return
+  }
+}
+
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func @test_cumsum_op_012
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xi32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[PARAM_2_]] : i32
+// CHECK:           [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [4096], strides: [1] : memref<*xf32> to memref<4096xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<4096xf32>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<4096xf32, strided<[1], offset: ?>> to memref<4096xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<4096xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tensor.empty() : tensor<4096xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_4_:%.+]] = ttx.cumsum {axis = 0 : ui32, operandSegmentSizes = array<i32: 1, 1>} ins([[VAR_2_]] : tensor<4096xf32>) outs([[VAR_3_]] : tensor<4096xf32>) -> tensor<4096xf32>
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_5_]]{{.}}, sizes: [4096], strides: [1] : memref<*xi32> to memref<4096xi32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_6_:%.+]] = tensor.empty() : tensor<4096xi32>
+// CHECK:           [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_4_]] : tensor<4096xf32>) outs([[VAR_6_]] : tensor<4096xi32>) {
+// CHECK:           ^bb0([[in_:.+]]: f32, [[out_:.+]]: i32):
+// CHECK:             [[VAR_8_:%.+]] = arith.fptosi [[in_]] : f32 to i32
+// CHECK:             linalg.yield [[VAR_8_]] : i32
+// CHECK:           } -> tensor<4096xi32>
+// CHECK:           memref.tensor_store [[VAR_7_]], [[VAR_reinterpret_cast_0_]] : memref<4096xi32, strided<[1], offset: ?>>
+// CHECK:           return
+// CHECK:         }

--- a/tools/RegisterTritonSharedDialects.h
+++ b/tools/RegisterTritonSharedDialects.h
@@ -9,6 +9,7 @@
 #include "triton/Conversion/TritonToTritonGPU/Passes.h"
 
 #include "triton-shared/Conversion/TritonToLinalg/Passes.h"
+#include "triton-shared/Dialect/TritonTilingExt/IR/TritonTilingExtDialect.h"
 
 #include "mlir/InitAllPasses.h"
 
@@ -34,8 +35,9 @@ inline void registerTritonSharedDialects(mlir::DialectRegistry &registry) {
   mlir::triton::registerConvertTritonGPUToLLVMPass();
 
   // TODO: register Triton & TritonGPU passes
-  registry.insert<mlir::triton::TritonDialect, mlir::cf::ControlFlowDialect,
-                  mlir::triton::gpu::TritonGPUDialect, mlir::math::MathDialect,
-                  mlir::arith::ArithDialect, mlir::scf::SCFDialect,
-                  mlir::gpu::GPUDialect>();
+  registry
+      .insert<mlir::ttx::TritonTilingExtDialect, mlir::triton::TritonDialect,
+              mlir::cf::ControlFlowDialect, mlir::triton::gpu::TritonGPUDialect,
+              mlir::math::MathDialect, mlir::arith::ArithDialect,
+              mlir::scf::SCFDialect, mlir::gpu::GPUDialect>();
 }


### PR DESCRIPTION
The `TritonTilingExt` dialect leverages linalg's TilingInterface to add tiling & fusion support for operators that cannot be represented in linalg Much of the tiling implementation is borrowed from linalg's tiling code. As an example, I have added a barebone version of `cumsum` that represents the cumulative sum of the inner-most dimension of a tensor. Other backends can then lower the op to lower-level implementation as needed after applying tiling & fusion.