### PR TITLE
Remove library name check for __nv_* intrinsics

### DIFF
--- a/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
+++ b/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
@@ -1741,8 +1741,7 @@ public:
   matchAndRewrite(triton::ExternElementwiseOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
-    if (op.getLibname().compare("libdevice") || !op.getPure() ||
-        op.getArgs().size() != 2)
+    if (!op.getPure() || op.getArgs().size() != 2)
       return failure();
 #define POPULATE_BINARY_OP(FUNC_NAME, DST_OP)                                  \
   if (!op.getSymbol().compare(FUNC_NAME)) {                                    \
@@ -1769,8 +1768,7 @@ public:
   matchAndRewrite(triton::ExternElementwiseOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
-    if (op.getLibname().compare("libdevice") || !op.getPure() ||
-        op.getArgs().size() != 1)
+    if (!op.getPure() || op.getArgs().size() != 1)
       return failure();
 #define POPULATE_UNARY_OP(FUNC_NAME, DST_OP)                                   \
   if (!op.getSymbol().compare(FUNC_NAME)) {                                    \

--- a/lib/Conversion/TritonArithToLinalg/TritonArithToLinalg.cpp
+++ b/lib/Conversion/TritonArithToLinalg/TritonArithToLinalg.cpp
@@ -1273,8 +1273,7 @@ public:
   matchAndRewrite(triton::ExternElementwiseOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
-    if (op.getLibname().compare("libdevice") || !op.getPure() ||
-        op.getArgs().size() != 2)
+    if (!op.getPure() || op.getArgs().size() != 2)
       return failure();
     if (!op.getSymbol().compare("__nv_atan2f") ||
         !op.getSymbol().compare("__nv_atan2")) {
@@ -1295,8 +1294,7 @@ public:
   matchAndRewrite(triton::ExternElementwiseOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
-    if (op.getLibname().compare("libdevice") || !op.getPure() ||
-        op.getArgs().size() != 1)
+    if (!op.getPure() || op.getArgs().size() != 1)
       return failure();
     if (!op.getSymbol().compare("__nv_sinf") ||
         !op.getSymbol().compare("__nv_sin")) {

--- a/test/Conversion/TritonArithToLinalg/convert_extern_elementwise.mlir
+++ b/test/Conversion/TritonArithToLinalg/convert_extern_elementwise.mlir
@@ -16,7 +16,7 @@ module {
     %10 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %11 = tt.addptr %10, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %12 = tt.load %11, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
-    %13 = tt.extern_elementwise %9, %12 {libname = "libdevice", libpath = "/triton/python/triton/language/../third_party/cuda/lib/libdevice.10.bc", pure = true, symbol = "__nv_atan2f"} : (tensor<32xf32>, tensor<32xf32>) -> tensor<32xf32>
+    %13 = tt.extern_elementwise %9, %12 {libname = "", libpath = "", pure = true, symbol = "__nv_atan2f"} : (tensor<32xf32>, tensor<32xf32>) -> tensor<32xf32>
     %14 = tt.splat %arg2 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %15 = tt.addptr %14, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %15, %13 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
@@ -46,7 +46,7 @@ module {
     %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
-    %10 = tt.extern_elementwise %9 {libname = "libdevice", libpath = "/triton/python/triton/language/../third_party/cuda/lib/libdevice.10.bc", pure = true, symbol = "__nv_sinf"} : (tensor<32xf32>) -> tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_sinf"} : (tensor<32xf32>) -> tensor<32xf32>
     %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>

--- a/test/Conversion/TritonArithToLinalg/unsupported_extern_elementwise.mlir
+++ b/test/Conversion/TritonArithToLinalg/unsupported_extern_elementwise.mlir
@@ -6,7 +6,7 @@ module {
     %1 = tt.splat %arg0 : (!tt.ptr<i32, 1>) -> tensor<8x!tt.ptr<i32, 1>>
     %2 = tt.addptr %1, %0 : tensor<8x!tt.ptr<i32, 1>>, tensor<8xi32>
     %3 = tt.load %2 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<8xi32>
-    %4 = tt.extern_elementwise %3, %0 {libname = "libdevice", libpath = "/path/to/something", pure = true, symbol = "some_symbol"} : (tensor<8xi32>, tensor<8xi32>) -> tensor<8xi32>
+    %4 = tt.extern_elementwise %3, %0 {libname = "", libpath = "", pure = true, symbol = "some_symbol"} : (tensor<8xi32>, tensor<8xi32>) -> tensor<8xi32>
     %5 = tt.splat %arg1 : (!tt.ptr<i32, 1>) -> tensor<8x!tt.ptr<i32, 1>>
     %6 = tt.addptr %5, %0 : tensor<8x!tt.ptr<i32, 1>>, tensor<8xi32>
     tt.store %6, %4 {cache = 1 : i32, evict = 1 : i32} : tensor<8xi32>
@@ -32,7 +32,7 @@ module {
 // CHECK:             linalg.yield [[VAR_10_1_]] : !tt.ptr<i32, 1>
 // CHECK:           } -> tensor<8x!tt.ptr<i32, 1>>
 // CHECK:           [[LOAD_VAR_4_MEM_:%.+]] = tt.load [[VAR_4_]] {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<8xi32>
-// CHECK-DAG:       [[VAR_6_:%.+]] = tt.extern_elementwise [[LOAD_VAR_4_MEM_]], [[VAR_1_]] {libname = "libdevice", libpath = "/path/to/something", pure = true, symbol = "some_symbol"} : (tensor<8xi32>, tensor<8xi32>) -> tensor<8xi32>
+// CHECK-DAG:       [[VAR_6_:%.+]] = tt.extern_elementwise [[LOAD_VAR_4_MEM_]], [[VAR_1_]] {libname = "", libpath = "", pure = true, symbol = "some_symbol"} : (tensor<8xi32>, tensor<8xi32>) -> tensor<8xi32>
 // CHECK-DAG:       [[VAR_7_:%.+]] = tensor.empty() : tensor<8x!tt.ptr<i32, 1>>
 // CHECK:           [[VAR_8_:%.+]] = linalg.fill ins([[PARAM_1_]] : !tt.ptr<i32, 1>) outs([[VAR_7_]] : tensor<8x!tt.ptr<i32, 1>>) -> tensor<8x!tt.ptr<i32, 1>>
 // CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]], [[VAR_1_]] : tensor<8x!tt.ptr<i32, 1>>, tensor<8xi32>) outs([[VAR_8_]] : tensor<8x!tt.ptr<i32, 1>>) {

--- a/test/Conversion/TritonToLinalg/convert_extern_elementwise.mlir
+++ b/test/Conversion/TritonToLinalg/convert_extern_elementwise.mlir
@@ -16,7 +16,7 @@ module {
     %10 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %11 = tt.addptr %10, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %12 = tt.load %11, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
-    %13 = tt.extern_elementwise %9, %12 {libname = "libdevice", libpath = "/triton/python/triton/language/../third_party/cuda/lib/libdevice.10.bc", pure = true, symbol = "__nv_atan2f"} : (tensor<32xf32>, tensor<32xf32>) -> tensor<32xf32>
+    %13 = tt.extern_elementwise %9, %12 {libname = "", libpath = "", pure = true, symbol = "__nv_atan2f"} : (tensor<32xf32>, tensor<32xf32>) -> tensor<32xf32>
     %14 = tt.splat %arg2 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %15 = tt.addptr %14, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %15, %13 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
@@ -49,7 +49,7 @@ module {
     %10 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %11 = tt.addptr %10, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %12 = tt.load %11, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
-    %13 = tt.extern_elementwise %9, %12 {libname = "libdevice", libpath = "/triton/python/triton/language/../third_party/cuda/lib/libdevice.10.bc", pure = true, symbol = "__nv_powf"} : (tensor<32xf32>, tensor<32xf32>) -> tensor<32xf32>
+    %13 = tt.extern_elementwise %9, %12 {libname = "", libpath = "", pure = true, symbol = "__nv_powf"} : (tensor<32xf32>, tensor<32xf32>) -> tensor<32xf32>
     %14 = tt.splat %arg2 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %15 = tt.addptr %14, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %15, %13 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
@@ -79,7 +79,7 @@ module {
     %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
-    %10 = tt.extern_elementwise %9 {libname = "libdevice", libpath = "/triton/python/triton/language/../third_party/cuda/lib/libdevice.10.bc", pure = true, symbol = "__nv_fabsf"} : (tensor<32xf32>) -> tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_fabsf"} : (tensor<32xf32>) -> tensor<32xf32>
     %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
@@ -110,7 +110,7 @@ module {
     %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
-    %10 = tt.extern_elementwise %9 {libname = "libdevice", libpath = "/triton/python/triton/language/../third_party/cuda/lib/libdevice.10.bc", pure = true, symbol = "__nv_sinf"} : (tensor<32xf32>) -> tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_sinf"} : (tensor<32xf32>) -> tensor<32xf32>
     %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
@@ -141,7 +141,7 @@ module {
     %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
-    %10 = tt.extern_elementwise %9 {libname = "libdevice", libpath = "/triton/python/triton/language/../third_party/cuda/lib/libdevice.10.bc", pure = true, symbol = "__nv_cosf"} : (tensor<32xf32>) -> tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_cosf"} : (tensor<32xf32>) -> tensor<32xf32>
     %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
@@ -172,7 +172,7 @@ module {
     %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
-    %10 = tt.extern_elementwise %9 {libname = "libdevice", libpath = "/triton/python/triton/language/../third_party/cuda/lib/libdevice.10.bc", pure = true, symbol = "__nv_tanf"} : (tensor<32xf32>) -> tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_tanf"} : (tensor<32xf32>) -> tensor<32xf32>
     %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
@@ -203,7 +203,7 @@ module {
     %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
-    %10 = tt.extern_elementwise %9 {libname = "libdevice", libpath = "/triton/python/triton/language/../third_party/cuda/lib/libdevice.10.bc", pure = true, symbol = "__nv_asinf"} : (tensor<32xf32>) -> tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_asinf"} : (tensor<32xf32>) -> tensor<32xf32>
     %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
@@ -234,7 +234,7 @@ module {
     %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
-    %10 = tt.extern_elementwise %9 {libname = "libdevice", libpath = "/triton/python/triton/language/../third_party/cuda/lib/libdevice.10.bc", pure = true, symbol = "__nv_acosf"} : (tensor<32xf32>) -> tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_acosf"} : (tensor<32xf32>) -> tensor<32xf32>
     %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
@@ -265,7 +265,7 @@ module {
     %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
-    %10 = tt.extern_elementwise %9 {libname = "libdevice", libpath = "/triton/python/triton/language/../third_party/cuda/lib/libdevice.10.bc", pure = true, symbol = "__nv_atanf"} : (tensor<32xf32>) -> tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_atanf"} : (tensor<32xf32>) -> tensor<32xf32>
     %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
@@ -296,7 +296,7 @@ module {
     %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
-    %10 = tt.extern_elementwise %9 {libname = "libdevice", libpath = "/triton/python/triton/language/../third_party/cuda/lib/libdevice.10.bc", pure = true, symbol = "__nv_sinhf"} : (tensor<32xf32>) -> tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_sinhf"} : (tensor<32xf32>) -> tensor<32xf32>
     %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
@@ -327,7 +327,7 @@ module {
     %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
-    %10 = tt.extern_elementwise %9 {libname = "libdevice", libpath = "/triton/python/triton/language/../third_party/cuda/lib/libdevice.10.bc", pure = true, symbol = "__nv_coshf"} : (tensor<32xf32>) -> tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_coshf"} : (tensor<32xf32>) -> tensor<32xf32>
     %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
@@ -358,7 +358,7 @@ module {
     %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
-    %10 = tt.extern_elementwise %9 {libname = "libdevice", libpath = "/triton/python/triton/language/../third_party/cuda/lib/libdevice.10.bc", pure = true, symbol = "__nv_tanhf"} : (tensor<32xf32>) -> tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_tanhf"} : (tensor<32xf32>) -> tensor<32xf32>
     %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
@@ -389,7 +389,7 @@ module {
     %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
-    %10 = tt.extern_elementwise %9 {libname = "libdevice", libpath = "/triton/python/triton/language/../third_party/cuda/lib/libdevice.10.bc", pure = true, symbol = "__nv_asinhf"} : (tensor<32xf32>) -> tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_asinhf"} : (tensor<32xf32>) -> tensor<32xf32>
     %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
@@ -420,7 +420,7 @@ module {
     %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
-    %10 = tt.extern_elementwise %9 {libname = "libdevice", libpath = "/triton/python/triton/language/../third_party/cuda/lib/libdevice.10.bc", pure = true, symbol = "__nv_acoshf"} : (tensor<32xf32>) -> tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_acoshf"} : (tensor<32xf32>) -> tensor<32xf32>
     %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
@@ -451,7 +451,7 @@ module {
     %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
-    %10 = tt.extern_elementwise %9 {libname = "libdevice", libpath = "/triton/python/triton/language/../third_party/cuda/lib/libdevice.10.bc", pure = true, symbol = "__nv_atanhf"} : (tensor<32xf32>) -> tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_atanhf"} : (tensor<32xf32>) -> tensor<32xf32>
     %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
@@ -482,7 +482,7 @@ module {
     %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
-    %10 = tt.extern_elementwise %9 {libname = "libdevice", libpath = "/triton/python/triton/language/../third_party/cuda/lib/libdevice.10.bc", pure = true, symbol = "__nv_logf"} : (tensor<32xf32>) -> tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_logf"} : (tensor<32xf32>) -> tensor<32xf32>
     %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
@@ -513,7 +513,7 @@ module {
     %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
-    %10 = tt.extern_elementwise %9 {libname = "libdevice", libpath = "/triton/python/triton/language/../third_party/cuda/lib/libdevice.10.bc", pure = true, symbol = "__nv_log10f"} : (tensor<32xf32>) -> tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_log10f"} : (tensor<32xf32>) -> tensor<32xf32>
     %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
@@ -544,7 +544,7 @@ module {
     %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
-    %10 = tt.extern_elementwise %9 {libname = "libdevice", libpath = "/triton/python/triton/language/../third_party/cuda/lib/libdevice.10.bc", pure = true, symbol = "__nv_log1pf"} : (tensor<32xf32>) -> tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_log1pf"} : (tensor<32xf32>) -> tensor<32xf32>
     %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
@@ -575,7 +575,7 @@ module {
     %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
-    %10 = tt.extern_elementwise %9 {libname = "libdevice", libpath = "/triton/python/triton/language/../third_party/cuda/lib/libdevice.10.bc", pure = true, symbol = "__nv_expf"} : (tensor<32xf32>) -> tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_expf"} : (tensor<32xf32>) -> tensor<32xf32>
     %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
@@ -606,7 +606,7 @@ module {
     %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
-    %10 = tt.extern_elementwise %9 {libname = "libdevice", libpath = "/triton/python/triton/language/../third_party/cuda/lib/libdevice.10.bc", pure = true, symbol = "__nv_exp2f"} : (tensor<32xf32>) -> tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_exp2f"} : (tensor<32xf32>) -> tensor<32xf32>
     %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
@@ -637,7 +637,7 @@ module {
     %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
-    %10 = tt.extern_elementwise %9 {libname = "libdevice", libpath = "/triton/python/triton/language/../third_party/cuda/lib/libdevice.10.bc", pure = true, symbol = "__nv_erff"} : (tensor<32xf32>) -> tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_erff"} : (tensor<32xf32>) -> tensor<32xf32>
     %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
@@ -668,7 +668,7 @@ module {
     %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
-    %10 = tt.extern_elementwise %9 {libname = "libdevice", libpath = "/triton/python/triton/language/../third_party/cuda/lib/libdevice.10.bc", pure = true, symbol = "__nv_sqrtf"} : (tensor<32xf32>) -> tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_sqrtf"} : (tensor<32xf32>) -> tensor<32xf32>
     %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
@@ -699,7 +699,7 @@ module {
     %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
-    %10 = tt.extern_elementwise %9 {libname = "libdevice", libpath = "/triton/python/triton/language/../third_party/cuda/lib/libdevice.10.bc", pure = true, symbol = "__nv_rsqrtf"} : (tensor<32xf32>) -> tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_rsqrtf"} : (tensor<32xf32>) -> tensor<32xf32>
     %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
@@ -730,7 +730,7 @@ module {
     %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
-    %10 = tt.extern_elementwise %9 {libname = "libdevice", libpath = "/triton/python/triton/language/../third_party/cuda/lib/libdevice.10.bc", pure = true, symbol = "__nv_ceilf"} : (tensor<32xf32>) -> tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_ceilf"} : (tensor<32xf32>) -> tensor<32xf32>
     %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
@@ -761,7 +761,7 @@ module {
     %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
-    %10 = tt.extern_elementwise %9 {libname = "libdevice", libpath = "/triton/python/triton/language/../third_party/cuda/lib/libdevice.10.bc", pure = true, symbol = "__nv_floorf"} : (tensor<32xf32>) -> tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_floorf"} : (tensor<32xf32>) -> tensor<32xf32>
     %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
@@ -792,7 +792,7 @@ module {
     %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
-    %10 = tt.extern_elementwise %9 {libname = "libdevice", libpath = "/triton/python/triton/language/../third_party/cuda/lib/libdevice.10.bc", pure = true, symbol = "__nv_truncf"} : (tensor<32xf32>) -> tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_truncf"} : (tensor<32xf32>) -> tensor<32xf32>
     %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>

--- a/test/Conversion/TritonToLinalg/unsupported_extern_elementwise.mlir
+++ b/test/Conversion/TritonToLinalg/unsupported_extern_elementwise.mlir
@@ -6,7 +6,7 @@ module {
     %1 = tt.splat %arg0 : (!tt.ptr<i32, 1>) -> tensor<8x!tt.ptr<i32, 1>>
     %2 = tt.addptr %1, %0 : tensor<8x!tt.ptr<i32, 1>>, tensor<8xi32>
     %3 = tt.load %2 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<8xi32>
-    %4 = tt.extern_elementwise %3, %0 {libname = "libdevice", libpath = "/path/to/something", pure = true, symbol = "some_symbol"} : (tensor<8xi32>, tensor<8xi32>) -> tensor<8xi32>
+    %4 = tt.extern_elementwise %3, %0 {libname = "", libpath = "", pure = true, symbol = "some_symbol"} : (tensor<8xi32>, tensor<8xi32>) -> tensor<8xi32>
     %5 = tt.splat %arg1 : (!tt.ptr<i32, 1>) -> tensor<8x!tt.ptr<i32, 1>>
     %6 = tt.addptr %5, %0 : tensor<8x!tt.ptr<i32, 1>>, tensor<8xi32>
     tt.store %6, %4 {cache = 1 : i32, evict = 1 : i32} : tensor<8xi32>
@@ -28,7 +28,7 @@ module {
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<8xi32>
 // CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<8xi32, strided<[1]>> to memref<8xi32>
 // CHECK:           [[VAR_2_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<8xi32>
-// CHECK-DAG:       [[VAR_3_:%.+]] = tt.extern_elementwise [[VAR_2_]], [[VAR_1_]] {libname = "libdevice", libpath = "/path/to/something", pure = true, symbol = "some_symbol"} : (tensor<8xi32>, tensor<8xi32>) -> tensor<8xi32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tt.extern_elementwise [[VAR_2_]], [[VAR_1_]] {libname = "", libpath = "", pure = true, symbol = "some_symbol"} : (tensor<8xi32>, tensor<8xi32>) -> tensor<8xi32>
 // CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: [0], sizes: [8], strides: [1] : memref<*xi32> to memref<8xi32, strided<[1]>>
 // CHECK:           bufferization.materialize_in_destination [[VAR_3_]] in writable [[VAR_reinterpret_cast_0_]]
 // CHECK:           return


### PR DESCRIPTION
Triton does not set libdevice name for __nv_* intrinsics after https://github.com/openai/triton/pull/2887

- Remove check for libdevice for __nv_* intrinsics
- Remove particular NVIDIA-related libdevice name from the tests