### PR TITLE
Extend MinMaxConverter with OGE and OLE cmpf predicates

### DIFF
--- a/lib/Conversion/TritonToLinalg/TritonToLinalg.cpp
+++ b/lib/Conversion/TritonToLinalg/TritonToLinalg.cpp
@@ -1515,10 +1515,12 @@ struct MinMaxConverter : public OpRewritePattern<CmpOp> {
                            arith::CmpFPredicate pred) const {
     switch (pred) {
     case arith::CmpFPredicate::OGT:
+    case arith::CmpFPredicate::OGE:
       rewriter.replaceOpWithNewOp<arith::MaximumFOp>(selectOp, cmpOp.getLhs(),
                                                      cmpOp.getRhs());
       break;
     case arith::CmpFPredicate::OLT:
+    case arith::CmpFPredicate::OLE:
       rewriter.replaceOpWithNewOp<arith::MinimumFOp>(selectOp, cmpOp.getLhs(),
                                                      cmpOp.getRhs());
       break;

--- a/test/Conversion/TritonToLinalg/convert_minmax.mlir
+++ b/test/Conversion/TritonToLinalg/convert_minmax.mlir
@@ -1,0 +1,50 @@
+// RUN: triton-shared-opt --triton-to-linalg --split-input-file %s | FileCheck %s
+module {
+  tt.func public @minmax_olt(%arg0: !tt.ptr<f32>, %arg1: f32, %arg2: f32) {
+    %0 = arith.cmpf olt, %arg1, %arg2 : f32
+    %1 = arith.select %0, %arg1, %arg2 : f32
+    tt.store %arg0, %1 {cache = 1 : i32, evict = 1 : i32} : f32
+    tt.return
+  }
+}
+// CHECK:  func.func @minmax_olt
+// CHECK:  %[[VAL:.*]] = arith.minimumf %arg1, %arg2 : f32
+
+// -----
+
+module {
+  tt.func public @minmax_ole(%arg0: !tt.ptr<f32>, %arg1: f32, %arg2: f32) {
+    %0 = arith.cmpf ole, %arg1, %arg2 : f32
+    %1 = arith.select %0, %arg1, %arg2 : f32
+    tt.store %arg0, %1 {cache = 1 : i32, evict = 1 : i32} : f32
+    tt.return
+  }
+}
+// CHECK:  func.func @minmax_ole
+// CHECK:  %[[VAL:.*]] = arith.minimumf %arg1, %arg2 : f32
+
+// -----
+
+module {
+  tt.func public @minmax_ogt(%arg0: !tt.ptr<f32>, %arg1: f32, %arg2: f32) {
+    %0 = arith.cmpf ogt, %arg1, %arg2 : f32
+    %1 = arith.select %0, %arg1, %arg2 : f32
+    tt.store %arg0, %1 {cache = 1 : i32, evict = 1 : i32} : f32
+    tt.return
+  }
+}
+// CHECK:  func.func @minmax_ogt
+// CHECK:  %[[VAL:.*]] = arith.maximumf %arg1, %arg2 : f32
+
+// -----
+
+module {
+  tt.func public @minmax_oge(%arg0: !tt.ptr<f32>, %arg1: f32, %arg2: f32) {
+    %0 = arith.cmpf oge, %arg1, %arg2 : f32
+    %1 = arith.select %0, %arg1, %arg2 : f32
+    tt.store %arg0, %1 {cache = 1 : i32, evict = 1 : i32} : f32
+    tt.return
+  }
+}
+// CHECK:  func.func @minmax_oge
+// CHECK:  %[[VAL:.*]] = arith.maximumf %arg1, %arg2 : f32


### PR DESCRIPTION
Convert arith.cmpf operation with OGE and OLE predicates the same way as for OGT and OLT to max/min operation