### PR TITLE
Fix cpu import error

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -16,5 +16,5 @@ jobs:
   test-cpuref:
     uses: ./.github/workflows/test-cpuref.yml
     with:
-        triton-ref: '05dc28be0e72dd496300a31b99a21a5a5118f8e9' # known good commit "[CI] refactor workflows (#2504)"
+        triton-ref: '768fc1fcd98ecfc0892f8982b0bb009dd7bb11ea' # known good commit "[CI] refactor workflows (#2504)"
         triton-shared-ref: ${{ github.ref }}

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -341,7 +341,7 @@ class TritonSharedRefCPUBackend(BaseBackend):
 
     def make_launcher_stub(self, name, signature, constants, ids):
         # name of files that are cached
-        so_cache_key = make_so_cache_key(self.version_key, signature, constants, ids)
+        so_cache_key = make_so_cache_key(self.get_version_key(), signature, constants, ids)
         so_cache_manager = get_cache_manager(so_cache_key)
         so_name = f"{name}.py"
         # retrieve stub from cache if it exists


### PR DESCRIPTION
From triton commit 768fc1fcd98ecfc0892f8982b0bb009dd7bb11ea, the functon `version_key()` is no longer there.