### PR TITLE
Introduce `structured-to-memref` pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.pyc
+.cache
+compile_commands.json

--- a/backend/compiler.py
+++ b/backend/compiler.py
@@ -32,7 +32,7 @@ def _ttir_to_ttsharedir(mod):
         dst_path = os.path.join(tmpdir, "ttshared.mlir")
         Path(src_path).write_text(ttir_code)
         triton_shared_opt_path = _get_triton_shared_opt_path()
-        subprocess.check_call([triton_shared_opt_path, src_path, "--triton-to-structured", "--canonicalize", "--triton-arith-to-linalg", "--structured-to-memref", "-o", dst_path])
+        subprocess.check_call([triton_shared_opt_path, src_path, "--triton-to-structured", "--canonicalize", "--triton-arith-to-linalg", "--cse", "--structured-to-memref", "-o", dst_path])
         return Path(dst_path).read_text()
 
 

--- a/backend/compiler.py
+++ b/backend/compiler.py
@@ -1,5 +1,5 @@
 from triton.backends.compiler import BaseBackend
-from triton._C.libtriton import ir, passes, llvm, triton_shared
+from triton._C.libtriton import ir, passes
 from dataclasses import dataclass
 from typing import Any
 import hashlib
@@ -32,7 +32,7 @@ def _ttir_to_ttsharedir(mod):
         dst_path = os.path.join(tmpdir, "ttshared.mlir")
         Path(src_path).write_text(ttir_code)
         triton_shared_opt_path = _get_triton_shared_opt_path()
-        subprocess.check_call([triton_shared_opt_path, src_path, "--triton-to-linalg", "-o", dst_path])
+        subprocess.check_call([triton_shared_opt_path, src_path, "--triton-to-structured", "--canonicalize", "--triton-arith-to-linalg", "--structured-to-memref", "-o", dst_path])
         return Path(dst_path).read_text()
 
 
@@ -151,7 +151,6 @@ class CPUBackend(BaseBackend):
 
     @staticmethod
     def make_ttir(mod, metadata, opt):
-        # assert False
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
         passes.common.add_inliner(pm)

--- a/include/triton-shared/AnalysisStructured/PtrAnalysis.h
+++ b/include/triton-shared/AnalysisStructured/PtrAnalysis.h
@@ -34,9 +34,8 @@ const extern std::string ptrAnalysisAttr;
 // shape field means the same field as tt.make_tensor_ptr; when it describes a
 // non-block pointer, shape field indicates how address wraps around (i.e.,
 // modulo); a constant 0 indicates no modulo for the dimension.
-class PtrState {
+struct PtrState {
 
-public:
   SmallVector<OpFoldResult> offsets;
   SmallVector<OpFoldResult> sizes;
   SmallVector<OpFoldResult> strides;

--- a/include/triton-shared/Conversion/CMakeLists.txt
+++ b/include/triton-shared/Conversion/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(TritonToLinalg)
 add_subdirectory(TritonToStructured)
 add_subdirectory(TritonArithToLinalg)
+add_subdirectory(StructuredToMemref)

--- a/include/triton-shared/Conversion/StructuredToMemref/CMakeLists.txt
+++ b/include/triton-shared/Conversion/StructuredToMemref/CMakeLists.txt
@@ -1,0 +1,3 @@
+set(LLVM_TARGET_DEFINITIONS Passes.td)
+mlir_tablegen(Passes.h.inc -gen-pass-decls --name StructuredToMemref)
+add_public_tablegen_target(StructuredToMemrefConversionPassIncGen)

--- a/include/triton-shared/Conversion/StructuredToMemref/Passes.h
+++ b/include/triton-shared/Conversion/StructuredToMemref/Passes.h
@@ -1,0 +1,15 @@
+#ifndef TRITON_STRUCTURED_TO_MEMREF_CONVERSION_PASSES_H
+#define TRITON_STRUCTURED_TO_MEMREF_CONVERSION_PASSES_H
+
+#include "triton-shared/Conversion/StructuredToMemref/StructuredToMemref.h"
+
+namespace mlir {
+namespace triton {
+
+#define GEN_PASS_REGISTRATION
+#include "triton-shared/Conversion/StructuredToMemref/Passes.h.inc"
+
+} // namespace triton
+} // namespace mlir
+
+#endif

--- a/include/triton-shared/Conversion/StructuredToMemref/Passes.td
+++ b/include/triton-shared/Conversion/StructuredToMemref/Passes.td
@@ -1,0 +1,20 @@
+#ifndef TRITON_ARITH_TO_LINALG_CONVERSION_PASSES
+#define TRITON_ARITH_TO_LINALG_CONVERSION_PASSES
+
+include "mlir/Pass/PassBase.td"
+
+def StructuredToMemref : Pass<"structured-to-memref", "mlir::ModuleOp"> {
+  let summary = "Convert Triton arithmetic operations into linalg";
+  let options = [
+      Option<"pidsToFuncArgs", "pids-to-func-args", "bool", /*default*/"true",
+             "Convert tt.get_program_id and tt.get_num_programs to reference to function arguments">,
+      Option<"ttToFuncFunc", "tt-to-func-func", "bool", /*default*/"true",
+             "Convert tt.func to func.func">,
+      Option<"addptrToLinalg", "addptr-to-linalg", "bool", /*default*/"true",
+             "Convert tt.addptr on tensors to linalg">,
+      Option<"assertToCf", "assert-to-cf", "bool", /*default*/"true",
+             "Convert tt.assert to cf.assert">,
+  ];
+}
+
+#endif

--- a/include/triton-shared/Conversion/StructuredToMemref/Passes.td
+++ b/include/triton-shared/Conversion/StructuredToMemref/Passes.td
@@ -4,17 +4,7 @@
 include "mlir/Pass/PassBase.td"
 
 def StructuredToMemref : Pass<"structured-to-memref", "mlir::ModuleOp"> {
-  let summary = "Convert Triton arithmetic operations into linalg";
-  let options = [
-      Option<"pidsToFuncArgs", "pids-to-func-args", "bool", /*default*/"true",
-             "Convert tt.get_program_id and tt.get_num_programs to reference to function arguments">,
-      Option<"ttToFuncFunc", "tt-to-func-func", "bool", /*default*/"true",
-             "Convert tt.func to func.func">,
-      Option<"addptrToLinalg", "addptr-to-linalg", "bool", /*default*/"true",
-             "Convert tt.addptr on tensors to linalg">,
-      Option<"assertToCf", "assert-to-cf", "bool", /*default*/"true",
-             "Convert tt.assert to cf.assert">,
-  ];
+  let summary = "Convert triton structured pointer ops to memref";
 }
 
 #endif

--- a/include/triton-shared/Conversion/StructuredToMemref/StructuredToMemref.h
+++ b/include/triton-shared/Conversion/StructuredToMemref/StructuredToMemref.h
@@ -1,0 +1,22 @@
+#ifndef TRITON_CONVERSION_STRUCTUREDTOMEMREF_STRUCTUREDTOMEMREF_H
+#define TRITON_CONVERSION_STRUCTUREDTOMEMREF_STRUCTUREDTOMEMREF_H
+
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+#include "triton/Dialect/Triton/IR/Dialect.h"
+
+namespace mlir {
+class TypeConverter;
+namespace triton {
+
+#define GEN_PASS_DECL
+#include "triton-shared/Conversion/StructuredToMemref/Passes.h.inc"
+
+void populateStructuredToMemrefConversionPatterns(RewritePatternSet &patterns,
+                                                  TypeConverter &typeConverter);
+
+} // namespace triton
+} // namespace mlir
+
+#endif // TRITON_CONVERSION_STRUCTUREDTOMEMREF_STRUCTUREDTOMEMREF_H

--- a/include/triton-shared/Dialect/TritonStructured/IR/TritonStructuredDialect.td
+++ b/include/triton-shared/Dialect/TritonStructured/IR/TritonStructuredDialect.td
@@ -102,6 +102,18 @@ def TTS_MakeTensorPtrOp
       Builder b(getContext());
       return ::mlir::getMixedValues(getStaticShape(), getShape(), b);
     }
+    bool isBlockPtr() {
+      return !getOrder().empty();
+    }
+    bool isRegularPtr() {
+      return !isBlockPtr() &&
+             llvm::all_of(getStaticShape(), [](auto shape) { return shape == 0; });
+    }
+    bool isSplitPtr() {
+      return !isBlockPtr() &&
+             !isRegularPtr() &&
+             llvm::any_of(getStaticShape(), [](auto shape) { return shape != 0; });
+    }
   }];
 
   // TODO
@@ -116,7 +128,7 @@ def TTS_LoadOp : TTS_Op<"load", [
   let summary = "optionally load data from in memory to fill a portion of the tensor";
 
   let arguments = (ins TT_PtrLike:$ptr,
-                       Variadic<Index>:$dims,
+                       Variadic<Index>:$dims,           // mask dimension
                        DenseI64ArrayAttr:$static_dims,
                        Optional<AnyTypeOf<[TT_Float, TT_Int, TT_Ptr]>>:$other);
 
@@ -125,6 +137,18 @@ def TTS_LoadOp : TTS_Op<"load", [
   let builders = [
     OpBuilder<(ins "Value":$ptr, "ArrayRef<OpFoldResult>":$dims, "Value":$other)>,
   ];
+
+  let extraClassDeclaration = [{
+    /// Return a vector of all the static or dynamic fields
+    SmallVector<OpFoldResult> getMixedMaskDims() {
+      Builder b(getContext());
+      return ::mlir::getMixedValues(getStaticDims(), getDims(), b);
+    }
+
+    bool hasMasks() {
+      return !getStaticDims().empty();
+    }
+  }];
 
   // TODO
   //let hasCustomAssemblyFormat = 1;
@@ -144,6 +168,18 @@ def TTS_StoreOp : TTS_Op<"store", [
   let builders = [
     OpBuilder<(ins "Value":$ptr, "Value":$value, "ArrayRef<OpFoldResult>":$dims)>,
   ];
+
+  let extraClassDeclaration = [{
+    /// Return a vector of all the static or dynamic fields
+    SmallVector<OpFoldResult> getMixedMaskDims() {
+      Builder b(getContext());
+      return ::mlir::getMixedValues(getStaticDims(), getDims(), b);
+    }
+
+    bool hasMasks() {
+      return !getStaticDims().empty();
+    }
+  }];
 
   // TODO
   //let hasCustomAssemblyFormat = 1;

--- a/include/triton-shared/Dialect/TritonStructured/IR/TritonStructuredDialect.td
+++ b/include/triton-shared/Dialect/TritonStructured/IR/TritonStructuredDialect.td
@@ -105,14 +105,13 @@ def TTS_MakeTensorPtrOp
     bool isBlockPtr() {
       return !getOrder().empty();
     }
-    bool isRegularPtr() {
+    bool isStructuredPtr() {
       return !isBlockPtr() &&
              llvm::all_of(getStaticShape(), [](auto shape) { return shape == 0; });
     }
     bool isSplitPtr() {
       return !isBlockPtr() &&
-             !isRegularPtr() &&
-             llvm::any_of(getStaticShape(), [](auto shape) { return shape != 0; });
+             !isStructuredPtr();
     }
   }];
 
@@ -128,25 +127,25 @@ def TTS_LoadOp : TTS_Op<"load", [
   let summary = "optionally load data from in memory to fill a portion of the tensor";
 
   let arguments = (ins TT_PtrLike:$ptr,
-                       Variadic<Index>:$dims,           // mask dimension
-                       DenseI64ArrayAttr:$static_dims,
+                       Variadic<Index>:$mask_dims,
+                       DenseI64ArrayAttr:$static_mask_dims,
                        Optional<AnyTypeOf<[TT_Float, TT_Int, TT_Ptr]>>:$other);
 
   let results = (outs TT_Tensor:$result);
 
   let builders = [
-    OpBuilder<(ins "Value":$ptr, "ArrayRef<OpFoldResult>":$dims, "Value":$other)>,
+    OpBuilder<(ins "Value":$ptr, "ArrayRef<OpFoldResult>":$mask_dims, "Value":$other)>,
   ];
 
   let extraClassDeclaration = [{
     /// Return a vector of all the static or dynamic fields
     SmallVector<OpFoldResult> getMixedMaskDims() {
       Builder b(getContext());
-      return ::mlir::getMixedValues(getStaticDims(), getDims(), b);
+      return ::mlir::getMixedValues(getStaticMaskDims(), getMaskDims(), b);
     }
 
-    bool hasMasks() {
-      return !getStaticDims().empty();
+    bool hasMask() {
+      return !getStaticMaskDims().empty();
     }
   }];
 
@@ -162,8 +161,8 @@ def TTS_StoreOp : TTS_Op<"store", [
 
   let arguments = (ins TT_PtrLike:$ptr,
                        TT_Tensor:$value,
-                       Variadic<Index>:$dims,
-                       DenseI64ArrayAttr:$static_dims);
+                       Variadic<Index>:$mask_dims,
+                       DenseI64ArrayAttr:$static_mask_dims);
 
   let builders = [
     OpBuilder<(ins "Value":$ptr, "Value":$value, "ArrayRef<OpFoldResult>":$dims)>,
@@ -173,11 +172,11 @@ def TTS_StoreOp : TTS_Op<"store", [
     /// Return a vector of all the static or dynamic fields
     SmallVector<OpFoldResult> getMixedMaskDims() {
       Builder b(getContext());
-      return ::mlir::getMixedValues(getStaticDims(), getDims(), b);
+      return ::mlir::getMixedValues(getStaticMaskDims(), getMaskDims(), b);
     }
 
-    bool hasMasks() {
-      return !getStaticDims().empty();
+    bool hasMask() {
+      return !getStaticMaskDims().empty();
     }
   }];
 

--- a/lib/AnalysisStructured/PtrAnalysis.cpp
+++ b/lib/AnalysisStructured/PtrAnalysis.cpp
@@ -812,14 +812,11 @@ LogicalResult PtrAnalysis::rewriteForOp(scf::ForOp op) {
     auto mappedV = ptrMap.lookupOrNull(arg);
     PtrState state;
 
-    arg.dump();
-
     if (mappedV) {
       llvm::dbgs() << "using mapped value\n";
       if (auto makeTPtrOp = mappedV.getDefiningOp<tts::MakeTensorPtrOp>()) {
         if (visitOperandMakeTPtr(makeTPtrOp, state, op.getLoc(), builder)
                 .succeeded()) {
-          // assert(0);
           newInitArgs.push_back(mappedV);
           // Record the PtrState for later processing
           initArgIndexState.push_back(std::make_pair(i, state));
@@ -846,15 +843,9 @@ LogicalResult PtrAnalysis::rewriteForOp(scf::ForOp op) {
           // Record the PtrState for later processing
           initArgIndexState.push_back(std::make_pair(i, state));
           continue;
-        } else {
-          assert(0);
         }
-      } else {
-        assert(0);
       }
     }
-
-    llvm::dbgs() << "using original value\n";
     // If any of the analysis failed, or init arg is not pointer related or
     // prior rewrite has failed. Pass as is
     newInitArgs.push_back(arg);

--- a/lib/AnalysisStructured/PtrAnalysis.cpp
+++ b/lib/AnalysisStructured/PtrAnalysis.cpp
@@ -813,7 +813,6 @@ LogicalResult PtrAnalysis::rewriteForOp(scf::ForOp op) {
     PtrState state;
 
     if (mappedV) {
-      llvm::dbgs() << "using mapped value\n";
       if (auto makeTPtrOp = mappedV.getDefiningOp<tts::MakeTensorPtrOp>()) {
         if (visitOperandMakeTPtr(makeTPtrOp, state, op.getLoc(), builder)
                 .succeeded()) {

--- a/lib/Conversion/CMakeLists.txt
+++ b/lib/Conversion/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(TritonToLinalg)
 add_subdirectory(TritonToStructured)
 add_subdirectory(TritonArithToLinalg)
+add_subdirectory(StructuredToMemref)

--- a/lib/Conversion/StructuredToMemref/CMakeLists.txt
+++ b/lib/Conversion/StructuredToMemref/CMakeLists.txt
@@ -1,0 +1,24 @@
+add_mlir_conversion_library(StructuredToMemref
+  StructuredToMemref.cpp
+  StructuredToMemrefPass.cpp
+
+  DEPENDS
+  StructuredToMemrefConversionPassIncGen
+
+  LINK_COMPONENTS
+  Core
+
+  LINK_LIBS PUBLIC
+  MLIRArithDialect
+  MLIRDialectUtils
+  MLIRIR
+  MLIRMathDialect
+  MLIRPass
+  MLIRTensorDialect
+  MLIRTransforms
+  MLIRSupport
+  TritonIR
+  TritonTransforms
+  TritonTilingExtIR
+  TritonStructuredIR
+)

--- a/lib/Conversion/StructuredToMemref/StructuredToMemref.cpp
+++ b/lib/Conversion/StructuredToMemref/StructuredToMemref.cpp
@@ -1,0 +1,872 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (c) Microsoft Corporation, Meta Platforms.
+// Licensed under the MIT license.
+//
+//===----------------------------------------------------------------------===//
+
+#include "triton-shared/Conversion/StructuredToMemref/StructuredToMemref.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypeInterfaces.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/TypeUtilities.h"
+#include "mlir/IR/Types.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "triton-shared/Analysis/OpFoldResultUtils.h"
+#include "triton-shared/Dialect/TritonStructured/IR/TritonStructuredDialect.h"
+
+#include "triton/Dialect/Triton/IR/Dialect.h"
+
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/MemRef/IR//MemRef.h"
+#include "triton/Dialect/Triton/IR/Types.h"
+
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+
+#define DEBUG_TYPE "structured-to-memref"
+
+using namespace mlir;
+using namespace triton;
+
+#define GEN_PASS_CLASSES
+#include "triton-shared/Conversion/TritonArithToLinalg/Passes.h.inc"
+
+static const std::string WRAP_SIDE_BY_SIDE = "wrap_side_by_side";
+static const std::string WRAP_STACKED = "wrap_stacked";
+
+static memref::SubViewOp getSubview(int rank, ArrayRef<OpFoldResult> dims,
+                                    Value source, Location loc, OpBuilder &b) {
+  auto sourceType = cast<MemRefType>(source.getType());
+  SmallVector<OpFoldResult> offsets(rank, b.getIndexAttr(0));
+  SmallVector<OpFoldResult> strides(rank, b.getIndexAttr(1));
+  auto dstType =
+      memref::SubViewOp::inferResultType(sourceType, offsets, dims, strides);
+
+  return b.create<memref::SubViewOp>(loc, cast<MemRefType>(dstType), source,
+                                     offsets, dims, strides);
+}
+
+namespace {
+
+struct MakeTensorPtrConverter
+    : public OpConversionPattern<tts::MakeTensorPtrOp> {
+private:
+  using OpConversionPattern<tts::MakeTensorPtrOp>::OpConversionPattern;
+
+  static Type getElementTypeRegularPtr(tts::MakeTensorPtrOp op) {
+    assert(!op.isBlockPtr());
+    // tensor<1024x!tt.ptr<f32, 1>>
+    auto ptrType = cast<triton::PointerType>(
+        cast<RankedTensorType>(op.getType()).getElementType());
+    return ptrType.getPointeeType();
+  }
+
+  static Type getElementTypeBlockPtr(tts::MakeTensorPtrOp op) {
+    assert(op.isBlockPtr());
+    // !tt.ptr<tensor<128x64xbf16>, 1>
+    auto shapedType = cast<ShapedType>(
+        cast<triton::PointerType>(op.getType()).getPointeeType());
+    return shapedType.getElementType();
+  }
+
+  static MemRefType getResultMemrefType(tts::MakeTensorPtrOp op, int64_t offset,
+                                        ArrayRef<int64_t> staticStrides,
+                                        ArrayRef<int64_t> resultShape) {
+    auto layout =
+        StridedLayoutAttr::get(op.getContext(), offset, staticStrides);
+    Type elemType;
+    if (op.isBlockPtr()) {
+      elemType = getElementTypeBlockPtr(op);
+    } else {
+      elemType = getElementTypeRegularPtr(op);
+    }
+    return MemRefType::get(resultShape, elemType, layout);
+  }
+
+  // If there are dimensions with size 1 and stride 0, replace 0 stride with
+  // the product of sizes of all lower dimensions. This avoids creating memref
+  // with zero stride. Note that we store the unmodified state into knownPtrs,
+  // since any following pointer arithmetic operations should use the original
+  // 0 stride.
+  static llvm::SmallVector<OpFoldResult>
+  getMixedStridesForMemref(tts::MakeTensorPtrOp op, OpBuilder &b) {
+    llvm::SmallVector<OpFoldResult> strides;
+    auto accumulate = 1;
+    for (auto [size, stride] :
+         llvm::reverse(llvm::zip(op.getSizes(), op.getMixedStrides()))) {
+      auto strideIntAttr = getIntAttr(stride);
+      if (size == 1 && strideIntAttr && strideIntAttr.value() == 0) {
+        strides.push_back(b.getIndexAttr(accumulate));
+      } else {
+        strides.push_back(stride);
+      }
+      accumulate *= size;
+    }
+    std::reverse(strides.begin(), strides.end());
+    return strides;
+  }
+
+  static OpFoldResult accumulateTargetOffset(tts::MakeTensorPtrOp op,
+                                             OpBuilder &b) {
+    Location loc = op->getLoc();
+    OpFoldResult targetOffset = b.getIndexAttr(0);
+    for (auto o : op.getMixedOffsets()) {
+      targetOffset = addOFRs(targetOffset, o, loc, b);
+    }
+    return targetOffset;
+  }
+
+  std::pair<memref::ReinterpretCastOp, memref::ReinterpretCastOp>
+  createSideBySideCastOps(tts::MakeTensorPtrOp op, OpAdaptor adaptor,
+                          ConversionPatternRewriter &rewriter) const {
+    auto loc = op->getLoc();
+    auto resultShape = cast<RankedTensorType>(op.getType()).getShape();
+
+    auto targetOffset =
+        ofrToIndexValue(accumulateTargetOffset(op, rewriter), loc, rewriter);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //
+    // Handling side-by-side wraparound
+    //
+    // Note: We do not support cases where the target has already overflown the
+    // number of columns! This is because in PtrAnalysis, the offset has already
+    // been collapsed into a single dimension, so it is ambiguous to determine
+    // whether the offset actually overflows or just refers to an element on the
+    // subsequent rows.
+    //
+    // Same limitations apply to the stacked wraparound case.
+    //
+    ////////////////////////////////////////////////////////////////////////////
+    //
+    //    nextOffset - targetOffset = colSize
+    //    d1 + d2 = colSize
+    //                          N
+    //                                x            clampedOffset
+    //      --------------------------*----------------*-----*
+    //      |                                          |     nextOffset (might
+    //      |                    targetOffset          |             overflow)
+    //  y   *-----                    *----------------|
+    //      |    |                    |                |
+    //  M   |-----                    -----------------|
+    //      | d2                              d1       |
+    //      --------------------------------------------
+    //
+    //    x = targetOffset % N
+    //    nextOffset = x + colSize
+    //    clampedOffset = min(nextOffset, N)
+    //    d1 = clampedOffset - x
+    //
+    ////////////////////////////////////////////////////////////////////////////
+
+    auto resultType = getResultMemrefType(
+        op, /* offset */ ShapedType::kDynamic,
+        /* staticStrides */
+        SmallVector<int64_t>(resultShape.size(), ShapedType::kDynamic),
+        /* result shape */
+        SmallVector<int64_t>{
+
+            // Row stays the same
+            resultShape[0],
+
+            // Column is dynamic, in most cases, this
+            // should be the same as the original column.
+            // The last chunk may be smaller due to
+            // wrapping around.
+            ShapedType::kDynamic});
+
+    Value rowSize = rewriter.create<arith::ConstantOp>(
+        loc, rewriter.getIndexAttr(op.getSizes()[0]));
+    Value colSize = rewriter.create<arith::ConstantOp>(
+        loc, rewriter.getIndexAttr(op.getSizes()[1]));
+
+    Value modN = ofrToIndexValue(op.getMixedShape()[1], loc, rewriter);
+
+    Value x = rewriter.create<arith::RemSIOp>(loc, targetOffset, modN);
+    Value y = rewriter.create<arith::SubIOp>(loc, targetOffset, x);
+
+    SmallVector<Value> strideVals =
+        ofrsToIndexValues(op.getMixedStrides(), loc, rewriter);
+
+    // First chunk
+    Value nextOffset = rewriter.create<arith::AddIOp>(loc, x, colSize);
+    Value clampedOffset =
+        rewriter.create<arith::MinSIOp>(loc, nextOffset, modN);
+    Value d1 = rewriter.create<arith::SubIOp>(loc, clampedOffset, x);
+    SmallVector<Value> sizes1{rowSize, d1};
+
+    auto cast1 = rewriter.create<memref::ReinterpretCastOp>(
+        loc, resultType, adaptor.getBase(), targetOffset, sizes1, strideVals);
+
+    // Second chunk
+    Value d2 = rewriter.create<arith::SubIOp>(loc, colSize, d1);
+    SmallVector<Value> sizes2{rowSize, d2};
+
+    auto cast2 = rewriter.create<memref::ReinterpretCastOp>(
+        loc, resultType, adaptor.getBase(), y, sizes2, strideVals);
+
+    return {cast1, cast2};
+  }
+
+  std::pair<memref::ReinterpretCastOp, memref::ReinterpretCastOp>
+  createStackedCastOps(tts::MakeTensorPtrOp op, OpAdaptor adaptor,
+                       ConversionPatternRewriter &rewriter) const {
+
+    auto loc = op->getLoc();
+    auto resultShape = cast<RankedTensorType>(op.getType()).getShape();
+
+    assert(resultShape.size() == 2);
+
+    auto targetOffset =
+        ofrToIndexValue(accumulateTargetOffset(op, rewriter), loc, rewriter);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //
+    // Handling stacked wraparound
+    //
+    // We do not support cases where the target offset has already overflown the
+    // number of rows. See side-by-side wraparound for details.
+    //
+    ////////////////////////////////////////////////////////////////////////////
+    //    We're loading a tensor of dim (rowSize, colSize)
+    //    d1 + d2 = rowSize
+    //    d2 is the number of rows that overflow
+    //
+    //                       cols
+    //
+    //               wrappedAroundOff
+    //      --------------*------------*--------
+    //      |        d2   |            |       |
+    //      |             |------------|       |
+    //  rows|                                  |
+    //      |                                  |
+    //      |           targetOffset           |
+    //      |             *------------|       |
+    //      |             |            |       |
+    //      |         d1  |            |       |
+    //      |             | clampedOff |       |
+    //      --------------*---------------------
+    //                    |  overflow  |
+    //                    *-------------
+    //                 nextOff
+    //
+    //    wrappedAroundOff = targetOffset % cols
+    //    clampedOff = (rows * strideRows) + wrappedAroundOff
+    //                  ~~~~~~~~~~~~~~~~~
+    //                         ^
+    //                         |
+    //          We have already computed
+    //          rows * strideRows = modRow = shape[1]
+    //          in TritonToStructured
+    //
+    //          clampedOff - targetOffset
+    //    d1 = --------------------
+    //              strideRows
+
+    auto resultType = getResultMemrefType(
+        op, /* offset */ ShapedType::kDynamic,
+        /* staticStrides */
+        SmallVector<int64_t>(resultShape.size(), ShapedType::kDynamic),
+        /* result shape */
+        SmallVector<int64_t>{
+            // Row is dynamic, in most cases, this should
+            // be the same as the original row. The last
+            // chunk may be smaller due to wrapping
+            // around.
+            ShapedType::kDynamic,
+
+            // Col stays the same.
+            resultShape[1],
+        });
+
+    Value rowSize = rewriter.create<arith::ConstantOp>(
+        loc, rewriter.getIndexAttr(op.getSizes()[0]));
+    Value colSize = rewriter.create<arith::ConstantOp>(
+        loc, rewriter.getIndexAttr(op.getSizes()[1]));
+
+    Value strideRow = ofrToIndexValue(op.getMixedStrides()[0], loc, rewriter);
+    Value strideCol = ofrToIndexValue(op.getMixedStrides()[1], loc, rewriter);
+
+    Value modRow = op.getShape()[0];
+
+    // First chunk
+    Value wrappedAroundOff =
+        rewriter.create<arith::RemSIOp>(loc, targetOffset, strideRow);
+    Value clampedOff =
+        rewriter.create<arith::AddIOp>(loc, modRow, wrappedAroundOff);
+    Value d1 = rewriter.create<arith::SubIOp>(loc, clampedOff, targetOffset);
+    d1 = rewriter.create<arith::DivSIOp>(loc, d1, strideRow);
+
+    SmallVector<Value> sizes1{d1, colSize};
+    memref::ReinterpretCastOp cast1 =
+        rewriter.create<memref::ReinterpretCastOp>(
+            loc, resultType, adaptor.getBase(), targetOffset, sizes1,
+            ValueRange{strideRow, strideCol});
+
+    // Second chunk
+    Value d2 = rewriter.create<arith::SubIOp>(loc, rowSize, d1);
+    SmallVector<Value> sizes2{d2, colSize};
+    memref::ReinterpretCastOp cast2 =
+        rewriter.create<memref::ReinterpretCastOp>(
+            loc, resultType, adaptor.getBase(), wrappedAroundOff, sizes2,
+            ValueRange{strideRow, strideCol});
+
+    return {cast1, cast2};
+  }
+
+  LogicalResult rewriteSplitPtr(tts::MakeTensorPtrOp op, OpAdaptor adaptor,
+                                ConversionPatternRewriter &rewriter) const {
+
+    auto parentShape = op.getStaticShape();
+
+    SmallVector<Value> casts;
+    StringRef wrapType;
+
+    if (parentShape[0] == ShapedType::kDynamic) {
+      // Stacked case
+      assert(parentShape[1] == 0);
+      auto [cast1, cast2] = createStackedCastOps(op, adaptor, rewriter);
+      casts = {cast1.getResult(), cast2.getResult()};
+      wrapType = WRAP_STACKED;
+    } else {
+      assert(parentShape[0] == 0);
+      auto [cast1, cast2] = createSideBySideCastOps(op, adaptor, rewriter);
+      casts = {cast1.getResult(), cast2.getResult()};
+      wrapType = WRAP_SIDE_BY_SIDE;
+    }
+
+    auto combinedCast = rewriter.create<UnrealizedConversionCastOp>(
+        op.getLoc(), op.getType(), casts);
+
+    combinedCast->setAttr(wrapType, rewriter.getUnitAttr());
+
+    rewriter.replaceOp(op, combinedCast);
+
+    return success();
+  }
+
+  LogicalResult rewritePtr(ArrayRef<int64_t> resultShape,
+                           tts::MakeTensorPtrOp op, OpAdaptor adaptor,
+                           ConversionPatternRewriter &rewriter) const {
+
+    auto mixedStrides = getMixedStridesForMemref(op, rewriter);
+    SmallVector<int64_t> staticStrides;
+    SmallVector<Value> dynamicStrides;
+    dispatchIndexOpFoldResults(mixedStrides, dynamicStrides, staticStrides);
+
+    auto targetOffset = accumulateTargetOffset(op, rewriter);
+    auto staticTargetOffset = getIntAttr(targetOffset);
+    auto resultType = getResultMemrefType(
+        op, staticTargetOffset.value_or(ShapedType::kDynamic), staticStrides,
+        resultShape);
+
+    // The base ptr, which is from one of the args, would have already been
+    // converted to memref<*> at this point, so get the base from adaptor
+    auto ptr = adaptor.getBase();
+
+    auto castOp = rewriter.create<memref::ReinterpretCastOp>(
+        op.getLoc(), resultType, ptr, accumulateTargetOffset(op, rewriter),
+        op.getMixedSizes(), mixedStrides);
+
+    rewriter.replaceOp(op, castOp);
+
+    return success();
+  }
+
+  LogicalResult rewriteRegularPtr(tts::MakeTensorPtrOp op, OpAdaptor adaptor,
+                                  ConversionPatternRewriter &rewriter) const {
+    ArrayRef<int64_t> resultShape = cast<ShapedType>(op.getType()).getShape();
+    return rewritePtr(resultShape, op, adaptor, rewriter);
+  }
+
+  LogicalResult rewriteBlockPtr(tts::MakeTensorPtrOp op, OpAdaptor adaptor,
+                                ConversionPatternRewriter &rewriter) const {
+    // Block pointers are basically the same as regular pointers except that
+    // the return types are !tt.ptr<tensor<AxBxCxbf16>> instead of
+    // tensor<AxBxCx!tt.ptr<bf16>>
+    ArrayRef<int64_t> resultShape =
+        cast<ShapedType>(
+            cast<triton::PointerType>(op.getType()).getPointeeType())
+            .getShape();
+    return rewritePtr(resultShape, op, adaptor, rewriter);
+  }
+
+public:
+  LogicalResult
+  matchAndRewrite(tts::MakeTensorPtrOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    if (op.isBlockPtr()) {
+      return rewriteBlockPtr(op, adaptor, rewriter);
+    }
+
+    if (op.isRegularPtr()) {
+      return rewriteRegularPtr(op, adaptor, rewriter);
+    }
+
+    if (op.isSplitPtr()) {
+      return rewriteSplitPtr(op, adaptor, rewriter);
+    }
+
+    return failure();
+  }
+};
+
+struct LoadConverter : public OpConversionPattern<tts::LoadOp> {
+private:
+  using OpConversionPattern<tts::LoadOp>::OpConversionPattern;
+
+  void createSideBySideCopies(Value block1, Value block2, Value dst,
+                              Location loc,
+                              ConversionPatternRewriter &rewriter) const {
+
+    auto zero =
+        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(0));
+
+    auto one =
+        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(1));
+
+    Value block1Row = rewriter.create<memref::DimOp>(loc, block1, 0);
+    Value block1Col = rewriter.create<memref::DimOp>(loc, block1, 1);
+
+    Value block2Row = rewriter.create<memref::DimOp>(loc, block2, 0);
+    Value block2Col = rewriter.create<memref::DimOp>(loc, block2, 1);
+
+    auto block1Dst =
+        rewriter.create<memref::SubViewOp>(loc, dst, /* offsets */
+                                           ValueRange{zero, zero},
+                                           /* sizes */
+                                           ValueRange{block1Row, block1Col},
+                                           /* strides */
+                                           ValueRange{one, one});
+
+    auto block2Dst =
+        rewriter.create<memref::SubViewOp>(loc, dst,
+                                           /* offsets */
+                                           ValueRange{zero, block1Col},
+                                           /* sizes */
+                                           ValueRange{block2Row, block2Col},
+                                           /* strides */
+                                           ValueRange{one, one});
+
+    rewriter.create<memref::CopyOp>(loc, block1, block1Dst);
+    rewriter.create<memref::CopyOp>(loc, block2, block2Dst);
+  }
+
+  void createStackedCopies(Value block1, Value block2, Value dst, Location loc,
+                           ConversionPatternRewriter &rewriter) const {
+
+    auto zero =
+        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(0));
+    auto one =
+        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(1));
+
+    Value block1Row = rewriter.create<memref::DimOp>(loc, block1, 0);
+    Value block1Col = rewriter.create<memref::DimOp>(loc, block1, 1);
+
+    Value block2Row = rewriter.create<memref::DimOp>(loc, block2, 0);
+    Value block2Col = rewriter.create<memref::DimOp>(loc, block2, 1);
+
+    auto block1Dst =
+        rewriter.create<memref::SubViewOp>(loc, dst, /* offsets */
+                                           ValueRange{zero, zero},
+                                           /* sizes */
+                                           ValueRange{block1Row, block1Col},
+                                           /* strides */
+                                           ValueRange{one, one});
+
+    auto block2Dst =
+        rewriter.create<memref::SubViewOp>(loc, dst,
+                                           /* offsets */
+                                           ValueRange{block1Row, zero},
+                                           /* sizes */
+                                           ValueRange{block2Row, block2Col},
+                                           /* strides */
+                                           ValueRange{one, one});
+
+    rewriter.create<memref::CopyOp>(loc, block1, block1Dst);
+    rewriter.create<memref::CopyOp>(loc, block2, block2Dst);
+  }
+
+  memref::SubViewOp createSubview(Value src, ArrayRef<OpFoldResult> offsets,
+                                  ArrayRef<OpFoldResult> sizes,
+                                  ArrayRef<OpFoldResult> strides, Location loc,
+                                  ConversionPatternRewriter &rewriter) const {
+    auto srcType = cast<MemRefType>(src.getType());
+    auto dstType =
+        memref::SubViewOp::inferResultType(srcType, offsets, sizes, strides);
+    return rewriter.create<memref::SubViewOp>(loc, cast<MemRefType>(dstType),
+                                              src, offsets, sizes, strides);
+  }
+
+  std::pair<memref::SubViewOp, memref::SubViewOp>
+  getSideBySideSubviews(ArrayRef<OpFoldResult> dims, Value block1, Value block2,
+                        Location loc,
+                        ConversionPatternRewriter &rewriter) const {
+    OpFoldResult subviewRowFull = dims[0];
+    OpFoldResult subviewColFull = dims[1];
+    OpFoldResult col1 =
+        rewriter.create<memref::DimOp>(loc, block1, 1).getResult();
+    OpFoldResult subviewCol1 = minOFRs(col1, subviewColFull, loc, rewriter);
+    OpFoldResult subviewCol2 =
+        subOFRs(subviewColFull, subviewCol1, loc, rewriter);
+
+    SmallVector<OpFoldResult> offsets(dims.size(), rewriter.getIndexAttr(0));
+    SmallVector<OpFoldResult> strides(dims.size(), rewriter.getIndexAttr(1));
+    auto sv1 = createSubview(block1, offsets, {subviewRowFull, subviewCol1},
+                             strides, loc, rewriter);
+    auto sv2 = createSubview(block2, offsets, {subviewRowFull, subviewCol2},
+                             strides, loc, rewriter);
+
+    return {sv1, sv2};
+  }
+
+  std::pair<memref::SubViewOp, memref::SubViewOp>
+  getStackedSubviews(ArrayRef<OpFoldResult> dims, Value block1, Value block2,
+                     const Location loc,
+                     ConversionPatternRewriter &rewriter) const {
+    OpFoldResult subviewRowFull = dims[0];
+    OpFoldResult subviewColFull = dims[1];
+    OpFoldResult row1 =
+        rewriter.create<memref::DimOp>(loc, block1, 0).getResult();
+    OpFoldResult subviewRow1 = minOFRs(row1, subviewRowFull, loc, rewriter);
+    OpFoldResult subviewRow2 =
+        subOFRs(subviewRowFull, subviewRow1, loc, rewriter);
+
+    SmallVector<OpFoldResult> offsets(dims.size(), rewriter.getIndexAttr(0));
+    SmallVector<OpFoldResult> strides(dims.size(), rewriter.getIndexAttr(1));
+    auto sv1 = createSubview(block1, offsets, {subviewRow1, subviewColFull},
+                             strides, loc, rewriter);
+    auto sv2 = createSubview(block2, offsets, {subviewRow2, subviewColFull},
+                             strides, loc, rewriter);
+    return {sv1, sv2};
+  }
+
+  LogicalResult rewriteRegularLoad(tts::LoadOp op, OpAdaptor adaptor,
+                                   ConversionPatternRewriter &rewriter) const {
+    assert(!op.hasMasks());
+
+    auto loc = op->getLoc();
+    auto ptr = adaptor.getPtr();
+    auto other = op.getOther();
+
+    auto tensorType = cast<RankedTensorType>(op.getType());
+    auto elemType = tensorType.getElementType();
+
+    auto alloc = rewriter.create<memref::AllocOp>(
+        loc, MemRefType::get(tensorType.getShape(), elemType));
+
+    // No mask
+    assert(!other && "other value used in non-masked load");
+
+    if (auto unrealizedCast = ptr.getDefiningOp<UnrealizedConversionCastOp>()) {
+      auto memrefs = unrealizedCast.getOperands();
+      auto block1 = memrefs[0];
+      auto block2 = memrefs[1];
+
+      if (unrealizedCast->hasAttr(WRAP_SIDE_BY_SIDE)) {
+        createSideBySideCopies(block1, block2, alloc, loc, rewriter);
+      } else if (unrealizedCast->hasAttr(WRAP_STACKED)) {
+        createStackedCopies(block1, block2, alloc, loc, rewriter);
+      } else {
+        llvm_unreachable("unexpected wraparound type");
+      }
+    } else {
+      rewriter.create<memref::CopyOp>(loc, ptr, alloc);
+    }
+
+    Value tensor = rewriter.create<bufferization::ToTensorOp>(
+        loc, tensorType, alloc, true /* restrict */, true /* writable */);
+    rewriter.replaceOp(op, tensor);
+
+    return success();
+  }
+
+  LogicalResult rewriteMaskedLoad(tts::LoadOp op, OpAdaptor adaptor,
+                                  ConversionPatternRewriter &rewriter) const {
+    assert(op.hasMasks());
+
+    auto loc = op->getLoc();
+    auto ptr = adaptor.getPtr();
+
+    auto tensorType = cast<RankedTensorType>(op.getType());
+    auto elemType = tensorType.getElementType();
+
+    auto alloc = rewriter.create<memref::AllocOp>(
+        loc, MemRefType::get(tensorType.getShape(), elemType));
+
+    SmallVector<OpFoldResult> mixedDims = op.getMixedMaskDims();
+
+    // Fill load destination with other value
+    if (op.getOther()) {
+      // For each dimension check if dims[i] < shape[i], or-accumulate
+      // the result
+      auto shape = tensorType.getShape();
+      auto accBase =
+          rewriter.create<arith::ConstantOp>(loc, rewriter.getBoolAttr(false))
+              .getResult();
+      for (size_t i = 0; i < shape.size(); i++) {
+        auto shapei = rewriter.create<arith::ConstantOp>(
+            loc, rewriter.getIndexAttr(shape[i]));
+
+        Value dimi = mixedDims[i].dyn_cast<Value>();
+        if (!dimi) {
+          dimi = rewriter.create<arith::ConstantOp>(
+              loc, rewriter.getIndexAttr(op.getStaticDims()[i]));
+        }
+
+        Value cmp = rewriter.create<arith::CmpIOp>(
+            loc, arith::CmpIPredicate::slt, dimi, shapei);
+        accBase = rewriter.create<arith::OrIOp>(loc, accBase, cmp);
+      }
+
+      // condition the memset on the or-accumulation
+      // initialize with padding prior to CopyOp
+      rewriter.create<scf::IfOp>(loc, accBase, [&](OpBuilder &b, Location loc) {
+        b.create<linalg::FillOp>(loc, ValueRange{op.getOther()},
+                                 ValueRange{alloc});
+        b.create<scf::YieldOp>(loc);
+      });
+    }
+
+    if (auto unrealizedCast = ptr.getDefiningOp<UnrealizedConversionCastOp>()) {
+
+      auto memrefs = unrealizedCast.getOperands();
+      auto block1 = memrefs[0];
+      auto block2 = memrefs[1];
+
+      if (unrealizedCast->hasAttr(WRAP_SIDE_BY_SIDE)) {
+        auto [subview1, subview2] =
+            getSideBySideSubviews(mixedDims, block1, block2, loc, rewriter);
+        createSideBySideCopies(subview1, subview2, alloc, loc, rewriter);
+      } else if (unrealizedCast->hasAttr(WRAP_STACKED)) {
+        auto [subview1, subview2] =
+            getStackedSubviews(mixedDims, block1, block2, loc, rewriter);
+        createStackedCopies(subview1, subview2, alloc, loc, rewriter);
+      } else {
+        llvm_unreachable("unexpected wraparound type");
+      }
+
+      rewriter.eraseOp(unrealizedCast);
+
+    } else {
+      memref::SubViewOp srcSubview =
+          getSubview(tensorType.getRank(), mixedDims, ptr, loc, rewriter);
+      memref::SubViewOp dstSubview =
+          getSubview(tensorType.getRank(), mixedDims, alloc, loc, rewriter);
+      rewriter.create<memref::CopyOp>(loc, srcSubview, dstSubview);
+    }
+
+    Value tensor = rewriter.create<bufferization::ToTensorOp>(
+        loc, tensorType, alloc, true /* restrict */, true /* writable */);
+    rewriter.replaceOp(op, tensor);
+
+    return success();
+  }
+
+public:
+  LogicalResult
+  matchAndRewrite(tts::LoadOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (op.hasMasks()) {
+      return rewriteMaskedLoad(op, adaptor, rewriter);
+    } else {
+      return rewriteRegularLoad(op, adaptor, rewriter);
+    }
+  }
+};
+
+struct StoreConverter : public OpConversionPattern<tts::StoreOp> {
+private:
+  using OpConversionPattern<tts::StoreOp>::OpConversionPattern;
+
+  static tensor::ExtractSliceOp
+  getExtractSlice(int rank, ArrayRef<OpFoldResult> dims, Value source,
+                  const Location loc, OpBuilder &b) {
+    auto sourceType = source.getType().cast<RankedTensorType>();
+    SmallVector<OpFoldResult> offsets(rank, b.getIndexAttr(0));
+    SmallVector<OpFoldResult> strides(rank, b.getIndexAttr(1));
+
+    auto dstType = tensor::ExtractSliceOp::inferResultType(sourceType, offsets,
+                                                           dims, strides);
+
+    return b.create<tensor::ExtractSliceOp>(loc, dstType, source, offsets, dims,
+                                            strides);
+  }
+
+public:
+  LogicalResult
+  matchAndRewrite(tts::StoreOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    auto ptr = adaptor.getPtr();
+    auto storeValue = op.getValue();
+    auto rank = cast<RankedTensorType>(storeValue.getType()).getRank();
+
+    if (op.hasMasks()) {
+      auto mixedDims = op.getMixedMaskDims();
+
+      auto srcSlice =
+          getExtractSlice(rank, mixedDims, storeValue, loc, rewriter);
+      auto dstSubview = getSubview(rank, mixedDims, ptr, loc, rewriter);
+
+      auto storeOp = rewriter.create<bufferization::MaterializeInDestinationOp>(
+          loc, srcSlice, dstSubview);
+      storeOp.setWritable(true);
+    } else {
+      auto storeOp = rewriter.create<bufferization::MaterializeInDestinationOp>(
+          loc, storeValue, ptr);
+      storeOp.setWritable(true);
+    }
+
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct ScalarAddptrConverter : public OpConversionPattern<triton::AddPtrOp> {
+  using OpConversionPattern<triton::AddPtrOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(triton::AddPtrOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (isa<ShapedType>(op.getType())) {
+      return failure();
+    }
+
+    auto ptr = adaptor.getPtr();
+    auto loc = op->getLoc();
+
+    auto offsetIndex = rewriter.create<arith::IndexCastOp>(
+        loc, rewriter.getIndexType(), op.getOffset());
+
+    auto layout =
+        StridedLayoutAttr::get(op.getContext(), ShapedType::kDynamic, {1});
+
+    auto elemType =
+        cast<triton::PointerType>(op.getPtr().getType()).getPointeeType();
+    auto memrefType = MemRefType::get({1}, elemType, layout);
+
+    auto extractMetadataOp =
+        rewriter.create<memref::ExtractStridedMetadataOp>(loc, ptr);
+    auto base = extractMetadataOp.getBaseBuffer();
+    auto offset = extractMetadataOp.getOffset();
+
+    auto newOffset = rewriter.create<arith::AddIOp>(loc, offset, offsetIndex);
+
+    auto castOp = rewriter.create<memref::ReinterpretCastOp>(
+        loc, memrefType, base, getAsOpFoldResult(newOffset) /*offset*/,
+        ArrayRef<OpFoldResult>{rewriter.getIndexAttr(1)} /*sizes*/,
+        ArrayRef<OpFoldResult>{rewriter.getIndexAttr(1)} /*strides*/);
+
+    rewriter.replaceOp(op, castOp.getResult());
+
+    return success();
+  }
+};
+
+struct ScalarLoadConverter : public OpConversionPattern<triton::LoadOp> {
+  using OpConversionPattern<triton::LoadOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(triton::LoadOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (!op.getType().isIntOrIndexOrFloat()) {
+      return failure();
+    }
+
+    auto loc = op->getLoc();
+    auto memrefPtr = adaptor.getPtr();
+    auto zeroMap = AffineMap::getConstantMap(0, rewriter.getContext());
+    auto loadOp = rewriter.create<affine::AffineLoadOp>(loc, memrefPtr, zeroMap,
+                                                        std::nullopt);
+    rewriter.replaceOp(op, loadOp.getResult());
+
+    return success();
+  }
+};
+
+struct ScalarStoreConverter : public OpConversionPattern<triton::StoreOp> {
+private:
+  using OpConversionPattern<triton::StoreOp>::OpConversionPattern;
+
+public:
+  LogicalResult
+  matchAndRewrite(triton::StoreOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    if (!op.getValue().getType().isIntOrIndexOrFloat()) {
+      return failure();
+    }
+
+    auto loc = op->getLoc();
+    auto memrefPtr = adaptor.getPtr();
+    auto val = op.getValue();
+    auto zeroMap = AffineMap::getConstantMap(0, rewriter.getContext());
+
+    rewriter.create<affine::AffineStoreOp>(loc, val, memrefPtr, zeroMap,
+                                           std::nullopt);
+    rewriter.eraseOp(op);
+
+    return success();
+  }
+};
+
+struct UnrealizedCastConverter
+    : public OpConversionPattern<UnrealizedConversionCastOp> {
+private:
+  using OpConversionPattern<UnrealizedConversionCastOp>::OpConversionPattern;
+
+public:
+  UnrealizedCastConverter(TypeConverter &typeConverter, MLIRContext *context)
+      : OpConversionPattern<UnrealizedConversionCastOp>(typeConverter,
+                                                        context) {}
+
+  LogicalResult
+  matchAndRewrite(UnrealizedConversionCastOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    auto resType = op->getResultTypes()[0];
+    if (auto ptrType = dyn_cast<triton::PointerType>(resType)) {
+
+      auto memrefType =
+          cast<MemRefType>(getTypeConverter()->convertType(ptrType));
+
+      auto cast = rewriter.create<memref::ReinterpretCastOp>(
+          op->getLoc(), memrefType, op.getInputs()[0], 0 /*offset*/,
+          SmallVector<int64_t>{1} /*sizes*/,
+          SmallVector<int64_t>{1} /*strides*/);
+
+      rewriter.replaceOp(op, cast);
+      return success();
+    }
+    return failure();
+  }
+};
+
+} // namespace
+
+void mlir::triton::populateStructuredToMemrefConversionPatterns(
+    RewritePatternSet &patterns, TypeConverter &typeConverter) {
+  patterns.add<UnrealizedCastConverter>(typeConverter, patterns.getContext());
+  patterns
+      .add<MakeTensorPtrConverter, LoadConverter, StoreConverter,
+           ScalarAddptrConverter, ScalarLoadConverter, ScalarStoreConverter>(
+          patterns.getContext());
+}

--- a/lib/Conversion/StructuredToMemref/StructuredToMemref.cpp
+++ b/lib/Conversion/StructuredToMemref/StructuredToMemref.cpp
@@ -101,9 +101,7 @@ private:
 
   // If there are dimensions with size 1 and stride 0, replace 0 stride with
   // the product of sizes of all lower dimensions. This avoids creating memref
-  // with zero stride. Note that we store the unmodified state into knownPtrs,
-  // since any following pointer arithmetic operations should use the original
-  // 0 stride.
+  // with zero stride.
   static llvm::SmallVector<OpFoldResult>
   getMixedStridesForMemref(tts::MakeTensorPtrOp op, OpBuilder &b) {
     llvm::SmallVector<OpFoldResult> strides;

--- a/lib/Conversion/StructuredToMemref/StructuredToMemrefPass.cpp
+++ b/lib/Conversion/StructuredToMemref/StructuredToMemrefPass.cpp
@@ -1,0 +1,156 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (c) Microsoft Corporation, Meta Platforms.
+// Licensed under the MIT license.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "triton-shared/Conversion/StructuredToMemref/StructuredToMemref.h"
+#include "triton-shared/Dialect/TritonStructured/IR/TritonStructuredDialect.h"
+#include "triton-shared/Dialect/TritonTilingExt/IR/TritonTilingExtDialect.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/SCF/Transforms/Patterns.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Transforms/Passes.h"
+#include "triton/Dialect/Triton/IR/Types.h"
+
+#include <optional>
+
+#define DEBUG_TYPE "structured-to-memref"
+
+using namespace mlir;
+using namespace triton;
+
+namespace mlir {
+namespace triton {
+#define GEN_PASS_DEF_STRUCTUREDTOMEMREF
+#include "triton-shared/Conversion/StructuredToMemref/Passes.h.inc"
+} // namespace triton
+} // namespace mlir
+
+namespace {
+
+class TritonTypeConverter : public TypeConverter {
+public:
+  TritonTypeConverter() {
+    // The order of type conversion is important: later ones are tried earlier.
+    addConversion([](Type type) { return type; });
+    addConversion([](triton::PointerType ptrType) {
+      return UnrankedMemRefType::get(ptrType.getPointeeType(), 0);
+    });
+    // addTargetMaterialization([&](OpBuilder &builder, Type resultType,
+    //                              ValueRange inputs,
+    //                              Location loc) -> std::optional<Value> {
+    //   return builder.create<UnrealizedConversionCastOp>(loc, resultType,
+    //   inputs)
+    //       .getResult(0);
+    // });
+
+    addSourceMaterialization([&](OpBuilder &builder, Type resultType,
+                                 ValueRange inputs,
+                                 Location loc) -> std::optional<Value> {
+      return builder.create<UnrealizedConversionCastOp>(loc, resultType, inputs)
+          .getResult(0);
+    });
+  }
+};
+
+class LoopTypeConverter : public TypeConverter {
+public:
+  LoopTypeConverter(MLIRContext *context) {
+    // The order of type conversion is important: later ones are tried earlier.
+    addConversion([](Type type) { return type; });
+    addConversion([&](triton::PointerType ptrType) {
+      SmallVector<int64_t> strides{1};
+      auto layout =
+          StridedLayoutAttr::get(context, ShapedType::kDynamic, strides);
+
+      auto elemType = ptrType.getPointeeType();
+      auto memrefType = MemRefType::get({1}, elemType, layout);
+      return memrefType;
+    });
+  }
+};
+
+class StructuredToMemrefPass
+    : public triton::impl::StructuredToMemrefBase<StructuredToMemrefPass> {
+  using StructuredToMemrefBase<StructuredToMemrefPass>::StructuredToMemrefBase;
+
+public:
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<func::FuncDialect, arith::ArithDialect, math::MathDialect,
+                    linalg::LinalgDialect, affine::AffineDialect,
+                    scf::SCFDialect, tensor::TensorDialect,
+                    bufferization::BufferizationDialect, triton::TritonDialect,
+                    ttx::TritonTilingExtDialect, memref::MemRefDialect>();
+  }
+
+  void convertMemrefArgs() {
+    auto moduleOp = getOperation();
+
+    RewritePatternSet patterns(&getContext());
+    ConversionTarget target(getContext());
+    TritonTypeConverter typeConverter;
+
+    // Update function signature to use memrefs
+    target.addDynamicallyLegalOp<func::FuncOp>([&](func::FuncOp op) {
+      return typeConverter.isSignatureLegal(op.getFunctionType());
+    });
+
+    populateFunctionOpInterfaceTypeConversionPattern<func::FuncOp>(
+        patterns, typeConverter);
+
+    if (failed(applyPartialConversion(moduleOp, target, std::move(patterns)))) {
+      signalPassFailure();
+    }
+  }
+
+  void runOnOperation() override {
+    convertMemrefArgs();
+
+    auto moduleOp = getOperation();
+
+    RewritePatternSet patterns(&getContext());
+    ConversionTarget target(getContext());
+    TritonTypeConverter typeConverter;
+
+    target.addLegalDialect<
+        func::FuncDialect, arith::ArithDialect, math::MathDialect,
+        linalg::LinalgDialect, affine::AffineDialect, scf::SCFDialect,
+        cf::ControlFlowDialect, tensor::TensorDialect,
+        bufferization::BufferizationDialect, ttx::TritonTilingExtDialect,
+        memref::MemRefDialect>();
+
+    target.addIllegalDialect<tts::TritonStructuredDialect>();
+
+    target.addDynamicallyLegalOp<UnrealizedConversionCastOp>([](Operation *op) {
+      auto resType = op->getResultTypes()[0];
+      return !isa<triton::PointerType>(resType);
+    });
+
+    LoopTypeConverter loop(patterns.getContext());
+    mlir::scf::populateSCFStructuralTypeConversionsAndLegality(loop, patterns,
+                                                               target);
+    triton::populateStructuredToMemrefConversionPatterns(patterns, loop);
+
+    if (failed(applyPartialConversion(moduleOp, target, std::move(patterns)))) {
+      signalPassFailure();
+    }
+
+    // Erase dead code and fold constants created during lowering
+    PassManager pm(&getContext(), moduleOp.getOperationName());
+    pm.addPass(createCanonicalizerPass());
+    if (failed(runPipeline(pm, getOperation()))) {
+      signalPassFailure();
+    }
+  }
+};
+} // namespace

--- a/python/examples/test_load_2d_tensor_block.py
+++ b/python/examples/test_load_2d_tensor_block.py
@@ -87,5 +87,3 @@ def test():
 
     torch.testing.assert_close(output, expected, rtol=0.001, atol=1e-5)
     print("Pass!")
-
-test()

--- a/python/examples/test_load_2d_tensor_block.py
+++ b/python/examples/test_load_2d_tensor_block.py
@@ -87,3 +87,5 @@ def test():
 
     torch.testing.assert_close(output, expected, rtol=0.001, atol=1e-5)
     print("Pass!")
+
+test()

--- a/python/examples/test_load_2d_tensor_col.py
+++ b/python/examples/test_load_2d_tensor_col.py
@@ -79,3 +79,5 @@ def test():
 
     torch.testing.assert_close(output, x, rtol=0.001, atol=1e-5)
     print("Pass!")
+
+test()

--- a/python/examples/test_load_2d_tensor_col.py
+++ b/python/examples/test_load_2d_tensor_col.py
@@ -79,5 +79,3 @@ def test():
 
     torch.testing.assert_close(output, x, rtol=0.001, atol=1e-5)
     print("Pass!")
-
-test()

--- a/python/examples/test_matmul.py
+++ b/python/examples/test_matmul.py
@@ -163,3 +163,6 @@ def test_matmul():
         print("✅ Triton and Torch match")
     else:
         print("❌ Triton and Torch differ")
+
+
+test_matmul()

--- a/python/examples/test_matmul.py
+++ b/python/examples/test_matmul.py
@@ -163,6 +163,3 @@ def test_matmul():
         print("✅ Triton and Torch match")
     else:
         print("❌ Triton and Torch differ")
-
-
-test_matmul()

--- a/python/examples/test_modulo.py
+++ b/python/examples/test_modulo.py
@@ -404,10 +404,3 @@ def test_torch_inductor_pattern():
     print(out)
     assert torch.equal(expected_out.int(), out.int())
     print('Passed')
-
-
-test_stacked_masked_loop()
-test_side_by_side_masked_loop()
-test_2d()
-test_1d()
-test_wrap_stacked()

--- a/python/examples/test_modulo.py
+++ b/python/examples/test_modulo.py
@@ -7,161 +7,49 @@ import triton.language as tl
 triton.runtime.driver.set_active(CPUDriver())
 
 
-@triton.jit
-def wrap_stacked_masked_loop(
-    a_ptr, c_ptr, M, N, stride_am, stride_an, stride_cm, stride_cn, BLOCK_SIZE_K: tl.constexpr
-):
-    offs_am = (2 + tl.arange(0, BLOCK_SIZE_K)) % M
-    offs_an = 3 + tl.arange(0, BLOCK_SIZE_K)
-    a_ptrs = a_ptr + (offs_am[:, None] * stride_am + offs_an[None, :] * stride_an)
+def test_wrap_stacked():
 
-    offs_cm = tl.arange(0, BLOCK_SIZE_K)
-    offs_cn = tl.arange(0, BLOCK_SIZE_K)
-    c_ptrs = c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
+    @triton.jit
+    def wrap_stacked(a_ptr, c_ptr, M, N, stride_am, stride_an, stride_cm,
+                     stride_cn, BLOCK_SIZE_K: tl.constexpr):
+        offs_am = (2 + tl.arange(0, 4)) % M
+        offs_an = tl.arange(0, 4)
+        a_ptrs = a_ptr + (offs_am[:, None] * stride_am +
+                          offs_an[None, :] * stride_an)
 
-    offs_k = tl.arange(0, BLOCK_SIZE_K)
+        offs_cm = tl.arange(0, 4)
+        offs_cn = tl.arange(0, 4)
+        c_ptrs = c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[
+            None, :]
 
-    for k in range(0, 2):
-        a = tl.load(a_ptrs, mask=offs_k[None, :] < 3, other=-99)
-        tl.store(c_ptrs, a)
-        a_ptrs += BLOCK_SIZE_K * stride_an
-        c_ptrs += BLOCK_SIZE_K * stride_an
+        for k in range(0, 2):
+            a = tl.load(a_ptrs)
+            tl.store(c_ptrs, a)
+            a_ptrs += BLOCK_SIZE_K * stride_an
+            c_ptrs += BLOCK_SIZE_K * stride_an
 
-
-@triton.jit
-def wrap_side_by_side_masked_loop(
-    a_ptr, c_ptr, M, N, stride_am, stride_an, stride_cm, stride_cn, BLOCK_SIZE_K: tl.constexpr
-):
-    offs_am = 2 + tl.arange(0, BLOCK_SIZE_K)
-    offs_an = (6 + tl.arange(0, BLOCK_SIZE_K)) % N
-    a_ptrs = a_ptr + (offs_am[:, None] * stride_am + offs_an[None, :] * stride_an)
-
-    offs_k = tl.arange(0, BLOCK_SIZE_K)
-
-    offs_cm = tl.arange(0, BLOCK_SIZE_K)
-    offs_cn = tl.arange(0, BLOCK_SIZE_K)
-    c_ptrs = c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
-
-    for k in range(0, 2):
-        a = tl.load(a_ptrs, mask=offs_k[:, None] < 2, other=-99)
-        tl.store(c_ptrs, a)
-        a_ptrs += BLOCK_SIZE_K * stride_am
-        c_ptrs += BLOCK_SIZE_K * stride_an
-
-
-@triton.jit
-def wrap_side_by_side_loop(
-    a_ptr, c_ptr, M, N, stride_am, stride_an, stride_cm, stride_cn, BLOCK_SIZE_K: tl.constexpr
-):
-    offs_am = tl.arange(0, 4)
-    offs_an = (6 + tl.arange(0, 4)) % N
-    a_ptrs = a_ptr + (offs_am[:, None] * stride_am + offs_an[None, :] * stride_an)
-
-    offs_cm = tl.arange(0, 4)
-    offs_cn = tl.arange(0, 4)
-    c_ptrs = c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
-
-    for k in range(0, 3):
-        a = tl.load(a_ptrs)
-        tl.store(c_ptrs, a)
-        a_ptrs += BLOCK_SIZE_K * stride_am
-        c_ptrs += BLOCK_SIZE_K * stride_am
-
-
-
-@triton.jit
-def wrap_side_by_side_loop_unroll(
-    a_ptr, c_ptr, M, N, stride_am, stride_an, stride_cm, stride_cn, BLOCK_SIZE_K: tl.constexpr
-):
-    offs_am = tl.arange(0, 4)
-    offs_an = (6 + tl.arange(0, 4)) % N
-    a_ptrs = a_ptr + (offs_am[:, None] * stride_am + offs_an[None, :] * stride_an)
-
-    offs_cm = tl.arange(0, 4)
-    offs_cn = tl.arange(0, 4)
-    c_ptrs = c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
-
-    a = tl.load(a_ptrs)
-    tl.store(c_ptrs, a)
-    a_ptrs += BLOCK_SIZE_K * stride_am
-    c_ptrs += BLOCK_SIZE_K * stride_an
-
-    a = tl.load(a_ptrs)
-    tl.store(c_ptrs, a)
-    a_ptrs += BLOCK_SIZE_K * stride_am
-    c_ptrs += BLOCK_SIZE_K * stride_an
-
-    a = tl.load(a_ptrs)
-    tl.store(c_ptrs, a)
-    a_ptrs += BLOCK_SIZE_K * stride_am
-    c_ptrs += BLOCK_SIZE_K * stride_an
-
-
-@triton.jit
-def mod_1d(
-    a_ptr, c_ptr, M, N, stride_am, stride_an, stride_cm, stride_cn, BLOCK_SIZE_K: tl.constexpr
-):
-    row = 7
-    offs_an = (6 + tl.arange(0, 4)) % N
-    a_ptrs = a_ptr + (row * stride_am) + offs_an[None, :] * stride_an
-
-    offs_cn = tl.arange(0, 4)
-    c_ptrs = c_ptr + stride_cn * offs_cn[None, :]
-
-    a = tl.load(a_ptrs)
-    tl.store(c_ptrs, a)
-
-
-@triton.jit
-def mod_2d(
-    a_ptr, c_ptr, M, N, stride_am, stride_an, stride_cm, stride_cn, BLOCK_SIZE_K: tl.constexpr
-):
-    offs_am = 2 + tl.arange(0, 4)
-    offs_an = (6 + tl.arange(0, 4)) % N
-    a_ptrs = a_ptr + (offs_am[:, None] * stride_am + offs_an[None, :] * stride_an)
-
-    offs_cm = tl.arange(0, 4)
-    offs_cn = tl.arange(0, 4)
-    c_ptrs = c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
-
-    a = tl.load(a_ptrs)
-    tl.store(c_ptrs, a)
-
-
-def test_side_by_side():
-    M = 12
+    M = 4
     N = 8
-    A = torch.arange(0, M * N, device="cpu", dtype=torch.float32).reshape((M, N))
+    A = torch.arange(0, M * N, device="cpu", dtype=torch.float32).reshape(
+        (M, N))
     out = torch.full((M, N), 88888, device="cpu", dtype=torch.float32)
-    print(out)
-    grid = lambda meta: (1,)
+    grid = lambda meta: (1, )
 
-    wrap_side_by_side_masked_loop[grid](
-        A,
-        out,
-        M,
-        N,
-        A.stride(0),
-        A.stride(1),
-        out.stride(0),
-        out.stride(1),
-        BLOCK_SIZE_K=4
-    )
+    wrap_stacked[grid](A,
+                       out,
+                       M,
+                       N,
+                       A.stride(0),
+                       A.stride(1),
+                       out.stride(0),
+                       out.stride(1),
+                       BLOCK_SIZE_K=4)
 
     # Expected output copied from running triton on NVDIA gpu
-    expected_out = torch.tensor([[   22,    23,    16,    17,    54,    55,    48,    49],
-        [   30,    31,    24,    25,    62,    63,    56,    57],
-        [  -99,   -99,   -99,   -99,   -99,   -99,   -99,   -99],
-        [  -99,   -99,   -99,   -99,   -99,   -99,   -99,   -99],
-        [88888, 88888, 88888, 88888, 88888, 88888, 88888, 88888],
-        [88888, 88888, 88888, 88888, 88888, 88888, 88888, 88888],
-        [88888, 88888, 88888, 88888, 88888, 88888, 88888, 88888],
-        [88888, 88888, 88888, 88888, 88888, 88888, 88888, 88888],
-        [88888, 88888, 88888, 88888, 88888, 88888, 88888, 88888],
-        [88888, 88888, 88888, 88888, 88888, 88888, 88888, 88888],
-        [88888, 88888, 88888, 88888, 88888, 88888, 88888, 88888],
-        [88888, 88888, 88888, 88888, 88888, 88888, 88888, 88888]], dtype=torch.int32)
-
+    expected_out = torch.tensor(
+        [[16, 17, 18, 19, 20, 21, 22, 23], [24, 25, 26, 27, 28, 29, 30, 31],
+         [0, 1, 2, 3, 4, 5, 6, 7], [8, 9, 10, 11, 12, 13, 14, 15]],
+        device="cpu")
 
     print(A)
     print(out.int())
@@ -169,37 +57,278 @@ def test_side_by_side():
     print('Hooooray')
 
 
-def test_stacked():
+def test_1d():
+
+    @triton.jit
+    def mod_1d(a_ptr, c_ptr, M, N, stride_am, stride_an, stride_cm, stride_cn,
+               BLOCK_SIZE_K: tl.constexpr):
+        row = 7
+        offs_an = (6 + tl.arange(0, 4)) % N
+        a_ptrs = a_ptr + (row * stride_am) + offs_an[None, :] * stride_an
+
+        offs_cn = tl.arange(0, 4)
+        c_ptrs = c_ptr + stride_cn * offs_cn[None, :]
+
+        a = tl.load(a_ptrs)
+        tl.store(c_ptrs, a)
+
+    M = 8
+    N = 8
+    A = torch.arange(0, M * N, device="cpu", dtype=torch.float32).reshape(
+        (M, N))
+    out = torch.full((M, N), 88888, device="cpu", dtype=torch.float32)
+    grid = lambda meta: (1, )
+
+    mod_1d[grid](A,
+                 out,
+                 M,
+                 N,
+                 A.stride(0),
+                 A.stride(1),
+                 out.stride(0),
+                 out.stride(1),
+                 BLOCK_SIZE_K=4)
+
+    # Expected output copied from running triton on NVDIA gpu
+    expected_out = torch.tensor(
+        [[62, 63, 56, 57, 88888, 88888, 88888, 88888],
+         [88888, 88888, 88888, 88888, 88888, 88888, 88888, 88888],
+         [88888, 88888, 88888, 88888, 88888, 88888, 88888, 88888],
+         [88888, 88888, 88888, 88888, 88888, 88888, 88888, 88888],
+         [88888, 88888, 88888, 88888, 88888, 88888, 88888, 88888],
+         [88888, 88888, 88888, 88888, 88888, 88888, 88888, 88888],
+         [88888, 88888, 88888, 88888, 88888, 88888, 88888, 88888],
+         [88888, 88888, 88888, 88888, 88888, 88888, 88888, 88888]],
+        device="cpu")
+
+    print(A)
+    print(out.int())
+    assert torch.equal(expected_out.int(), out.int())
+    print('Hooooray')
+
+
+def test_2d():
+
+    @triton.jit
+    def mod_2d(a_ptr, c_ptr, M, N, stride_am, stride_an, stride_cm, stride_cn,
+               BLOCK_SIZE_K: tl.constexpr):
+        offs_am = 2 + tl.arange(0, 4)
+        offs_an = (6 + tl.arange(0, 4)) % N
+        a_ptrs = a_ptr + (offs_am[:, None] * stride_am +
+                          offs_an[None, :] * stride_an)
+
+        offs_cm = tl.arange(0, 4)
+        offs_cn = tl.arange(0, 4)
+        c_ptrs = c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[
+            None, :]
+
+        a = tl.load(a_ptrs)
+        tl.store(c_ptrs, a)
+
+    M = 8
+    N = 8
+    A = torch.arange(0, M * N, device="cpu", dtype=torch.float32).reshape(
+        (M, N))
+    out = torch.full((M, N), 88888, device="cpu", dtype=torch.float32)
+    grid = lambda meta: (1, )
+
+    mod_2d[grid](A,
+                 out,
+                 M,
+                 N,
+                 A.stride(0),
+                 A.stride(1),
+                 out.stride(0),
+                 out.stride(1),
+                 BLOCK_SIZE_K=4)
+
+    # Expected output copied from running triton on NVDIA gpu
+    expected_out = torch.tensor(
+        [[22, 23, 16, 17, 88888, 88888, 88888, 88888],
+         [30, 31, 24, 25, 88888, 88888, 88888, 88888],
+         [38, 39, 32, 33, 88888, 88888, 88888, 88888],
+         [46, 47, 40, 41, 88888, 88888, 88888, 88888],
+         [88888, 88888, 88888, 88888, 88888, 88888, 88888, 88888],
+         [88888, 88888, 88888, 88888, 88888, 88888, 88888, 88888],
+         [88888, 88888, 88888, 88888, 88888, 88888, 88888, 88888],
+         [88888, 88888, 88888, 88888, 88888, 88888, 88888, 88888]],
+        device="cpu")
+
+    print(A)
+    print(out.int())
+    assert torch.equal(expected_out.int(), out.int())
+    print('Hooooray')
+
+
+def test_side_by_side_masked_loop():
+
+    @triton.jit
+    def wrap_side_by_side_masked_loop(a_ptr, c_ptr, M, N, stride_am, stride_an,
+                                      stride_cm, stride_cn,
+                                      BLOCK_SIZE_K: tl.constexpr):
+        offs_am = 2 + tl.arange(0, BLOCK_SIZE_K)
+        offs_an = (6 + tl.arange(0, BLOCK_SIZE_K)) % N
+        a_ptrs = a_ptr + (offs_am[:, None] * stride_am +
+                          offs_an[None, :] * stride_an)
+
+        offs_k = tl.arange(0, BLOCK_SIZE_K)
+
+        offs_cm = tl.arange(0, BLOCK_SIZE_K)
+        offs_cn = tl.arange(0, BLOCK_SIZE_K)
+        c_ptrs = c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[
+            None, :]
+
+        for k in range(0, 2):
+            a = tl.load(a_ptrs, mask=offs_k[:, None] < 2, other=-99)
+            tl.store(c_ptrs, a)
+            a_ptrs += BLOCK_SIZE_K * stride_am
+            c_ptrs += BLOCK_SIZE_K * stride_an
+
+    M = 12
+    N = 8
+    A = torch.arange(0, M * N, device="cpu", dtype=torch.float32).reshape(
+        (M, N))
+    out = torch.full((M, N), 88888, device="cpu", dtype=torch.float32)
+    print(out)
+    grid = lambda meta: (1, )
+
+    wrap_side_by_side_masked_loop[grid](A,
+                                        out,
+                                        M,
+                                        N,
+                                        A.stride(0),
+                                        A.stride(1),
+                                        out.stride(0),
+                                        out.stride(1),
+                                        BLOCK_SIZE_K=4)
+
+    # Expected output copied from running triton on NVDIA gpu
+    expected_out = torch.tensor(
+        [[22, 23, 16, 17, 54, 55, 48, 49], [30, 31, 24, 25, 62, 63, 56, 57],
+         [-99, -99, -99, -99, -99, -99, -99, -99],
+         [-99, -99, -99, -99, -99, -99, -99, -99],
+         [88888, 88888, 88888, 88888, 88888, 88888, 88888, 88888],
+         [88888, 88888, 88888, 88888, 88888, 88888, 88888, 88888],
+         [88888, 88888, 88888, 88888, 88888, 88888, 88888, 88888],
+         [88888, 88888, 88888, 88888, 88888, 88888, 88888, 88888],
+         [88888, 88888, 88888, 88888, 88888, 88888, 88888, 88888],
+         [88888, 88888, 88888, 88888, 88888, 88888, 88888, 88888],
+         [88888, 88888, 88888, 88888, 88888, 88888, 88888, 88888],
+         [88888, 88888, 88888, 88888, 88888, 88888, 88888, 88888]],
+        dtype=torch.int32)
+
+    print(A)
+    print(out.int())
+    assert torch.equal(expected_out.int(), out.int())
+    print('Hooooray')
+
+
+def test_stacked_masked_loop():
+
+    @triton.jit
+    def wrap_stacked_masked_loop(a_ptr, c_ptr, M, N, stride_am, stride_an,
+                                 stride_cm, stride_cn,
+                                 BLOCK_SIZE_K: tl.constexpr):
+        offs_am = (2 + tl.arange(0, BLOCK_SIZE_K)) % M
+        offs_an = 3 + tl.arange(0, BLOCK_SIZE_K)
+        a_ptrs = a_ptr + (offs_am[:, None] * stride_am +
+                          offs_an[None, :] * stride_an)
+
+        offs_cm = tl.arange(0, BLOCK_SIZE_K)
+        offs_cn = tl.arange(0, BLOCK_SIZE_K)
+        c_ptrs = c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[
+            None, :]
+
+        offs_k = tl.arange(0, BLOCK_SIZE_K)
+
+        for k in range(0, 2):
+            a = tl.load(a_ptrs, mask=offs_k[None, :] < 3, other=-99)
+            tl.store(c_ptrs, a)
+            a_ptrs += BLOCK_SIZE_K * stride_an
+            c_ptrs += BLOCK_SIZE_K * stride_an
+
     M = 4
     N = 12
     BLOCK_SIZE_M = 4
     BLOCK_SIZE_N = 4
-    A = torch.arange(0, M * N, device="cpu", dtype=torch.float32).reshape((M, N))
-    out = torch.full((BLOCK_SIZE_M, N), 88888, device="cpu", dtype=torch.float32)
+    A = torch.arange(0, M * N, device="cpu", dtype=torch.float32).reshape(
+        (M, N))
+    out = torch.full((BLOCK_SIZE_M, N),
+                     88888,
+                     device="cpu",
+                     dtype=torch.float32)
     print(out)
-    grid = lambda meta: (1,)
+    grid = lambda meta: (1, )
 
-    wrap_stacked_masked_loop[grid](
-        A,
-        out,
-        M,
-        N,
-        A.stride(0),
-        A.stride(1),
-        out.stride(0),
-        out.stride(1),
-        BLOCK_SIZE_K=4
-    )
+    wrap_stacked_masked_loop[grid](A,
+                                   out,
+                                   M,
+                                   N,
+                                   A.stride(0),
+                                   A.stride(1),
+                                   out.stride(0),
+                                   out.stride(1),
+                                   BLOCK_SIZE_K=4)
 
     # Expected output copied from running triton on NVDIA gpu
-    expected_out = torch.tensor(
+    expected_out = torch.tensor([
         [
-            [27.0, 28.0, 29.0, -99.0, 31.0, 32.0, 33.0, -99.0, 88888, 88888, 88888, 88888,],
-            [39.0, 40.0, 41.0, -99.0, 43.0, 44.0, 45.0, -99.0, 88888, 88888, 88888, 88888,],
-            [3.0, 4.0, 5.0, -99.0, 7.0, 8.0, 9.0, -99.0, 88888, 88888, 88888, 88888,],
-            [15.0, 16.0, 17.0, -99.0, 19.0, 20.0, 21.0, -99.0, 88888, 88888, 88888, 88888,],
+            27.0,
+            28.0,
+            29.0,
+            -99.0,
+            31.0,
+            32.0,
+            33.0,
+            -99.0,
+            88888,
+            88888,
+            88888,
+            88888,
         ],
-    )
+        [
+            39.0,
+            40.0,
+            41.0,
+            -99.0,
+            43.0,
+            44.0,
+            45.0,
+            -99.0,
+            88888,
+            88888,
+            88888,
+            88888,
+        ],
+        [
+            3.0,
+            4.0,
+            5.0,
+            -99.0,
+            7.0,
+            8.0,
+            9.0,
+            -99.0,
+            88888,
+            88888,
+            88888,
+            88888,
+        ],
+        [
+            15.0,
+            16.0,
+            17.0,
+            -99.0,
+            19.0,
+            20.0,
+            21.0,
+            -99.0,
+            88888,
+            88888,
+            88888,
+            88888,
+        ],
+    ], )
 
     print(A)
     print(out.int())
@@ -208,13 +337,10 @@ def test_stacked():
 
 
 def test_torch_inductor_pattern():
-    def compile():
-        ret = triton.compile(triton_, signature="*i32,*i32,i32,i32,i32", constants={"XBLOCK": 64, "RBLOCK": 64})
-        print(ret.asm["ttir"])
-
 
     @triton.jit
-    def triton_(in_ptr2, out_ptr2, rnumel, XBLOCK : tl.constexpr, RBLOCK : tl.constexpr):
+    def triton_(in_ptr2, out_ptr2, rnumel, XBLOCK: tl.constexpr,
+                RBLOCK: tl.constexpr):
         xnumel = 128
         rnumel = 32
         xoffset = tl.program_id(0) * XBLOCK
@@ -226,8 +352,10 @@ def test_torch_inductor_pattern():
         rindex = roffset + rbase
         rmask = rindex < rnumel
         r2 = rindex
-        tmp3 = tl.load(in_ptr2 + (r2 + (xnumel*x0)), rmask, other=77)
-        tl.store(out_ptr2 + (XBLOCK * tl.arange(0, RBLOCK)[None, :] + tl.arange(0, XBLOCK)[:, None]), tmp3)
+        tmp3 = tl.load(in_ptr2 + (r2 + (xnumel * x0)), rmask, other=77)
+        tl.store(
+            out_ptr2 + (XBLOCK * tl.arange(0, RBLOCK)[None, :] +
+                        tl.arange(0, XBLOCK)[:, None]), tmp3)
 
     device = "cpu"
     xnumel = 128
@@ -235,41 +363,51 @@ def test_torch_inductor_pattern():
 
     XBLOCK = 4
     RBLOCK = 64
-    A = torch.arange(0, xnumel * rnumel, device=device, dtype=torch.int32).reshape((xnumel, rnumel))
+    A = torch.arange(0, xnumel * rnumel, device=device,
+                     dtype=torch.int32).reshape((xnumel, rnumel))
     out = torch.full((XBLOCK, RBLOCK), 88888, device=device, dtype=torch.int32)
-    grid = lambda meta: (1,)
+    grid = lambda meta: (1, )
 
-    triton_[grid](
-        A,
-        out,
-        rnumel,
-        XBLOCK=XBLOCK,
-        RBLOCK=RBLOCK
-    )
+    triton_[grid](A, out, rnumel, XBLOCK=XBLOCK, RBLOCK=RBLOCK)
 
     # Expected output copied from running triton on NVDIA gpu
-    expected_out = torch.tensor([[  0, 128, 256, 384,   1, 129, 257, 385,   2, 130, 258, 386,   3, 131,
-        259, 387,   4, 132, 260, 388,   5, 133, 261, 389,   6, 134, 262, 390,
-        7, 135, 263, 391,   8, 136, 264, 392,   9, 137, 265, 393,  10, 138,
-        266, 394,  11, 139, 267, 395,  12, 140, 268, 396,  13, 141, 269, 397,
-        14, 142, 270, 398,  15, 143, 271, 399],
-        [ 16, 144, 272, 400,  17, 145, 273, 401,  18, 146, 274, 402,  19, 147,
-        275, 403,  20, 148, 276, 404,  21, 149, 277, 405,  22, 150, 278, 406,
-        23, 151, 279, 407,  24, 152, 280, 408,  25, 153, 281, 409,  26, 154,
-        282, 410,  27, 155, 283, 411,  28, 156, 284, 412,  29, 157, 285, 413,
-        30, 158, 286, 414,  31, 159, 287, 415],
-        [ 77,  77,  77,  77,  77,  77,  77,  77,  77,  77,  77,  77,  77,  77,
-        77,  77,  77,  77,  77,  77,  77,  77,  77,  77,  77,  77,  77,  77,
-        77,  77,  77,  77,  77,  77,  77,  77,  77,  77,  77,  77,  77,  77,
-        77,  77,  77,  77,  77,  77,  77,  77,  77,  77,  77,  77,  77,  77,
-        77,  77,  77,  77,  77,  77,  77,  77],
-        [ 77,  77,  77,  77,  77,  77,  77,  77,  77,  77,  77,  77,  77,  77,
-        77,  77,  77,  77,  77,  77,  77,  77,  77,  77,  77,  77,  77,  77,
-        77,  77,  77,  77,  77,  77,  77,  77,  77,  77,  77,  77,  77,  77,
-        77,  77,  77,  77,  77,  77,  77,  77,  77,  77,  77,  77,  77,  77,
-        77,  77,  77,  77,  77,  77,  77,  77]], device=device,
-    dtype=torch.int32)
+    expected_out = torch.tensor(
+        [[
+            0, 128, 256, 384, 1, 129, 257, 385, 2, 130, 258, 386, 3, 131, 259,
+            387, 4, 132, 260, 388, 5, 133, 261, 389, 6, 134, 262, 390, 7, 135,
+            263, 391, 8, 136, 264, 392, 9, 137, 265, 393, 10, 138, 266, 394,
+            11, 139, 267, 395, 12, 140, 268, 396, 13, 141, 269, 397, 14, 142,
+            270, 398, 15, 143, 271, 399
+        ],
+         [
+             16, 144, 272, 400, 17, 145, 273, 401, 18, 146, 274, 402, 19, 147,
+             275, 403, 20, 148, 276, 404, 21, 149, 277, 405, 22, 150, 278, 406,
+             23, 151, 279, 407, 24, 152, 280, 408, 25, 153, 281, 409, 26, 154,
+             282, 410, 27, 155, 283, 411, 28, 156, 284, 412, 29, 157, 285, 413,
+             30, 158, 286, 414, 31, 159, 287, 415
+         ],
+         [
+             77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77,
+             77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77,
+             77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77,
+             77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77
+         ],
+         [
+             77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77,
+             77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77,
+             77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77,
+             77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77, 77
+         ]],
+        device=device,
+        dtype=torch.int32)
 
     print(out)
     assert torch.equal(expected_out.int(), out.int())
     print('Passed')
+
+
+test_stacked_masked_loop()
+test_side_by_side_masked_loop()
+test_2d()
+test_1d()
+test_wrap_stacked()

--- a/python/examples/test_reduce.py
+++ b/python/examples/test_reduce.py
@@ -59,5 +59,3 @@ def test():
     print(ret.asm["llir"])
     print(ret.asm["cpuasm"])
     print('Pass')
-
-test()

--- a/python/examples/test_scalar_store.py
+++ b/python/examples/test_scalar_store.py
@@ -1,0 +1,38 @@
+import torch
+
+import triton
+from triton.backends.triton_shared.driver import CPUDriver
+import triton.language as tl
+
+triton.runtime.driver.set_active(CPUDriver())
+
+
+@triton.jit
+def reduce_kernel_2d(
+    output_ptr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid0 = tl.program_id(axis=0)
+    base_ptr = output_ptr + pid0
+    # tl.store(base_ptr, 1)
+    for i in range(0, BLOCK_SIZE):
+        output = i
+        tl.store(base_ptr, output)
+        base_ptr += 1
+
+
+def test():
+    BLOCK_SIZE = 8
+    x = torch.full([BLOCK_SIZE], -1, device="cpu", dtype=torch.float32)
+    output = torch.full((BLOCK_SIZE,), -99, device=x.device, dtype=x.dtype)
+    grid = lambda meta: (1,)
+
+    reduce_kernel_2d[grid](output, BLOCK_SIZE=BLOCK_SIZE)
+    ans = torch.arange(BLOCK_SIZE, device="cpu", dtype=torch.float32)
+    print('Expected: ', ans)
+    print('Actual: ', output)
+    torch.testing.assert_close(output, ans, rtol=0.001, atol=1e-5)
+    print("Pass!")
+
+
+test()

--- a/python/examples/test_scalar_store.py
+++ b/python/examples/test_scalar_store.py
@@ -14,7 +14,6 @@ def reduce_kernel_2d(
 ):
     pid0 = tl.program_id(axis=0)
     base_ptr = output_ptr + pid0
-    # tl.store(base_ptr, 1)
     for i in range(0, BLOCK_SIZE):
         output = i
         tl.store(base_ptr, output)
@@ -33,6 +32,3 @@ def test():
     print('Actual: ', output)
     torch.testing.assert_close(output, ans, rtol=0.001, atol=1e-5)
     print("Pass!")
-
-
-test()

--- a/python/examples/test_softmax.py
+++ b/python/examples/test_softmax.py
@@ -65,3 +65,6 @@ def test_softmax():
     y_triton = softmax(x)
     y_torch = torch.softmax(x, axis=1)
     assert torch.allclose(y_triton, y_torch), (y_triton, y_torch)
+    print('ok')
+
+test_softmax()

--- a/python/examples/test_softmax.py
+++ b/python/examples/test_softmax.py
@@ -66,5 +66,3 @@ def test_softmax():
     y_torch = torch.softmax(x, axis=1)
     assert torch.allclose(y_triton, y_torch), (y_triton, y_torch)
     print('ok')
-
-test_softmax()

--- a/python/examples/test_splat.py
+++ b/python/examples/test_splat.py
@@ -51,6 +51,3 @@ def test():
 
     torch.testing.assert_close(output, expected_result, rtol=0.001, atol=1e-5)
     print("Pass!")
-
-
-test()

--- a/python/examples/test_splat.py
+++ b/python/examples/test_splat.py
@@ -51,3 +51,6 @@ def test():
 
     torch.testing.assert_close(output, expected_result, rtol=0.001, atol=1e-5)
     print("Pass!")
+
+
+test()

--- a/python/examples/test_vec_add.py
+++ b/python/examples/test_vec_add.py
@@ -68,3 +68,5 @@ def test():
         f"The maximum difference between torch and triton is "
         f"{torch.max(torch.abs(output_torch - output_triton))}"
     )
+
+test()

--- a/python/examples/test_vec_add.py
+++ b/python/examples/test_vec_add.py
@@ -68,5 +68,3 @@ def test():
         f"The maximum difference between torch and triton is "
         f"{torch.max(torch.abs(output_torch - output_triton))}"
     )
-
-test()

--- a/test/Conversion/StructuredToMemref/addptr_2d_example.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_2d_example.mlir
@@ -1,0 +1,73 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+module {
+  tt.func @kernel(
+    %arg0 : !tt.ptr<bf16>,
+    %arg1 : !tt.ptr<bf16>,
+    %arg2 : !tt.ptr<bf16>,
+    %arg3 : i32
+  )
+  {
+    %0 = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32>
+    // offset = 0, size = 4, stride = 1
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<4xi32>) -> tensor<4x1xi32>
+    // offset = [0,0], size = [4,1], stride = [1,0]
+    %2 = tt.broadcast %1 : (tensor<4x1xi32>) -> tensor<4x256xi32>
+    // offset = [0,0], size = [4,256], stride = [1,0]
+    %arg3splat = tt.splat %arg3 : (i32) -> tensor<4x256xi32>
+    %offset3 = arith.addi %2, %arg3splat : tensor<4x256xi32>
+    // offset = [%arg3,0], size = [4,256], stride = [1,0]
+    %3 = tt.make_range {end = 256 : i32, start = 0 : i32}: tensor<256xi32>
+    // offset = 0, size = 256, stride = 1
+    %4 = tt.expand_dims %3 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
+    // offset = [0,0], size = [1,256], stride = [0,1]
+    %5 = tt.broadcast %4 : (tensor<1x256xi32>) -> tensor<4x256xi32>
+    // offset = [0,0], size = [4,256], stride = [0,1]
+    %6 = arith.constant 5 : i32
+    %splat6 = tt.splat %6 : (i32) -> tensor<4x256xi32>
+    %scale5 = arith.muli %5, %splat6 : tensor<4x256xi32>
+    // offset = [0,0], size = [4,256], stride = [0,5]
+    %7 = arith.addi %offset3, %scale5: tensor<4x256xi32>
+    // offset = [%arg3, 0], size = [4, 256], stride = [1, 5]
+    %8 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<4x256x!tt.ptr<bf16>>
+    %9 = tt.addptr %8, %7 : tensor<4x256x!tt.ptr<bf16>>, tensor<4x256xi32>
+    // source: %arg0, offset = [%arg3, 0], size = [4, 256], stride = [1, 5]
+    %10 = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<4x256xbf16>
+    %11 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<4x256x!tt.ptr<bf16>>
+    %12 = tt.addptr %11, %7 : tensor<4x256x!tt.ptr<bf16>>, tensor<4x256xi32>
+    // source: %arg1, offset = [%arg3, 0], size = [4, 256], stride = [1, 5]
+    %13 = tt.load %12 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<4x256xbf16>
+    %14 = arith.addf %10, %13 : tensor<4x256xbf16>
+    %15 = tt.splat %arg2 : (!tt.ptr<bf16>) -> tensor<4x256x!tt.ptr<bf16>>
+    %16 = tt.addptr %15, %7 : tensor<4x256x!tt.ptr<bf16>>, tensor<4x256xi32>
+    // source: %arg2, offset = [%arg3, 0], size = [4, 256], stride = [1, 5]
+    tt.store %16, %14 : tensor<4x256xbf16>
+    tt.return
+  }
+}
+// mlir2FileCheck.py
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK-LABEL:  func.func @kernel
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: memref<*xbf16>, [[PARAM_2_:%.+]]: memref<*xbf16>, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_5_:%.+]] = arith.constant 5 : index
+// CHECK-DAG:       [[VAR_0_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_0_]]{{.}}, sizes: [4, 256], strides: [1, [[CST_5_]]{{.}} : memref<*xbf16> to memref<4x256xbf16, strided<[1, ?], offset: ?>>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<4x256xbf16>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<4x256xbf16, strided<[1, ?], offset: ?>> to memref<4x256xbf16>
+// CHECK-DAG:       [[VAR_1_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<4x256xbf16>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [4, 256], strides: [1, [[CST_5_]]{{.}} : memref<*xbf16> to memref<4x256xbf16, strided<[1, ?], offset: ?>>
+// CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc() : memref<4x256xbf16>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_0_]], [[RES_1_]] : memref<4x256xbf16, strided<[1, ?], offset: ?>> to memref<4x256xbf16>
+// CHECK:           [[VAR_3_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<4x256xbf16>
+// CHECK:           [[VAR_4_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_1_]], [[VAR_3_]] : tensor<4x256xbf16>, tensor<4x256xbf16>) outs([[VAR_1_]] : tensor<4x256xbf16>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: bf16, [[IN_1_:%.+]]: bf16, [[IN_2_:%.+]]: bf16):
+// CHECK:             [[VAR_6_:%.+]] = arith.addf [[IN_0_]], [[IN_1_]] : bf16
+// CHECK:             linalg.yield [[VAR_6_]] : bf16
+// CHECK:           } -> tensor<4x256xbf16>
+// CHECK:           [[VAR_5_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
+// CHECK:           [[VAR_reinterpret_cast_2_:%.+]] = memref.reinterpret_cast [[PARAM_2_]] to offset: {{.}}[[VAR_5_]]{{.}}, sizes: [4, 256], strides: [1, [[CST_5_]]{{.}} : memref<*xbf16> to memref<4x256xbf16, strided<[1, ?], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_4_]] in writable [[VAR_reinterpret_cast_2_]] : (tensor<4x256xbf16>, memref<4x256xbf16, strided<[1, ?], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/addptr_2d_example.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_2d_example.mlir
@@ -9,35 +9,35 @@ module {
   {
     %0 = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32>
     // offset = 0, size = 4, stride = 1
-    %1 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<4xi32>) -> tensor<4x1xi32>
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<4xi32> -> tensor<4x1xi32>
     // offset = [0,0], size = [4,1], stride = [1,0]
-    %2 = tt.broadcast %1 : (tensor<4x1xi32>) -> tensor<4x256xi32>
+    %2 = tt.broadcast %1 : tensor<4x1xi32> -> tensor<4x256xi32>
     // offset = [0,0], size = [4,256], stride = [1,0]
-    %arg3splat = tt.splat %arg3 : (i32) -> tensor<4x256xi32>
+    %arg3splat = tt.splat %arg3 : i32 -> tensor<4x256xi32>
     %offset3 = arith.addi %2, %arg3splat : tensor<4x256xi32>
     // offset = [%arg3,0], size = [4,256], stride = [1,0]
     %3 = tt.make_range {end = 256 : i32, start = 0 : i32}: tensor<256xi32>
     // offset = 0, size = 256, stride = 1
-    %4 = tt.expand_dims %3 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
+    %4 = tt.expand_dims %3 {axis = 0 : i32} : tensor<256xi32> -> tensor<1x256xi32>
     // offset = [0,0], size = [1,256], stride = [0,1]
-    %5 = tt.broadcast %4 : (tensor<1x256xi32>) -> tensor<4x256xi32>
+    %5 = tt.broadcast %4 : tensor<1x256xi32> -> tensor<4x256xi32>
     // offset = [0,0], size = [4,256], stride = [0,1]
     %6 = arith.constant 5 : i32
-    %splat6 = tt.splat %6 : (i32) -> tensor<4x256xi32>
+    %splat6 = tt.splat %6 : i32 -> tensor<4x256xi32>
     %scale5 = arith.muli %5, %splat6 : tensor<4x256xi32>
     // offset = [0,0], size = [4,256], stride = [0,5]
     %7 = arith.addi %offset3, %scale5: tensor<4x256xi32>
     // offset = [%arg3, 0], size = [4, 256], stride = [1, 5]
-    %8 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<4x256x!tt.ptr<bf16>>
+    %8 = tt.splat %arg0 : !tt.ptr<bf16> -> tensor<4x256x!tt.ptr<bf16>>
     %9 = tt.addptr %8, %7 : tensor<4x256x!tt.ptr<bf16>>, tensor<4x256xi32>
     // source: %arg0, offset = [%arg3, 0], size = [4, 256], stride = [1, 5]
     %10 = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<4x256xbf16>
-    %11 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<4x256x!tt.ptr<bf16>>
+    %11 = tt.splat %arg1 : !tt.ptr<bf16> -> tensor<4x256x!tt.ptr<bf16>>
     %12 = tt.addptr %11, %7 : tensor<4x256x!tt.ptr<bf16>>, tensor<4x256xi32>
     // source: %arg1, offset = [%arg3, 0], size = [4, 256], stride = [1, 5]
     %13 = tt.load %12 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<4x256xbf16>
     %14 = arith.addf %10, %13 : tensor<4x256xbf16>
-    %15 = tt.splat %arg2 : (!tt.ptr<bf16>) -> tensor<4x256x!tt.ptr<bf16>>
+    %15 = tt.splat %arg2 : !tt.ptr<bf16> -> tensor<4x256x!tt.ptr<bf16>>
     %16 = tt.addptr %15, %7 : tensor<4x256x!tt.ptr<bf16>>, tensor<4x256xi32>
     // source: %arg2, offset = [%arg3, 0], size = [4, 256], stride = [1, 5]
     tt.store %16, %14 : tensor<4x256xbf16>

--- a/test/Conversion/StructuredToMemref/addptr_add_value.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_add_value.mlir
@@ -9,36 +9,36 @@ module {
   {
   %0 = tt.make_range {end = 4 : i32, start = 0 : i32}:tensor<4xi32>
   // offset = 0, size = 4, stride = 1
-  %1 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<4xi32>) -> tensor<4x1xi32>
+  %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<4xi32> -> tensor<4x1xi32>
   // offset = [0,0], size = [4,1], stride = [1,0]
-  %2 = tt.broadcast %1 : (tensor<4x1xi32>) -> tensor<4x256xi32>
+  %2 = tt.broadcast %1 : tensor<4x1xi32> -> tensor<4x256xi32>
   // offset = [0,0], size = [4,256], stride = [1,0]
-  %arg2splat = tt.splat %arg2 : (i32) -> tensor<4x256xi32>
+  %arg2splat = tt.splat %arg2 : i32 -> tensor<4x256xi32>
   %offset2 = arith.addi %2, %arg2splat : tensor<4x256xi32>
   // offset = [%arg2,0], size = [4,256], stride = [1,0]
-  %arg3splat = tt.splat %arg3 : (i32) -> tensor<4x256xi32>
+  %arg3splat = tt.splat %arg3 : i32 -> tensor<4x256xi32>
   %offset3 = arith.addi %offset2, %arg3splat : tensor<4x256xi32>
   // offset = [%arg2+%arg3,0], size = [4,256], stride = [1,0]
   %c10 = arith.constant 10 : i32
-  %c10splat = tt.splat %c10 : (i32) -> tensor<4x256xi32>
+  %c10splat = tt.splat %c10 : i32 -> tensor<4x256xi32>
   %offset4 = arith.addi %offset3, %c10splat : tensor<4x256xi32>
   // offset = [%arg2+%arg3+10,0], size = [4,256], stride = [1,0]
   %3 = tt.make_range {end = 256 : i32, start = 0 : i32}:tensor<256xi32>
   // offset = 0, size = 256, stride = 1
-  %4 = tt.expand_dims %3 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
+  %4 = tt.expand_dims %3 {axis = 0 : i32} : tensor<256xi32> -> tensor<1x256xi32>
   // offset = [0,0], size = [1,256], stride = [0,1]
-  %5 = tt.broadcast %4 : (tensor<1x256xi32>) -> tensor<4x256xi32>
+  %5 = tt.broadcast %4 : tensor<1x256xi32> -> tensor<4x256xi32>
   // offset = [0,0], size = [4,256], stride = [0,1]
   %c6 = arith.constant 6 : i32
-  %splat6 = tt.splat %c6 : (i32) -> tensor<4x256xi32>
+  %splat6 = tt.splat %c6 : i32 -> tensor<4x256xi32>
   %scale5 = arith.muli %5, %splat6 : tensor<4x256xi32>
   // offset = [0,0], size = [4,256], stride = [0,6]
   %7 = arith.addi %offset4, %scale5: tensor<4x256xi32>
   // offset = [%arg2+%arg3+10, 0], size = [4, 256], stride = [1, 6]
-  %8 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<4x256x!tt.ptr<bf16>>
+  %8 = tt.splat %arg0 : !tt.ptr<bf16> -> tensor<4x256x!tt.ptr<bf16>>
   %9 = tt.addptr %8, %7 : tensor<4x256x!tt.ptr<bf16>>,tensor<4x256xi32>
   // source = %arg0, offset = [%arg2+%arg3+10, 0], size = [4, 256], stride = [1, 6]
-  %10 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<4x256x!tt.ptr<bf16>>
+  %10 = tt.splat %arg1 : !tt.ptr<bf16> -> tensor<4x256x!tt.ptr<bf16>>
   %11 = tt.addptr %10, %7 : tensor<4x256x!tt.ptr<bf16>>, tensor<4x256xi32>
   // source = %arg1, offset = [%arg2+%arg3+10, 0], size = [4, 256], stride = [1, 6]
   %12 = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<4x256xbf16>

--- a/test/Conversion/StructuredToMemref/addptr_add_value.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_add_value.mlir
@@ -1,0 +1,69 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+module {
+  tt.func @kernel(
+  %arg0 : !tt.ptr<bf16>,
+  %arg1 : !tt.ptr<bf16>,
+  %arg2 : i32,
+  %arg3 : i32
+  )
+  {
+  %0 = tt.make_range {end = 4 : i32, start = 0 : i32}:tensor<4xi32>
+  // offset = 0, size = 4, stride = 1
+  %1 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<4xi32>) -> tensor<4x1xi32>
+  // offset = [0,0], size = [4,1], stride = [1,0]
+  %2 = tt.broadcast %1 : (tensor<4x1xi32>) -> tensor<4x256xi32>
+  // offset = [0,0], size = [4,256], stride = [1,0]
+  %arg2splat = tt.splat %arg2 : (i32) -> tensor<4x256xi32>
+  %offset2 = arith.addi %2, %arg2splat : tensor<4x256xi32>
+  // offset = [%arg2,0], size = [4,256], stride = [1,0]
+  %arg3splat = tt.splat %arg3 : (i32) -> tensor<4x256xi32>
+  %offset3 = arith.addi %offset2, %arg3splat : tensor<4x256xi32>
+  // offset = [%arg2+%arg3,0], size = [4,256], stride = [1,0]
+  %c10 = arith.constant 10 : i32
+  %c10splat = tt.splat %c10 : (i32) -> tensor<4x256xi32>
+  %offset4 = arith.addi %offset3, %c10splat : tensor<4x256xi32>
+  // offset = [%arg2+%arg3+10,0], size = [4,256], stride = [1,0]
+  %3 = tt.make_range {end = 256 : i32, start = 0 : i32}:tensor<256xi32>
+  // offset = 0, size = 256, stride = 1
+  %4 = tt.expand_dims %3 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
+  // offset = [0,0], size = [1,256], stride = [0,1]
+  %5 = tt.broadcast %4 : (tensor<1x256xi32>) -> tensor<4x256xi32>
+  // offset = [0,0], size = [4,256], stride = [0,1]
+  %c6 = arith.constant 6 : i32
+  %splat6 = tt.splat %c6 : (i32) -> tensor<4x256xi32>
+  %scale5 = arith.muli %5, %splat6 : tensor<4x256xi32>
+  // offset = [0,0], size = [4,256], stride = [0,6]
+  %7 = arith.addi %offset4, %scale5: tensor<4x256xi32>
+  // offset = [%arg2+%arg3+10, 0], size = [4, 256], stride = [1, 6]
+  %8 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<4x256x!tt.ptr<bf16>>
+  %9 = tt.addptr %8, %7 : tensor<4x256x!tt.ptr<bf16>>,tensor<4x256xi32>
+  // source = %arg0, offset = [%arg2+%arg3+10, 0], size = [4, 256], stride = [1, 6]
+  %10 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<4x256x!tt.ptr<bf16>>
+  %11 = tt.addptr %10, %7 : tensor<4x256x!tt.ptr<bf16>>, tensor<4x256xi32>
+  // source = %arg1, offset = [%arg2+%arg3+10, 0], size = [4, 256], stride = [1, 6]
+  %12 = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<4x256xbf16>
+  tt.store %11, %12 : tensor<4x256xbf16>
+  tt.return
+  }
+}
+// mlir2FileCheck.py
+// CHECK-LABEL:  func.func @kernel
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: memref<*xbf16>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_6_:%.+]] = arith.constant 6 : index
+// CHECK-DAG:       [[CST_10_:%.+]] = arith.constant 10 : index
+// CHECK-DAG:       [[VAR_0_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
+// CHECK:           [[VAR_2_:%.+]] = arith.addi [[VAR_0_]], [[VAR_1_]] : index
+// CHECK:           [[VAR_3_:%.+]] = arith.addi [[VAR_2_]], [[CST_10_]] : index
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_3_]]{{.}}, sizes: [4, 256], strides: [1, [[CST_6_]]{{.}} : memref<*xbf16> to memref<4x256xbf16, strided<[1, ?], offset: ?>>
+// CHECK-DAG:       [[VAR_4_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
+// CHECK:           [[VAR_6_:%.+]] = arith.addi [[VAR_4_]], [[VAR_5_]] : index
+// CHECK:           [[VAR_7_:%.+]] = arith.addi [[VAR_6_]], [[CST_10_]] : index
+// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_7_]]{{.}}, sizes: [4, 256], strides: [1, [[CST_6_]]{{.}} : memref<*xbf16> to memref<4x256xbf16, strided<[1, ?], offset: ?>>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<4x256xbf16>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<4x256xbf16, strided<[1, ?], offset: ?>> to memref<4x256xbf16>
+// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<4x256xbf16>
+// CHECK:           bufferization.materialize_in_destination [[VAR_8_]] in writable [[VAR_reinterpret_cast_0_]] : (tensor<4x256xbf16>, memref<4x256xbf16, strided<[1, ?], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/addptr_dim1.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_dim1.mlir
@@ -1,0 +1,105 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+
+module {
+  tt.func @kernel(
+    %arg0 : !tt.ptr<bf16>,
+    %arg1 : i32
+  )
+  {
+    %0 = tt.make_range {end = 256 : i32, start = 0 : i32}:tensor<256xi32>
+    %1 = tt.expand_dims %0 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
+
+    %splat_arg0 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<1x256x!tt.ptr<bf16>>
+    %2 = tt.addptr %splat_arg0, %1 : tensor<1x256x!tt.ptr<bf16>>, tensor<1x256xi32>
+
+    // 1x256 pointer should have meaningful stride in outer dimension
+    %3 = tt.load %2 {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<1x256xbf16>
+
+    %4 = tt.splat %arg1 : (i32) -> tensor<1x256xi32>
+    // 1x256 pointer should have meaningful stride in outer dimension
+    %5 = tt.addptr %2, %4 : tensor<1x256x!tt.ptr<bf16>>, tensor<1x256xi32>
+    tt.store %5, %3 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1x256x!tt.ptr<bf16>>, tensor<1x256xbf16>
+
+    %10 = arith.constant 0.0 : bf16
+    %11 = tt.splat %10 : (bf16) -> tensor<4x256xbf16>
+
+    %c0 = arith.constant 0 : index
+    %c12 = arith.constant 12 : index
+    %c3 = arith.constant 3 : index
+    %i_c3 = arith.constant 3 : i32
+    %c256 = arith.constant 256 : i32
+    %sum_out, %_ptr = scf.for %i = %c0 to %c12 step %c3 iter_args(%sum_iter = %11, %ptr = %2) -> (tensor<4x256xbf16>, tensor<1x256x!tt.ptr<bf16>>) {
+        %bptr = tt.broadcast %ptr : (tensor<1x256x!tt.ptr<bf16>>) -> tensor<4x256x!tt.ptr<bf16>>
+
+        %20 = tt.make_range {end = 4 : i32, start = 0 : i32}:tensor<4xi32>
+        %i_i32 = arith.index_cast %i : index to i32
+        %21 = arith.muli %c256, %i_i32 : i32
+        %22 = tt.splat %21 : (i32) -> tensor<4xi32>
+        %23 = arith.muli %20, %22 : tensor<4xi32>
+        %24 = tt.expand_dims %23 {axis = 1 : i32} : (tensor<4xi32>) -> tensor<4x1xi32>
+        %25 = tt.broadcast %24 : (tensor<4x1xi32>) -> tensor<4x256xi32>
+
+        // %bptr should have zero stride and %30 should have correct stride
+        %30 = tt.addptr %bptr, %25 : tensor<4x256x!tt.ptr<bf16>>, tensor<4x256xi32>
+        %31 = tt.load %30 {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<4x256xbf16>
+        %32 = arith.addf %sum_iter, %31 : tensor<4x256xbf16>
+
+        %40 = tt.splat %c256 : (i32) -> tensor<1x256xi32>
+        %41 = tt.addptr %ptr, %40 : tensor<1x256x!tt.ptr<bf16>>, tensor<1x256xi32>
+
+        scf.yield %32, %41 : tensor<4x256xbf16>, tensor<1x256x!tt.ptr<bf16>>
+    }
+
+    %31 = tt.make_range {end = 4 : i32, start = 0 : i32}:tensor<4xi32>
+    %splat_c256 = tt.splat %c256 : (i32) -> tensor<4xi32>
+    %32 = arith.muli %31, %splat_c256 : tensor<4xi32>
+    %33 = tt.expand_dims %32 {axis = 1 : i32} : (tensor<4xi32>) -> tensor<4x1xi32>
+    %34 = tt.broadcast %33 : (tensor<4x1xi32>) -> tensor<4x256xi32>
+    %35 = tt.broadcast %2 : (tensor<1x256x!tt.ptr<bf16>>) -> tensor<4x256x!tt.ptr<bf16>>
+    %36 = tt.addptr %35, %34 : tensor<4x256x!tt.ptr<bf16>>, tensor<4x256xi32>
+    tt.store %36, %sum_out {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<4x256x!tt.ptr<bf16>>, tensor<4x256xbf16>
+    tt.return
+  }
+}
+
+// mlir2FileCheck.py
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK-LABEL:  func.func @kernel
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: i32, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
+// CHECK-DAG:       [[CST_12_:%.+]] = arith.constant 12 : index
+// CHECK-DAG:       [[CST_3_:%.+]] = arith.constant 3 : index
+// CHECK-DAG:       [[CST_256_:%.+]] = arith.constant 256 : i32
+// CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : index
+// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : bf16
+// CHECK-DAG:       [[CST_256_1_:%.+]] = arith.constant 256 : index
+// CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<4x256xbf16>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_1_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : bf16) outs([[VAR_0_]] : tensor<4x256xbf16>) -> tensor<4x256xbf16>
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [1, 256], strides: [256, 1] : memref<*xbf16> to memref<1x256xbf16, strided<[256, 1]>>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<1x256xbf16>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<1x256xbf16, strided<[256, 1]>> to memref<1x256xbf16>
+// CHECK-DAG:       [[VAR_2_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<1x256xbf16>
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[PARAM_1_]] : i32 to index
+// CHECK:           [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_3_]]{{.}}, sizes: [1, 256], strides: [256, 1] : memref<*xbf16> to memref<1x256xbf16, strided<[256, 1], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_2_]] in writable [[VAR_reinterpret_cast_0_]] : (tensor<1x256xbf16>, memref<1x256xbf16, strided<[256, 1], offset: ?>>) -> ()
+// CHECK-DAG:       [[VAR_4_:%.+]]:2 = scf.for [[VAR_arg8_:%.+]] = [[CST_0_]] to [[CST_12_]] step [[CST_3_]] iter_args([[VAR_arg9_:%.+]] = [[VAR_1_]], [[VAR_arg10_:%.+]] = [[CST_0_]]) -> (tensor<4x256xbf16>, index) {
+// CHECK-DAG:         [[VAR_5_:%.+]] = arith.index_cast [[VAR_arg8_]] : index to i32
+// CHECK:             [[VAR_6_:%.+]] = arith.muli [[VAR_5_]], [[CST_256_]] : i32
+// CHECK:             [[VAR_7_:%.+]] = arith.index_cast [[VAR_6_]] : i32 to index
+// CHECK-DAG:         [[VAR_reinterpret_cast_2_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_arg10_]]{{.}}, sizes: [4, 256], strides: {{.}}[[VAR_7_]], [[CST_1_]]{{.}} : memref<*xbf16> to memref<4x256xbf16, strided<[?, ?], offset: ?>>
+// CHECK-DAG:         [[RES_1_:%.+]] = memref.alloc() : memref<4x256xbf16>
+// CHECK:             memref.copy [[VAR_reinterpret_cast_2_]], [[RES_1_]] : memref<4x256xbf16, strided<[?, ?], offset: ?>> to memref<4x256xbf16>
+// CHECK:             [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<4x256xbf16>
+// CHECK:             [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_arg9_]], [[VAR_8_]] : tensor<4x256xbf16>, tensor<4x256xbf16>) outs([[VAR_arg9_]] : tensor<4x256xbf16>) {
+// CHECK:             ^bb0([[IN_0_:%.+]]: bf16, [[IN_1_:%.+]]: bf16, [[IN_2_:%.+]]: bf16):
+// CHECK:               [[VAR_11_:%.+]] = arith.addf [[IN_0_]], [[IN_1_]] : bf16
+// CHECK:               linalg.yield [[VAR_11_]] : bf16
+// CHECK:             } -> tensor<4x256xbf16>
+// CHECK:             [[VAR_10_:%.+]] = arith.addi [[VAR_arg10_]], [[CST_256_1_]] : index
+// CHECK:             scf.yield [[VAR_9_]], [[VAR_10_]] : tensor<4x256xbf16>, index
+// CHECK:           }
+// CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [4, 256], strides: {{.}}[[CST_256_1_]], 1] : memref<*xbf16> to memref<4x256xbf16, strided<[?, 1]>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_4_]]#0 in writable [[VAR_reinterpret_cast_1_]] : (tensor<4x256xbf16>, memref<4x256xbf16, strided<[?, 1]>>) -> ()
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/addptr_dim1.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_dim1.mlir
@@ -7,21 +7,21 @@ module {
   )
   {
     %0 = tt.make_range {end = 256 : i32, start = 0 : i32}:tensor<256xi32>
-    %1 = tt.expand_dims %0 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
+    %1 = tt.expand_dims %0 {axis = 0 : i32} : tensor<256xi32> -> tensor<1x256xi32>
 
-    %splat_arg0 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<1x256x!tt.ptr<bf16>>
+    %splat_arg0 = tt.splat %arg0 : !tt.ptr<bf16> -> tensor<1x256x!tt.ptr<bf16>>
     %2 = tt.addptr %splat_arg0, %1 : tensor<1x256x!tt.ptr<bf16>>, tensor<1x256xi32>
 
     // 1x256 pointer should have meaningful stride in outer dimension
     %3 = tt.load %2 {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<1x256xbf16>
 
-    %4 = tt.splat %arg1 : (i32) -> tensor<1x256xi32>
+    %4 = tt.splat %arg1 : i32 -> tensor<1x256xi32>
     // 1x256 pointer should have meaningful stride in outer dimension
     %5 = tt.addptr %2, %4 : tensor<1x256x!tt.ptr<bf16>>, tensor<1x256xi32>
     tt.store %5, %3 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1x256x!tt.ptr<bf16>>, tensor<1x256xbf16>
 
     %10 = arith.constant 0.0 : bf16
-    %11 = tt.splat %10 : (bf16) -> tensor<4x256xbf16>
+    %11 = tt.splat %10 : bf16 -> tensor<4x256xbf16>
 
     %c0 = arith.constant 0 : index
     %c12 = arith.constant 12 : index
@@ -29,33 +29,33 @@ module {
     %i_c3 = arith.constant 3 : i32
     %c256 = arith.constant 256 : i32
     %sum_out, %_ptr = scf.for %i = %c0 to %c12 step %c3 iter_args(%sum_iter = %11, %ptr = %2) -> (tensor<4x256xbf16>, tensor<1x256x!tt.ptr<bf16>>) {
-        %bptr = tt.broadcast %ptr : (tensor<1x256x!tt.ptr<bf16>>) -> tensor<4x256x!tt.ptr<bf16>>
+        %bptr = tt.broadcast %ptr : tensor<1x256x!tt.ptr<bf16>> -> tensor<4x256x!tt.ptr<bf16>>
 
         %20 = tt.make_range {end = 4 : i32, start = 0 : i32}:tensor<4xi32>
         %i_i32 = arith.index_cast %i : index to i32
         %21 = arith.muli %c256, %i_i32 : i32
-        %22 = tt.splat %21 : (i32) -> tensor<4xi32>
+        %22 = tt.splat %21 : i32 -> tensor<4xi32>
         %23 = arith.muli %20, %22 : tensor<4xi32>
-        %24 = tt.expand_dims %23 {axis = 1 : i32} : (tensor<4xi32>) -> tensor<4x1xi32>
-        %25 = tt.broadcast %24 : (tensor<4x1xi32>) -> tensor<4x256xi32>
+        %24 = tt.expand_dims %23 {axis = 1 : i32} : tensor<4xi32> -> tensor<4x1xi32>
+        %25 = tt.broadcast %24 : tensor<4x1xi32> -> tensor<4x256xi32>
 
         // %bptr should have zero stride and %30 should have correct stride
         %30 = tt.addptr %bptr, %25 : tensor<4x256x!tt.ptr<bf16>>, tensor<4x256xi32>
         %31 = tt.load %30 {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<4x256xbf16>
         %32 = arith.addf %sum_iter, %31 : tensor<4x256xbf16>
 
-        %40 = tt.splat %c256 : (i32) -> tensor<1x256xi32>
+        %40 = tt.splat %c256 : i32 -> tensor<1x256xi32>
         %41 = tt.addptr %ptr, %40 : tensor<1x256x!tt.ptr<bf16>>, tensor<1x256xi32>
 
         scf.yield %32, %41 : tensor<4x256xbf16>, tensor<1x256x!tt.ptr<bf16>>
     }
 
     %31 = tt.make_range {end = 4 : i32, start = 0 : i32}:tensor<4xi32>
-    %splat_c256 = tt.splat %c256 : (i32) -> tensor<4xi32>
+    %splat_c256 = tt.splat %c256 : i32 -> tensor<4xi32>
     %32 = arith.muli %31, %splat_c256 : tensor<4xi32>
-    %33 = tt.expand_dims %32 {axis = 1 : i32} : (tensor<4xi32>) -> tensor<4x1xi32>
-    %34 = tt.broadcast %33 : (tensor<4x1xi32>) -> tensor<4x256xi32>
-    %35 = tt.broadcast %2 : (tensor<1x256x!tt.ptr<bf16>>) -> tensor<4x256x!tt.ptr<bf16>>
+    %33 = tt.expand_dims %32 {axis = 1 : i32} : tensor<4xi32> -> tensor<4x1xi32>
+    %34 = tt.broadcast %33 : tensor<4x1xi32> -> tensor<4x256xi32>
+    %35 = tt.broadcast %2 : tensor<1x256x!tt.ptr<bf16>> -> tensor<4x256x!tt.ptr<bf16>>
     %36 = tt.addptr %35, %34 : tensor<4x256x!tt.ptr<bf16>>, tensor<4x256xi32>
     tt.store %36, %sum_out {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<4x256x!tt.ptr<bf16>>, tensor<4x256xbf16>
     tt.return

--- a/test/Conversion/StructuredToMemref/addptr_for_accumulation.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_for_accumulation.mlir
@@ -1,0 +1,95 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+module {
+  tt.func @kernel(
+    %arg0 : !tt.ptr<bf16>,
+    %arg1 : !tt.ptr<bf16>,
+    %arg2 : !tt.ptr<bf16>,
+    %arg3 : i32,
+    %arg4 : i32
+  )
+  {
+    %0 = tt.make_range {end = 4 : i32, start = 0 : i32}:tensor<4xi32>
+    // offset = 0, size = 4, stride = 1
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<4xi32>) -> tensor<4x1xi32>
+    // offset = [0,0], size = [4,1], stride = [1,0]
+    %2 = tt.broadcast %1 : (tensor<4x1xi32>) -> tensor<4x256xi32>
+    // offset = [0,0], size = [4,256], stride = [1,0]
+    %arg3splat = tt.splat %arg3 : (i32) -> tensor<4x256xi32>
+    %offset3 = arith.addi %2, %arg3splat : tensor<4x256xi32>
+    // offset = [%arg3,0], size = [4,256], stride = [1,0]
+    %3 = tt.make_range {end = 256 : i32, start = 0 : i32}:tensor<256xi32>
+    // offset = 0, size = 256, stride = 1
+    %4 = tt.expand_dims %3 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
+    // offset = [0,0], size = [1,256], stride = [0,1]
+    %5 = tt.broadcast %4 : (tensor<1x256xi32>) -> tensor<4x256xi32>
+    // offset = [0,0], size = [4,256], stride = [0,1]
+    %c5 = arith.constant 5 : i32
+    %splat6 = tt.splat %c5 : (i32) -> tensor<4x256xi32>
+    // scalar = 5
+    %scale5 = arith.muli %5, %splat6 : tensor<4x256xi32> // Why we never called the conversion function for the inputs here?
+    // offset = [0,0], size = [4,256], stride = [0,5]
+    %7 = arith.addi %offset3, %scale5: tensor<4x256xi32> // Why we never called the conversion function for the inputs here?
+    // offset = [%arg3, 0], size = [4, 256], stride = [1, 5]
+    %8 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<4x256x!tt.ptr<bf16>> // Why is the input unknown
+    %9 = tt.addptr %8, %7 : tensor<4x256x!tt.ptr<bf16>>, tensor<4x256xi32>
+    // source: %arg0, offset = [%arg3, 0], size = [4, 256], stride = [1, 5]
+    %19 = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<4x256xbf16> // this will be replaced with a memref.copy
+    %11 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<4x256x!tt.ptr<bf16>>
+    %12 = tt.addptr %11, %7 : tensor<4x256x!tt.ptr<bf16>>, tensor<4x256xi32>
+    // source: %arg1, offset = [%arg3, 0], size = [4, 256], stride = [1, 5]
+    %c0 = arith.constant 0 : index
+    %c12 = arith.constant 12 : index
+    %c3 = arith.constant 3 : index
+    %i_c3 = arith.constant 3 : i32
+    %sum_out, %_ptr = scf.for %i = %c0 to %c12 step %c3 iter_args(%sum_iter = %19, %ptr_iter = %12) -> (tensor<4x256xbf16>, tensor<4x256x!tt.ptr<bf16>>) {
+        %20 = tt.load %ptr_iter {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<4x256xbf16>
+        %sum = arith.addf %sum_iter, %20 : tensor<4x256xbf16>
+        // pointer updates
+        %17 = tt.splat %i_c3 : (i32) -> tensor<4x256xi32>
+        // offset: [3, 0], size = [4, 256], stride [0, 0]
+        %ptr = tt.addptr %ptr_iter, %17 : tensor<4x256x!tt.ptr<bf16>>, tensor<4x256xi32>
+        // source: %arg1, offset = [%arg3+%i, 0], size = [4, 256], stride = [1, 5]
+        scf.yield %sum, %ptr : tensor<4x256xbf16>, tensor<4x256x!tt.ptr<bf16>>
+    }
+    %15 = tt.splat %arg2 : (!tt.ptr<bf16>) -> tensor<4x256x!tt.ptr<bf16>>
+    %16 = tt.addptr %15, %7 : tensor<4x256x!tt.ptr<bf16>>, tensor<4x256xi32>
+    // source: %arg2, offset = [%arg3, 0], size = [4, 256], stride = [1, 5]
+    tt.store %16, %sum_out : tensor<4x256xbf16>
+    tt.return
+  }
+}
+// mlir2FileCheck.py
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK-LABEL:  func.func @kernel
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: memref<*xbf16>, [[PARAM_2_:%.+]]: memref<*xbf16>, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32, [[PARAM_10_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_5_:%.+]] = arith.constant 5 : index
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
+// CHECK-DAG:       [[CST_12_:%.+]] = arith.constant 12 : index
+// CHECK-DAG:       [[CST_3_:%.+]] = arith.constant 3 : index
+// CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : index
+// CHECK-DAG:       [[VAR_0_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_0_]]{{.}}, sizes: [4, 256], strides: [1, [[CST_5_]]{{.}} : memref<*xbf16> to memref<4x256xbf16, strided<[1, ?], offset: ?>>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<4x256xbf16>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<4x256xbf16, strided<[1, ?], offset: ?>> to memref<4x256xbf16>
+// CHECK-DAG:       [[VAR_1_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<4x256xbf16>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_3_:%.+]]:2 = scf.for [[VAR_arg11_:%.+]] = [[CST_0_]] to [[CST_12_]] step [[CST_3_]] iter_args([[VAR_arg12_:%.+]] = [[VAR_1_]], [[VAR_arg13_:%.+]] = [[VAR_2_]]) -> (tensor<4x256xbf16>, index) {
+// CHECK-DAG:         [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_arg13_]]{{.}}, sizes: [4, 256], strides: {{.}}[[CST_1_]], [[CST_5_]]{{.}} : memref<*xbf16> to memref<4x256xbf16, strided<[?, ?], offset: ?>>
+// CHECK-DAG:         [[RES_1_:%.+]] = memref.alloc() : memref<4x256xbf16>
+// CHECK:             memref.copy [[VAR_reinterpret_cast_1_]], [[RES_1_]] : memref<4x256xbf16, strided<[?, ?], offset: ?>> to memref<4x256xbf16>
+// CHECK:             [[VAR_5_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<4x256xbf16>
+// CHECK:             [[VAR_6_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_arg12_]], [[VAR_5_]] : tensor<4x256xbf16>, tensor<4x256xbf16>) outs([[VAR_arg12_]] : tensor<4x256xbf16>) {
+// CHECK:             ^bb0([[IN_0_:%.+]]: bf16, [[IN_1_:%.+]]: bf16, [[IN_2_:%.+]]: bf16):
+// CHECK:               [[VAR_8_:%.+]] = arith.addf [[IN_0_]], [[IN_1_]] : bf16
+// CHECK:               linalg.yield [[VAR_8_]] : bf16
+// CHECK:             } -> tensor<4x256xbf16>
+// CHECK:             [[VAR_7_:%.+]] = arith.addi [[VAR_arg13_]], [[CST_3_]] : index
+// CHECK:             scf.yield [[VAR_6_]], [[VAR_7_]] : tensor<4x256xbf16>, index
+// CHECK:           }
+// CHECK:           [[VAR_4_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
+// CHECK:           [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_2_]] to offset: {{.}}[[VAR_4_]]{{.}}, sizes: [4, 256], strides: [1, [[CST_5_]]{{.}} : memref<*xbf16> to memref<4x256xbf16, strided<[1, ?], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_3_]]#0 in writable [[VAR_reinterpret_cast_0_]] : (tensor<4x256xbf16>, memref<4x256xbf16, strided<[1, ?], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/addptr_for_accumulation.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_for_accumulation.mlir
@@ -10,31 +10,31 @@ module {
   {
     %0 = tt.make_range {end = 4 : i32, start = 0 : i32}:tensor<4xi32>
     // offset = 0, size = 4, stride = 1
-    %1 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<4xi32>) -> tensor<4x1xi32>
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<4xi32> -> tensor<4x1xi32>
     // offset = [0,0], size = [4,1], stride = [1,0]
-    %2 = tt.broadcast %1 : (tensor<4x1xi32>) -> tensor<4x256xi32>
+    %2 = tt.broadcast %1 : tensor<4x1xi32> -> tensor<4x256xi32>
     // offset = [0,0], size = [4,256], stride = [1,0]
-    %arg3splat = tt.splat %arg3 : (i32) -> tensor<4x256xi32>
+    %arg3splat = tt.splat %arg3 : i32 -> tensor<4x256xi32>
     %offset3 = arith.addi %2, %arg3splat : tensor<4x256xi32>
     // offset = [%arg3,0], size = [4,256], stride = [1,0]
     %3 = tt.make_range {end = 256 : i32, start = 0 : i32}:tensor<256xi32>
     // offset = 0, size = 256, stride = 1
-    %4 = tt.expand_dims %3 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
+    %4 = tt.expand_dims %3 {axis = 0 : i32} : tensor<256xi32> -> tensor<1x256xi32>
     // offset = [0,0], size = [1,256], stride = [0,1]
-    %5 = tt.broadcast %4 : (tensor<1x256xi32>) -> tensor<4x256xi32>
+    %5 = tt.broadcast %4 : tensor<1x256xi32> -> tensor<4x256xi32>
     // offset = [0,0], size = [4,256], stride = [0,1]
     %c5 = arith.constant 5 : i32
-    %splat6 = tt.splat %c5 : (i32) -> tensor<4x256xi32>
+    %splat6 = tt.splat %c5 : i32 -> tensor<4x256xi32>
     // scalar = 5
     %scale5 = arith.muli %5, %splat6 : tensor<4x256xi32> // Why we never called the conversion function for the inputs here?
     // offset = [0,0], size = [4,256], stride = [0,5]
     %7 = arith.addi %offset3, %scale5: tensor<4x256xi32> // Why we never called the conversion function for the inputs here?
     // offset = [%arg3, 0], size = [4, 256], stride = [1, 5]
-    %8 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<4x256x!tt.ptr<bf16>> // Why is the input unknown
+    %8 = tt.splat %arg0 : !tt.ptr<bf16> -> tensor<4x256x!tt.ptr<bf16>> // Why is the input unknown
     %9 = tt.addptr %8, %7 : tensor<4x256x!tt.ptr<bf16>>, tensor<4x256xi32>
     // source: %arg0, offset = [%arg3, 0], size = [4, 256], stride = [1, 5]
     %19 = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<4x256xbf16> // this will be replaced with a memref.copy
-    %11 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<4x256x!tt.ptr<bf16>>
+    %11 = tt.splat %arg1 : !tt.ptr<bf16> -> tensor<4x256x!tt.ptr<bf16>>
     %12 = tt.addptr %11, %7 : tensor<4x256x!tt.ptr<bf16>>, tensor<4x256xi32>
     // source: %arg1, offset = [%arg3, 0], size = [4, 256], stride = [1, 5]
     %c0 = arith.constant 0 : index
@@ -45,13 +45,13 @@ module {
         %20 = tt.load %ptr_iter {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<4x256xbf16>
         %sum = arith.addf %sum_iter, %20 : tensor<4x256xbf16>
         // pointer updates
-        %17 = tt.splat %i_c3 : (i32) -> tensor<4x256xi32>
+        %17 = tt.splat %i_c3 : i32 -> tensor<4x256xi32>
         // offset: [3, 0], size = [4, 256], stride [0, 0]
         %ptr = tt.addptr %ptr_iter, %17 : tensor<4x256x!tt.ptr<bf16>>, tensor<4x256xi32>
         // source: %arg1, offset = [%arg3+%i, 0], size = [4, 256], stride = [1, 5]
         scf.yield %sum, %ptr : tensor<4x256xbf16>, tensor<4x256x!tt.ptr<bf16>>
     }
-    %15 = tt.splat %arg2 : (!tt.ptr<bf16>) -> tensor<4x256x!tt.ptr<bf16>>
+    %15 = tt.splat %arg2 : !tt.ptr<bf16> -> tensor<4x256x!tt.ptr<bf16>>
     %16 = tt.addptr %15, %7 : tensor<4x256x!tt.ptr<bf16>>, tensor<4x256xi32>
     // source: %arg2, offset = [%arg3, 0], size = [4, 256], stride = [1, 5]
     tt.store %16, %sum_out : tensor<4x256xbf16>

--- a/test/Conversion/StructuredToMemref/addptr_for_expand_ptr.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_for_expand_ptr.mlir
@@ -8,7 +8,7 @@ module {
     %c12 = arith.constant 12 : index
     %c3 = arith.constant 3 : index
     %i_c3 = arith.constant 3 : i32
-    %0 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<256x!tt.ptr<bf16>>
+    %0 = tt.splat %arg0 : !tt.ptr<bf16> -> tensor<256x!tt.ptr<bf16>>
     %1 = tt.make_range {end = 1280 : i32, start = 1024 : i32}:tensor<256xi32>
     // source: null, sizes: 256, offsets: 1024, strides: 1
 
@@ -18,22 +18,22 @@ module {
     // gep operand is another gep' output, which is passed into the loop as varible, used after update
     %_ptr = scf.for %i = %c0 to %c12 step %c3 iter_args(%ptr = %2) -> (tensor<256x!tt.ptr<bf16>>) {
       %6 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
-      %7 = tt.expand_dims %6 {axis = 1 : i32} : (tensor<256xi32>) -> tensor<256x1xi32>
+      %7 = tt.expand_dims %6 {axis = 1 : i32} : tensor<256xi32> -> tensor<256x1xi32>
 
-      %8 = tt.broadcast %7 : (tensor<256x1xi32>) -> tensor<256x256xi32>
+      %8 = tt.broadcast %7 : tensor<256x1xi32> -> tensor<256x256xi32>
       // sizes: [256, 256], offsets: [0, 0], strides: [1, 0]
 
       %9 = tt.make_range {end = 512 : i32, start = 256 : i32} : tensor<256xi32>
-      %10 = tt.expand_dims %9 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
+      %10 = tt.expand_dims %9 {axis = 0 : i32} : tensor<256xi32> -> tensor<1x256xi32>
 
-      %11 = tt.broadcast %10 : (tensor<1x256xi32>) -> tensor<256x256xi32>
+      %11 = tt.broadcast %10 : tensor<1x256xi32> -> tensor<256x256xi32>
       // sizes: [256, 256], offsets: [0, 256], strides: [0, 1]
 
       %12 = arith.addi %8, %11 : tensor<256x256xi32>
       // sizes: [256, 256], offsets: [0, 256], strides: [1, 1]
 
-      %13 = tt.expand_dims %ptr {axis = 1 : i32} : (tensor<256x!tt.ptr<bf16>>) -> tensor<256x1x!tt.ptr<bf16>>
-      %14 = tt.broadcast %13 : (tensor<256x1x!tt.ptr<bf16>>) -> tensor<256x256x!tt.ptr<bf16>>
+      %13 = tt.expand_dims %ptr {axis = 1 : i32} : tensor<256x!tt.ptr<bf16>> -> tensor<256x1x!tt.ptr<bf16>>
+      %14 = tt.broadcast %13 : tensor<256x1x!tt.ptr<bf16>> -> tensor<256x256x!tt.ptr<bf16>>
 
       %15 = tt.addptr %14, %12 : tensor<256x256x!tt.ptr<bf16>>, tensor<256x256xi32>
       // source: arg0, sizes: [256, 256], offsets: [1024 + i, 256], strides: [2, 1]
@@ -42,7 +42,7 @@ module {
       %16 = tt.load %15 {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<256x256xbf16>
       tt.store %15, %16 : tensor<256x256xbf16>
       // pointer updates
-      %17 = tt.splat %i_c3 : (i32) -> tensor<256xi32>
+      %17 = tt.splat %i_c3 : i32 -> tensor<256xi32>
       // sizes: 256, offsets: 3, strides: 0
       %ptr_iter = tt.addptr %ptr, %17 : tensor<256x!tt.ptr<bf16>>, tensor<256xi32>
       // source: arg0, sizes: 256, offsets: 1024 + i, strides: 4

--- a/test/Conversion/StructuredToMemref/addptr_for_expand_ptr.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_for_expand_ptr.mlir
@@ -1,0 +1,76 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+module {
+  tt.func @kernel(
+    %arg0 : !tt.ptr<bf16>
+  )
+  {
+    %c0 = arith.constant 0 : index
+    %c12 = arith.constant 12 : index
+    %c3 = arith.constant 3 : index
+    %i_c3 = arith.constant 3 : i32
+    %0 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<256x!tt.ptr<bf16>>
+    %1 = tt.make_range {end = 1280 : i32, start = 1024 : i32}:tensor<256xi32>
+    // source: null, sizes: 256, offsets: 1024, strides: 1
+
+    %2 = tt.addptr %0, %1 : tensor<256x!tt.ptr<bf16>>, tensor<256xi32>
+    // source: arg0, sizes: 256, offsets: 1024, strides: 1
+
+    // gep operand is another gep' output, which is passed into the loop as varible, used after update
+    %_ptr = scf.for %i = %c0 to %c12 step %c3 iter_args(%ptr = %2) -> (tensor<256x!tt.ptr<bf16>>) {
+      %6 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
+      %7 = tt.expand_dims %6 {axis = 1 : i32} : (tensor<256xi32>) -> tensor<256x1xi32>
+
+      %8 = tt.broadcast %7 : (tensor<256x1xi32>) -> tensor<256x256xi32>
+      // sizes: [256, 256], offsets: [0, 0], strides: [1, 0]
+
+      %9 = tt.make_range {end = 512 : i32, start = 256 : i32} : tensor<256xi32>
+      %10 = tt.expand_dims %9 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
+
+      %11 = tt.broadcast %10 : (tensor<1x256xi32>) -> tensor<256x256xi32>
+      // sizes: [256, 256], offsets: [0, 256], strides: [0, 1]
+
+      %12 = arith.addi %8, %11 : tensor<256x256xi32>
+      // sizes: [256, 256], offsets: [0, 256], strides: [1, 1]
+
+      %13 = tt.expand_dims %ptr {axis = 1 : i32} : (tensor<256x!tt.ptr<bf16>>) -> tensor<256x1x!tt.ptr<bf16>>
+      %14 = tt.broadcast %13 : (tensor<256x1x!tt.ptr<bf16>>) -> tensor<256x256x!tt.ptr<bf16>>
+
+      %15 = tt.addptr %14, %12 : tensor<256x256x!tt.ptr<bf16>>, tensor<256x256xi32>
+      // source: arg0, sizes: [256, 256], offsets: [1024 + i, 256], strides: [2, 1]
+
+      // perform load
+      %16 = tt.load %15 {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<256x256xbf16>
+      tt.store %15, %16 : tensor<256x256xbf16>
+      // pointer updates
+      %17 = tt.splat %i_c3 : (i32) -> tensor<256xi32>
+      // sizes: 256, offsets: 3, strides: 0
+      %ptr_iter = tt.addptr %ptr, %17 : tensor<256x!tt.ptr<bf16>>, tensor<256xi32>
+      // source: arg0, sizes: 256, offsets: 1024 + i, strides: 4
+      scf.yield %ptr_iter : tensor<256x!tt.ptr<bf16>>
+    }
+    tt.return
+  }
+}
+// mlir2FileCheck.py
+// CHECK-LABEL:  func.func @kernel
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: i32, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_256_:%.+]] = arith.constant 256 : index
+// CHECK-DAG:       [[CST_3_:%.+]] = arith.constant 3 : index
+// CHECK-DAG:       [[CST_12_:%.+]] = arith.constant 12 : index
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
+// CHECK-DAG:       [[CST_1024_:%.+]] = arith.constant 1024 : index
+// CHECK-DAG:       [[CST_2_:%.+]] = arith.constant 2 : index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_0_:%.+]] = scf.for [[VAR_arg7_:%.+]] = [[CST_0_]] to [[CST_12_]] step [[CST_3_]] iter_args([[VAR_arg8_:%.+]] = [[CST_1024_]]) -> (index) {
+// CHECK-DAG:         [[VAR_1_:%.+]] = arith.addi [[VAR_arg8_]], [[CST_256_]] : index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [256, 256], strides: {{.}}[[CST_2_]], 1] : memref<*xbf16> to memref<256x256xbf16, strided<[?, 1], offset: ?>>
+// CHECK-DAG:         [[RES_:%.+]] = memref.alloc() : memref<256x256xbf16>
+// CHECK:             memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<256x256xbf16, strided<[?, 1], offset: ?>> to memref<256x256xbf16>
+// CHECK:             [[VAR_2_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<256x256xbf16>
+// CHECK:             bufferization.materialize_in_destination [[VAR_2_]] in writable [[VAR_reinterpret_cast_]] : (tensor<256x256xbf16>, memref<256x256xbf16, strided<[?, 1], offset: ?>>) -> ()
+// CHECK:             [[VAR_3_:%.+]] = arith.addi [[VAR_arg8_]], [[CST_3_]] : index
+// CHECK:             scf.yield [[VAR_3_]] : index
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/addptr_for_more_init_args.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_for_more_init_args.mlir
@@ -1,0 +1,71 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+module {
+  tt.func @kernel(
+    %arg0 : !tt.ptr<bf16>,
+    %arg1 : !tt.ptr<bf16>
+  )
+  {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+    %c12 = arith.constant 12 : index
+    %0 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<256x!tt.ptr<bf16>>
+    %1 = tt.make_range {end = 1280 : i32, start = 1024 : i32}:tensor<256xi32>
+    // source: null, sizes: 256, offsets: 1024, strides: 1
+    %2 = tt.addptr %0, %1 : tensor<256x!tt.ptr<bf16>>, tensor<256xi32>
+    // source: arg0, sizes: 256, offsets: 1024, strides: 1
+    %3 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<256x!tt.ptr<bf16>>
+    %4 = tt.addptr %3, %1 : tensor<256x!tt.ptr<bf16>>, tensor<256xi32>
+    // source: arg1, sizes: 256, offsets: 1024, strides: 1
+    %_arg2, %_ptr_ld, %_arg3, %_ptr_st, %_arg4 = scf.for %i = %c0 to %c12 step %c3 iter_args(%arg2 = %c1, %ptr_ld = %2, %arg3 = %c2, %ptr_st = %4, %arg4 = %c3) -> (index, tensor<256x!tt.ptr<bf16>>, index, tensor<256x!tt.ptr<bf16>>, index) {
+        // perform load
+        %5 = tt.load %ptr_ld {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<256xbf16>
+        tt.store %ptr_st, %5 : tensor<256xbf16>
+        // pointer updates
+        %cast3 = arith.index_cast %c3 : index to i32
+        %6 = tt.splat %cast3 : (i32) -> tensor<256xi32>
+        %ptr_ld_iter = tt.addptr %ptr_ld, %6 : tensor<256x!tt.ptr<bf16>>, tensor<256xi32>
+        // source: arg0, sizes: 256, offsets: 1024 + i*3, strides: 1
+        %arg2_iter = arith.addi %arg2, %c3 : index
+        %arg3_iter = arith.addi %arg3, %c3 : index
+        %arg4_iter = arith.addi %arg4, %c3 : index
+        %7 = arith.addi %arg2_iter, %arg3_iter : index
+        %8 = arith.addi %7, %arg4_iter : index
+        %cast8 = arith.index_cast %8 : index to i32
+        %9 = tt.splat %cast8 : (i32) -> tensor<256xi32>
+        %ptr_st_iter = tt.addptr %ptr_st, %9 : tensor<256x!tt.ptr<bf16>>, tensor<256xi32>
+        // source: arg1, sizes: 256, offsets: 1024 + loop-carry variable*i, strides: 1
+        scf.yield %arg2_iter, %ptr_ld_iter, %arg3_iter, %ptr_st_iter, %arg4_iter : index, tensor<256x!tt.ptr<bf16>>, index, tensor<256x!tt.ptr<bf16>>, index
+    }
+    tt.return
+  }
+}
+// mlir2FileCheck.py
+// CHECK-LABEL:  func.func @kernel
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: memref<*xbf16>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_12_:%.+]] = arith.constant 12 : index
+// CHECK-DAG:       [[CST_3_:%.+]] = arith.constant 3 : index
+// CHECK-DAG:       [[CST_2_:%.+]] = arith.constant 2 : index
+// CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : index
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
+// CHECK-DAG:       [[CST_1024_:%.+]] = arith.constant 1024 : index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_0_:%.+]]:5 = scf.for [[VAR_arg8_:%.+]] = [[CST_0_]] to [[CST_12_]] step [[CST_3_]] iter_args([[VAR_arg9_:%.+]] = [[CST_1_]], [[VAR_arg10_:%.+]] = [[CST_2_]], [[VAR_arg11_:%.+]] = [[CST_3_]], [[VAR_arg12_:%.+]] = [[CST_1024_]], [[VAR_arg13_:%.+]] = [[CST_1024_]]) -> (index, index, index, index, index) {
+// CHECK-DAG:         [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_arg13_]]{{.}}, sizes: [256], strides: {{.}}[[CST_1_]]{{.}} : memref<*xbf16> to memref<256xbf16, strided<[?], offset: ?>>
+// CHECK-DAG:         [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_arg12_]]{{.}}, sizes: [256], strides: {{.}}[[CST_1_]]{{.}} : memref<*xbf16> to memref<256xbf16, strided<[?], offset: ?>>
+// CHECK-DAG:         [[RES_:%.+]] = memref.alloc() : memref<256xbf16>
+// CHECK:             memref.copy [[VAR_reinterpret_cast_0_]], [[RES_]] : memref<256xbf16, strided<[?], offset: ?>> to memref<256xbf16>
+// CHECK:             [[VAR_1_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<256xbf16>
+// CHECK:             bufferization.materialize_in_destination [[VAR_1_]] in writable [[VAR_reinterpret_cast_]] : (tensor<256xbf16>, memref<256xbf16, strided<[?], offset: ?>>) -> ()
+// CHECK-DAG:         [[VAR_2_:%.+]] = arith.addi [[VAR_arg12_]], [[CST_3_]] : index
+// CHECK-DAG:         [[VAR_3_:%.+]] = arith.addi [[VAR_arg9_]], [[CST_3_]] : index
+// CHECK-DAG:         [[VAR_4_:%.+]] = arith.addi [[VAR_arg10_]], [[CST_3_]] : index
+// CHECK-DAG:         [[VAR_5_:%.+]] = arith.addi [[VAR_arg11_]], [[CST_3_]] : index
+// CHECK:             [[VAR_6_:%.+]] = arith.addi [[VAR_3_]], [[VAR_4_]] : index
+// CHECK:             [[VAR_7_:%.+]] = arith.addi [[VAR_6_]], [[VAR_5_]] : index
+// CHECK:             [[VAR_8_:%.+]] = arith.addi [[VAR_arg13_]], [[VAR_7_]] : index
+// CHECK:             scf.yield [[VAR_3_]], [[VAR_4_]], [[VAR_5_]], [[VAR_2_]], [[VAR_8_]] : index, index, index, index, index
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/addptr_for_more_init_args.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_for_more_init_args.mlir
@@ -10,12 +10,12 @@ module {
     %c2 = arith.constant 2 : index
     %c3 = arith.constant 3 : index
     %c12 = arith.constant 12 : index
-    %0 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<256x!tt.ptr<bf16>>
+    %0 = tt.splat %arg0 : !tt.ptr<bf16> -> tensor<256x!tt.ptr<bf16>>
     %1 = tt.make_range {end = 1280 : i32, start = 1024 : i32}:tensor<256xi32>
     // source: null, sizes: 256, offsets: 1024, strides: 1
     %2 = tt.addptr %0, %1 : tensor<256x!tt.ptr<bf16>>, tensor<256xi32>
     // source: arg0, sizes: 256, offsets: 1024, strides: 1
-    %3 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<256x!tt.ptr<bf16>>
+    %3 = tt.splat %arg1 : !tt.ptr<bf16> -> tensor<256x!tt.ptr<bf16>>
     %4 = tt.addptr %3, %1 : tensor<256x!tt.ptr<bf16>>, tensor<256xi32>
     // source: arg1, sizes: 256, offsets: 1024, strides: 1
     %_arg2, %_ptr_ld, %_arg3, %_ptr_st, %_arg4 = scf.for %i = %c0 to %c12 step %c3 iter_args(%arg2 = %c1, %ptr_ld = %2, %arg3 = %c2, %ptr_st = %4, %arg4 = %c3) -> (index, tensor<256x!tt.ptr<bf16>>, index, tensor<256x!tt.ptr<bf16>>, index) {
@@ -24,7 +24,7 @@ module {
         tt.store %ptr_st, %5 : tensor<256xbf16>
         // pointer updates
         %cast3 = arith.index_cast %c3 : index to i32
-        %6 = tt.splat %cast3 : (i32) -> tensor<256xi32>
+        %6 = tt.splat %cast3 : i32 -> tensor<256xi32>
         %ptr_ld_iter = tt.addptr %ptr_ld, %6 : tensor<256x!tt.ptr<bf16>>, tensor<256xi32>
         // source: arg0, sizes: 256, offsets: 1024 + i*3, strides: 1
         %arg2_iter = arith.addi %arg2, %c3 : index
@@ -33,7 +33,7 @@ module {
         %7 = arith.addi %arg2_iter, %arg3_iter : index
         %8 = arith.addi %7, %arg4_iter : index
         %cast8 = arith.index_cast %8 : index to i32
-        %9 = tt.splat %cast8 : (i32) -> tensor<256xi32>
+        %9 = tt.splat %cast8 : i32 -> tensor<256xi32>
         %ptr_st_iter = tt.addptr %ptr_st, %9 : tensor<256x!tt.ptr<bf16>>, tensor<256xi32>
         // source: arg1, sizes: 256, offsets: 1024 + loop-carry variable*i, strides: 1
         scf.yield %arg2_iter, %ptr_ld_iter, %arg3_iter, %ptr_st_iter, %arg4_iter : index, tensor<256x!tt.ptr<bf16>>, index, tensor<256x!tt.ptr<bf16>>, index

--- a/test/Conversion/StructuredToMemref/addptr_for_used_after_update.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_for_used_after_update.mlir
@@ -1,0 +1,101 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+module {
+  tt.func @kernel(
+    %arg0 : !tt.ptr<bf16>
+  )
+  {
+    %c0 = arith.constant 0 : index
+    %c12 = arith.constant 12 : index
+    %c3 = arith.constant 3 : index
+    %i_c3 = arith.constant 3 : i32
+    %0 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<256x!tt.ptr<bf16>>
+    %1 = tt.make_range {end = 1280 : i32, start = 1024 : i32}:tensor<256xi32>
+    // source: null, sizes: 256, offsets: 1024, strides: 1
+    %2 = tt.addptr %0, %1 : tensor<256x!tt.ptr<bf16>>, tensor<256xi32>
+    // source: arg0, sizes: 256, offsets: 1024, strides: 1
+    // gep operand is another gep' output, which is passed into the loop as varible, used after update
+    %_ptr = scf.for %i = %c0 to %c12 step %c3 iter_args(%ptr = %2) -> (tensor<256x!tt.ptr<bf16>>) {
+        // pointer updates
+        %4 = tt.splat %i_c3 : (i32) -> tensor<256xi32>
+        // sizes: 256, offsets: 3, strides: 0
+        %ptr_iter = tt.addptr %ptr, %4 : tensor<256x!tt.ptr<bf16>>, tensor<256xi32>
+        // source: arg0, sizes: 256, offsets: 1024 + i, strides: 1
+        // perform load
+        %3 = tt.load %ptr_iter {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<256xbf16>
+        tt.store %ptr_iter, %3 : tensor<256xbf16>
+        scf.yield %ptr_iter : tensor<256x!tt.ptr<bf16>>
+    }
+    // Expected output
+    // %offset_dim0 = arith.constant 1024                                                       <- insert instructions to initialize init arg(new)
+    // for iter_args (%offset_dim0_iter = %offset_dim0) {                                       <- replace varibles passed in as init arg (new)
+    //  %4 = %offset_dim0_iter + %c3                                                            <- replace gep of splat with add (already done)
+    //  %subview = memref.subview %arg0, [%4][256][4] : memref<> -> memref<>                    <- generate subview on getelementptr (already done)
+    //  ...
+    //  scf.yield %4                                                                            <- replace yielding an gep output with the corresponding dim variable (new)
+    // }
+    // TODO: examples below are not supported since scf.for does not support returning a tensor type
+    // Example 3, gep operand is a vector of i32, which is passed into the loop as variable, pointer updated using step, used after update
+    //%_ptr3 = scf.for %i = %c0 to %c12 step %c3 iter_args(%ptr = %1) -> (tensor<256xi32>) {
+    //    // offset update
+    //    %3 = tt.splat %c3 : (i32) -> tensor<256xi32>
+    //    %ptr_iter = arith.addi %3, %ptr : tensor<256xi32>
+    //    // generate pointer
+    //    %gep_ptr = tt.addptr %0, %ptr_iter : tensor<256x!tt.ptr<bf16>>
+    //    // perform load
+    //    %4 = tt.load %gep_ptr {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<256xbf16>
+    //    tt.store %gep_ptr, %4 : tensor<256xbf16>
+    //    scf.yield %ptr_iter : tensor<256xi32>
+    //}
+    // Expected output
+    // %offset_dim0 = arith.constant 1024                                                       <- insert instructions to initialize init arg(new)
+    // for iter_args (%offset_dim0_iter = %offset_dim0) {                                       <- replace varibles passed in as init arg (new)
+    //  %4 = %offset_dim0_iter + %c3                                                            <- replace gep of splat with add (already done)
+    //  %subview = memref.subview %arg0, [%offset_dim0_iter][256][4] : memref<> -> memref<>     <- generate subview on load (new)
+    //  ...
+    //  scf.yield %4                                                                            <- replace yielding an gep output with the corresponding dim variable (new)
+    // }
+    //// Example 4, gep operand is a vector of i32, which is passed into the loop as variable, pointer updated using step, used before update
+    //%_ptr4 = scf.for %i = %c0 to %c12 step %c3 iter_args(%ptr = %1) -> (tensor<256xi32>) {
+    //    // generate pointer
+    //    %gep_ptr = tt.addptr %0, %ptr : tensor<256x!tt.ptr<bf16>>
+    //
+    //    // perform load
+    //    %4 = tt.load %gep_ptr {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<256xbf16>
+    //    tt.store %gep_ptr, %4 : tensor<256xbf16>
+    //    // offset update
+    //    %3 = tt.splat %c3 : (i32) -> tensor<256xi32>
+    //    %ptr_iter = arith.addi %3, %ptr : tensor<256xi32>
+    //    scf.yield %ptr_iter : tensor<256xi32>
+    //}
+    // Expected output
+    // %offset_dim0 = arith.constant 1024                                                       <- insert instructions to initialize init arg(new)
+    // for iter_args (%offset_dim0_iter = %offset_dim0) {                                       <- replace varibles passed in as init arg (new)
+    //  %subview = memref.subview %arg0, [%offset_dim0_iter][256][4] : memref<> -> memref<>     <- generate subview on load (new)
+    //  ...
+    //  %4 = %offset_dim0_iter + %c3                                                            <- replace gep of splat with add (already done)
+    //  scf.yield %4                                                                            <- replace yielding an gep output with the corresponding dim variable (new)
+    // }
+    tt.return
+  }
+}
+// mlir2FileCheck.py
+// CHECK-LABEL:  func.func @kernel
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: i32, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_3_:%.+]] = arith.constant 3 : index
+// CHECK-DAG:       [[CST_12_:%.+]] = arith.constant 12 : index
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
+// CHECK-DAG:       [[CST_1024_:%.+]] = arith.constant 1024 : index
+// CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_0_:%.+]] = scf.for [[VAR_arg7_:%.+]] = [[CST_0_]] to [[CST_12_]] step [[CST_3_]] iter_args([[VAR_arg8_:%.+]] = [[CST_1024_]]) -> (index) {
+// CHECK-DAG:         [[VAR_1_:%.+]] = arith.addi [[VAR_arg8_]], [[CST_3_]] : index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [256], strides: {{.}}[[CST_1_]]{{.}} : memref<*xbf16> to memref<256xbf16, strided<[?], offset: ?>>
+// CHECK-DAG:         [[RES_:%.+]] = memref.alloc() : memref<256xbf16>
+// CHECK:             memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<256xbf16, strided<[?], offset: ?>> to memref<256xbf16>
+// CHECK:             [[VAR_2_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<256xbf16>
+// CHECK:             bufferization.materialize_in_destination [[VAR_2_]] in writable [[VAR_reinterpret_cast_]] : (tensor<256xbf16>, memref<256xbf16, strided<[?], offset: ?>>) -> ()
+// CHECK:             scf.yield [[VAR_1_]] : index
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/addptr_for_used_after_update.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_for_used_after_update.mlir
@@ -8,7 +8,7 @@ module {
     %c12 = arith.constant 12 : index
     %c3 = arith.constant 3 : index
     %i_c3 = arith.constant 3 : i32
-    %0 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<256x!tt.ptr<bf16>>
+    %0 = tt.splat %arg0 : !tt.ptr<bf16> -> tensor<256x!tt.ptr<bf16>>
     %1 = tt.make_range {end = 1280 : i32, start = 1024 : i32}:tensor<256xi32>
     // source: null, sizes: 256, offsets: 1024, strides: 1
     %2 = tt.addptr %0, %1 : tensor<256x!tt.ptr<bf16>>, tensor<256xi32>
@@ -16,7 +16,7 @@ module {
     // gep operand is another gep' output, which is passed into the loop as varible, used after update
     %_ptr = scf.for %i = %c0 to %c12 step %c3 iter_args(%ptr = %2) -> (tensor<256x!tt.ptr<bf16>>) {
         // pointer updates
-        %4 = tt.splat %i_c3 : (i32) -> tensor<256xi32>
+        %4 = tt.splat %i_c3 : i32 -> tensor<256xi32>
         // sizes: 256, offsets: 3, strides: 0
         %ptr_iter = tt.addptr %ptr, %4 : tensor<256x!tt.ptr<bf16>>, tensor<256xi32>
         // source: arg0, sizes: 256, offsets: 1024 + i, strides: 1
@@ -37,7 +37,7 @@ module {
     // Example 3, gep operand is a vector of i32, which is passed into the loop as variable, pointer updated using step, used after update
     //%_ptr3 = scf.for %i = %c0 to %c12 step %c3 iter_args(%ptr = %1) -> (tensor<256xi32>) {
     //    // offset update
-    //    %3 = tt.splat %c3 : (i32) -> tensor<256xi32>
+    //    %3 = tt.splat %c3 : i32 -> tensor<256xi32>
     //    %ptr_iter = arith.addi %3, %ptr : tensor<256xi32>
     //    // generate pointer
     //    %gep_ptr = tt.addptr %0, %ptr_iter : tensor<256x!tt.ptr<bf16>>
@@ -63,7 +63,7 @@ module {
     //    %4 = tt.load %gep_ptr {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<256xbf16>
     //    tt.store %gep_ptr, %4 : tensor<256xbf16>
     //    // offset update
-    //    %3 = tt.splat %c3 : (i32) -> tensor<256xi32>
+    //    %3 = tt.splat %c3 : i32 -> tensor<256xi32>
     //    %ptr_iter = arith.addi %3, %ptr : tensor<256xi32>
     //    scf.yield %ptr_iter : tensor<256xi32>
     //}

--- a/test/Conversion/StructuredToMemref/addptr_for_used_before_update.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_for_used_before_update.mlir
@@ -8,7 +8,7 @@ module {
     %c12 = arith.constant 12 : index
     %c3 = arith.constant 3 : index
     %i_c3 = arith.constant 3 : i32
-    %0 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<256x!tt.ptr<bf16>>
+    %0 = tt.splat %arg0 : !tt.ptr<bf16> -> tensor<256x!tt.ptr<bf16>>
     %1 = tt.make_range {end = 1280 : i32, start = 1024 : i32}:tensor<256xi32>
     // source: null, sizes: 256, offsets: 1024, strides: 1
     %2 = tt.addptr %0, %1 : tensor<256x!tt.ptr<bf16>>, tensor<256xi32>
@@ -19,7 +19,7 @@ module {
         %3 = tt.load %ptr {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<256xbf16>
         tt.store %ptr, %3 : tensor<256xbf16>
         // pointer updates
-        %4 = tt.splat %i_c3 : (i32) -> tensor<256xi32>
+        %4 = tt.splat %i_c3 : i32 -> tensor<256xi32>
         %ptr_iter = tt.addptr %ptr, %4 : tensor<256x!tt.ptr<bf16>>, tensor<256xi32>
         scf.yield %ptr_iter : tensor<256x!tt.ptr<bf16>>
     }

--- a/test/Conversion/StructuredToMemref/addptr_for_used_before_update.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_for_used_before_update.mlir
@@ -1,0 +1,56 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+module {
+  tt.func @kernel(
+    %arg0 : !tt.ptr<bf16>
+  )
+  {
+    %c0 = arith.constant 0 : index
+    %c12 = arith.constant 12 : index
+    %c3 = arith.constant 3 : index
+    %i_c3 = arith.constant 3 : i32
+    %0 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<256x!tt.ptr<bf16>>
+    %1 = tt.make_range {end = 1280 : i32, start = 1024 : i32}:tensor<256xi32>
+    // source: null, sizes: 256, offsets: 1024, strides: 1
+    %2 = tt.addptr %0, %1 : tensor<256x!tt.ptr<bf16>>, tensor<256xi32>
+    // source: arg0, sizes: 256, offsets: 1024, strides: 1
+    // Example 2, gep operand is another gep's output, which is passed into the loop as varible, used before update
+    %_ptr2 = scf.for %i = %c0 to %c12 step %c3 iter_args(%ptr = %2) -> (tensor<256x!tt.ptr<bf16>>) {
+        // perform load
+        %3 = tt.load %ptr {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<256xbf16>
+        tt.store %ptr, %3 : tensor<256xbf16>
+        // pointer updates
+        %4 = tt.splat %i_c3 : (i32) -> tensor<256xi32>
+        %ptr_iter = tt.addptr %ptr, %4 : tensor<256x!tt.ptr<bf16>>, tensor<256xi32>
+        scf.yield %ptr_iter : tensor<256x!tt.ptr<bf16>>
+    }
+    // Expected output
+    // %offset_dim0 = arith.constant 1024                                                       <- insert instructions to initialize init arg(new)
+    // for iter_args (%offset_dim0_iter = %offset_dim0) {                                       <- replace varibles passed in as init arg (new)
+    //  %subview = memref.subview %arg0, [%offset_dim0_iter][256][4] : memref<> -> memref<>     <- generate subview on load (new)
+    //  ...
+    //  %4 = %offset_dim0_iter + %c3                                                            <- replace gep of splat with add (already done)
+    //  scf.yield %4                                                                            <- replace yielding an gep output with the corresponding dim variable (new)
+    // }
+    tt.return
+  }
+}
+// mlir2FileCheck.py
+// CHECK-LABEL:  func.func @kernel
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: i32, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_3_:%.+]] = arith.constant 3 : index
+// CHECK-DAG:       [[CST_12_:%.+]] = arith.constant 12 : index
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
+// CHECK-DAG:       [[CST_1024_:%.+]] = arith.constant 1024 : index
+// CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_0_:%.+]] = scf.for [[VAR_arg7_:%.+]] = [[CST_0_]] to [[CST_12_]] step [[CST_3_]] iter_args([[VAR_arg8_:%.+]] = [[CST_1024_]]) -> (index) {
+// CHECK-DAG:         [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_arg8_]]{{.}}, sizes: [256], strides: {{.}}[[CST_1_]]{{.}} : memref<*xbf16> to memref<256xbf16, strided<[?], offset: ?>>
+// CHECK-DAG:         [[RES_:%.+]] = memref.alloc() : memref<256xbf16>
+// CHECK:             memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<256xbf16, strided<[?], offset: ?>> to memref<256xbf16>
+// CHECK:             [[VAR_1_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<256xbf16>
+// CHECK:             bufferization.materialize_in_destination [[VAR_1_]] in writable [[VAR_reinterpret_cast_]] : (tensor<256xbf16>, memref<256xbf16, strided<[?], offset: ?>>) -> ()
+// CHECK:             [[VAR_2_:%.+]] = arith.addi [[VAR_arg8_]], [[CST_3_]] : index
+// CHECK:             scf.yield [[VAR_2_]] : index
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/addptr_loopback.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_loopback.mlir
@@ -8,29 +8,29 @@ module {
   {
   %0 = tt.make_range {end = 4 : i32, start = 0 : i32}:tensor<4xi32>
   // offset = 0, size = 4, stride = 1
-  %1 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<4xi32>) -> tensor<4x1xi32>
+  %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<4xi32> -> tensor<4x1xi32>
   // offset = [0,0], size = [4,1], stride = [1,0]
-  %2 = tt.broadcast %1 : (tensor<4x1xi32>) -> tensor<4x256xi32>
+  %2 = tt.broadcast %1 : tensor<4x1xi32> -> tensor<4x256xi32>
   // offset = [0,0], size = [4,256], stride = [1,0]
-  %arg2splat = tt.splat %arg2 : (i32) -> tensor<4x256xi32>
+  %arg2splat = tt.splat %arg2 : i32 -> tensor<4x256xi32>
   %offset2 = arith.addi %2, %arg2splat : tensor<4x256xi32>
   // offset = [%arg2,0], size = [4,256], stride = [1,0]
   %3 = tt.make_range {end = 256 : i32, start = 0 : i32}:tensor<256xi32>
   // offset = 0, size = 256, stride = 1
-  %4 = tt.expand_dims %3 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
+  %4 = tt.expand_dims %3 {axis = 0 : i32} : tensor<256xi32> -> tensor<1x256xi32>
   // offset = [0,0], size = [1,256], stride = [0,1]
-  %5 = tt.broadcast %4 : (tensor<1x256xi32>) -> tensor<4x256xi32>
+  %5 = tt.broadcast %4 : tensor<1x256xi32> -> tensor<4x256xi32>
   // offset = [0,0], size = [4,256], stride = [0,1]
   %c6 = arith.constant 6 : i32
-  %splat6 = tt.splat %c6 : (i32) -> tensor<4x256xi32>
+  %splat6 = tt.splat %c6 : i32 -> tensor<4x256xi32>
   %scale5 = arith.muli %5, %splat6 : tensor<4x256xi32>
   // offset = [0,0], size = [4,256], stride = [0,6]
   %7 = arith.addi %offset2, %scale5: tensor<4x256xi32>
   // offset = [%arg2, 0], size = [4, 256], stride = [1, 6]
-  %8 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<4x256x!tt.ptr<bf16>>
+  %8 = tt.splat %arg0 : !tt.ptr<bf16> -> tensor<4x256x!tt.ptr<bf16>>
   %9 = tt.addptr %8, %7 : tensor<4x256x!tt.ptr<bf16>>, tensor<4x256xi32>
   // source: arg0, offset = [%arg2, 0], size = [4, 256], stride = [1, 6]
-  %10 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<4x256x!tt.ptr<bf16>>
+  %10 = tt.splat %arg1 : !tt.ptr<bf16> -> tensor<4x256x!tt.ptr<bf16>>
   %11 = tt.addptr %10, %7 : tensor<4x256x!tt.ptr<bf16>>, tensor<4x256xi32>
   // source: arg1, offset = [%arg2, 0], size = [4, 256], stride = [1, 6]
   %12 = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<4x256xbf16>

--- a/test/Conversion/StructuredToMemref/addptr_loopback.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_loopback.mlir
@@ -1,0 +1,56 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+module {
+  tt.func @kernel(
+  %arg0 : !tt.ptr<bf16>,
+  %arg1 : !tt.ptr<bf16>,
+  %arg2 : i32
+  )
+  {
+  %0 = tt.make_range {end = 4 : i32, start = 0 : i32}:tensor<4xi32>
+  // offset = 0, size = 4, stride = 1
+  %1 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<4xi32>) -> tensor<4x1xi32>
+  // offset = [0,0], size = [4,1], stride = [1,0]
+  %2 = tt.broadcast %1 : (tensor<4x1xi32>) -> tensor<4x256xi32>
+  // offset = [0,0], size = [4,256], stride = [1,0]
+  %arg2splat = tt.splat %arg2 : (i32) -> tensor<4x256xi32>
+  %offset2 = arith.addi %2, %arg2splat : tensor<4x256xi32>
+  // offset = [%arg2,0], size = [4,256], stride = [1,0]
+  %3 = tt.make_range {end = 256 : i32, start = 0 : i32}:tensor<256xi32>
+  // offset = 0, size = 256, stride = 1
+  %4 = tt.expand_dims %3 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
+  // offset = [0,0], size = [1,256], stride = [0,1]
+  %5 = tt.broadcast %4 : (tensor<1x256xi32>) -> tensor<4x256xi32>
+  // offset = [0,0], size = [4,256], stride = [0,1]
+  %c6 = arith.constant 6 : i32
+  %splat6 = tt.splat %c6 : (i32) -> tensor<4x256xi32>
+  %scale5 = arith.muli %5, %splat6 : tensor<4x256xi32>
+  // offset = [0,0], size = [4,256], stride = [0,6]
+  %7 = arith.addi %offset2, %scale5: tensor<4x256xi32>
+  // offset = [%arg2, 0], size = [4, 256], stride = [1, 6]
+  %8 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<4x256x!tt.ptr<bf16>>
+  %9 = tt.addptr %8, %7 : tensor<4x256x!tt.ptr<bf16>>, tensor<4x256xi32>
+  // source: arg0, offset = [%arg2, 0], size = [4, 256], stride = [1, 6]
+  %10 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<4x256x!tt.ptr<bf16>>
+  %11 = tt.addptr %10, %7 : tensor<4x256x!tt.ptr<bf16>>, tensor<4x256xi32>
+  // source: arg1, offset = [%arg2, 0], size = [4, 256], stride = [1, 6]
+  %12 = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<4x256xbf16>
+  tt.store %11, %12 : tensor<4x256xbf16>
+  tt.return
+  }
+}
+// mlir2FileCheck.py
+// CHECK-LABEL:  func.func @kernel
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: memref<*xbf16>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_6_:%.+]] = arith.constant 6 : index
+// CHECK-DAG:       [[VAR_0_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_0_]]{{.}}, sizes: [4, 256], strides: [1, [[CST_6_]]{{.}} : memref<*xbf16> to memref<4x256xbf16, strided<[1, ?], offset: ?>>
+// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [4, 256], strides: [1, [[CST_6_]]{{.}} : memref<*xbf16> to memref<4x256xbf16, strided<[1, ?], offset: ?>>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<4x256xbf16>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<4x256xbf16, strided<[1, ?], offset: ?>> to memref<4x256xbf16>
+// CHECK:           [[VAR_2_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<4x256xbf16>
+// CHECK:           bufferization.materialize_in_destination [[VAR_2_]] in writable [[VAR_reinterpret_cast_0_]] : (tensor<4x256xbf16>, memref<4x256xbf16, strided<[1, ?], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/addptr_mul_const_const.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_mul_const_const.mlir
@@ -1,0 +1,50 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+module {
+  tt.func @kernel(
+    %arg0 : !tt.ptr<bf16>,
+    %arg1 : !tt.ptr<bf16>,
+    %arg2 : i32
+  )
+  {
+    %0 = tt.get_program_id x : i32
+    %1 = tt.make_range {end = 1024 : i32, start = 0 : i32}:tensor<1024xi32>
+    %2 = tt.splat %0 : (i32) -> tensor<1024xi32>
+    %3 = arith.addi %2, %1 : tensor<1024xi32>
+    //%3: splat(%0) + range(0, 1024)
+    //%3: offset = %0, size = 1024, stride = 1
+    // vector and scalar are both constant
+    %4 = tt.make_range {end = 3072 : i32, start = 2048 : i32}:tensor<1024xi32>
+    %c10 = arith.constant 10 : i32
+    %5 = tt.splat %c10 : (i32) -> tensor<1024xi32>
+    %6 = arith.muli %5, %4 : tensor<1024xi32>
+    //%6: splat(%c10)*range(2048, 4096);
+    //%6: offset = %c10*2048, size = 1024, stride = %c10*1
+    %7 = arith.addi %3, %6 : tensor<1024xi32>
+    //%7: offset = %c10*2048 + %0, size = 1024, stride = %c10*1+1
+    %8 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<1024x!tt.ptr<bf16>>
+    %9 = tt.addptr %8, %7 : tensor<1024x!tt.ptr<bf16>>, tensor<1024xi32>
+    //source=%arg0 offset = %c10*2048 + pid0, size = 1024, stride = %c10*1+1
+    %10 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<1024x!tt.ptr<bf16>>
+    %11 = tt.addptr %10, %3 : tensor<1024x!tt.ptr<bf16>>, tensor<1024xi32>
+    //source=%arg1, offset = pid0, size = 1024, stride = 1
+    %16 = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xbf16>
+    tt.store %11, %16 : tensor<1024xbf16>
+    tt.return
+  }
+}
+// mlir2FileCheck.py
+// CHECK-LABEL:  func.func @kernel
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: memref<*xbf16>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_20480_:%.+]] = arith.constant 20480 : index
+// CHECK-DAG:       [[CST_11_:%.+]] = arith.constant 11 : index
+// CHECK-DAG:       [[VAR_0_:%.+]] = arith.index_cast [[PARAM_6_]] : i32 to index
+// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[PARAM_6_]] : i32 to index
+// CHECK:           [[VAR_2_:%.+]] = arith.addi [[VAR_1_]], [[CST_20480_]] : index
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [1024], strides: {{.}}[[CST_11_]]{{.}} : memref<*xbf16> to memref<1024xbf16, strided<[?], offset: ?>>
+// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_0_]]{{.}}, sizes: [1024], strides: [1] : memref<*xbf16> to memref<1024xbf16, strided<[1], offset: ?>>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<1024xbf16>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<1024xbf16, strided<[?], offset: ?>> to memref<1024xbf16>
+// CHECK:           [[VAR_3_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<1024xbf16>
+// CHECK:           bufferization.materialize_in_destination [[VAR_3_]] in writable [[VAR_reinterpret_cast_0_]] : (tensor<1024xbf16>, memref<1024xbf16, strided<[1], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/addptr_mul_const_const.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_mul_const_const.mlir
@@ -8,23 +8,23 @@ module {
   {
     %0 = tt.get_program_id x : i32
     %1 = tt.make_range {end = 1024 : i32, start = 0 : i32}:tensor<1024xi32>
-    %2 = tt.splat %0 : (i32) -> tensor<1024xi32>
+    %2 = tt.splat %0 : i32 -> tensor<1024xi32>
     %3 = arith.addi %2, %1 : tensor<1024xi32>
     //%3: splat(%0) + range(0, 1024)
     //%3: offset = %0, size = 1024, stride = 1
     // vector and scalar are both constant
     %4 = tt.make_range {end = 3072 : i32, start = 2048 : i32}:tensor<1024xi32>
     %c10 = arith.constant 10 : i32
-    %5 = tt.splat %c10 : (i32) -> tensor<1024xi32>
+    %5 = tt.splat %c10 : i32 -> tensor<1024xi32>
     %6 = arith.muli %5, %4 : tensor<1024xi32>
     //%6: splat(%c10)*range(2048, 4096);
     //%6: offset = %c10*2048, size = 1024, stride = %c10*1
     %7 = arith.addi %3, %6 : tensor<1024xi32>
     //%7: offset = %c10*2048 + %0, size = 1024, stride = %c10*1+1
-    %8 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<1024x!tt.ptr<bf16>>
+    %8 = tt.splat %arg0 : !tt.ptr<bf16> -> tensor<1024x!tt.ptr<bf16>>
     %9 = tt.addptr %8, %7 : tensor<1024x!tt.ptr<bf16>>, tensor<1024xi32>
     //source=%arg0 offset = %c10*2048 + pid0, size = 1024, stride = %c10*1+1
-    %10 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<1024x!tt.ptr<bf16>>
+    %10 = tt.splat %arg1 : !tt.ptr<bf16> -> tensor<1024x!tt.ptr<bf16>>
     %11 = tt.addptr %10, %3 : tensor<1024x!tt.ptr<bf16>>, tensor<1024xi32>
     //source=%arg1, offset = pid0, size = 1024, stride = 1
     %16 = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xbf16>

--- a/test/Conversion/StructuredToMemref/addptr_mul_value_const.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_mul_value_const.mlir
@@ -8,22 +8,22 @@ module {
   {
     %0 = tt.get_program_id x : i32
     %1 = tt.make_range {end = 1024 : i32, start = 0 : i32}:tensor<1024xi32>
-    %2 = tt.splat %0 : (i32) -> tensor<1024xi32>
+    %2 = tt.splat %0 : i32 -> tensor<1024xi32>
     %3 = arith.addi %2, %1 : tensor<1024xi32>
     //%3: splat(%0) + range(0, 1024)
     //%3: offset = %0, size = 1024, stride = 1
     // vector is constant, scalar is value
     %4 = tt.make_range {end = 3072 : i32, start = 2048 : i32}:tensor<1024xi32>
-    %5 = tt.splat %arg2 : (i32) -> tensor<1024xi32>
+    %5 = tt.splat %arg2 : i32 -> tensor<1024xi32>
     %6 = arith.muli %5, %4 : tensor<1024xi32>
     //%6: splat(%arg2)*range(2048, 3072);
     //%6: offset = %arg2*2048, size = 1024, stride = %arg2*1
     %7 = arith.addi %3, %6 : tensor<1024xi32>
     //%7: offset = %arg2*2048 + %0, size = 1024, stride = %arg2*1+1
-    %8 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<1024x!tt.ptr<bf16>>
+    %8 = tt.splat %arg0 : !tt.ptr<bf16> -> tensor<1024x!tt.ptr<bf16>>
     %9 = tt.addptr %8, %7 : tensor<1024x!tt.ptr<bf16>>, tensor<1024xi32>
     //source=%arg0: offset = %arg2*2048 + pid0, size = 1024, stride = %arg2*1+1
-    %10 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<1024x!tt.ptr<bf16>>
+    %10 = tt.splat %arg1 : !tt.ptr<bf16> -> tensor<1024x!tt.ptr<bf16>>
     %11 = tt.addptr %10, %3 : tensor<1024x!tt.ptr<bf16>>, tensor<1024xi32>
     //source=%arg1: offset = pid0, size = 1024, stride = 1
     %16 = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xbf16>

--- a/test/Conversion/StructuredToMemref/addptr_mul_value_const.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_mul_value_const.mlir
@@ -1,0 +1,53 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+module {
+  tt.func @kernel(
+    %arg0 : !tt.ptr<bf16>,
+    %arg1 : !tt.ptr<bf16>,
+    %arg2 : i32
+  )
+  {
+    %0 = tt.get_program_id x : i32
+    %1 = tt.make_range {end = 1024 : i32, start = 0 : i32}:tensor<1024xi32>
+    %2 = tt.splat %0 : (i32) -> tensor<1024xi32>
+    %3 = arith.addi %2, %1 : tensor<1024xi32>
+    //%3: splat(%0) + range(0, 1024)
+    //%3: offset = %0, size = 1024, stride = 1
+    // vector is constant, scalar is value
+    %4 = tt.make_range {end = 3072 : i32, start = 2048 : i32}:tensor<1024xi32>
+    %5 = tt.splat %arg2 : (i32) -> tensor<1024xi32>
+    %6 = arith.muli %5, %4 : tensor<1024xi32>
+    //%6: splat(%arg2)*range(2048, 3072);
+    //%6: offset = %arg2*2048, size = 1024, stride = %arg2*1
+    %7 = arith.addi %3, %6 : tensor<1024xi32>
+    //%7: offset = %arg2*2048 + %0, size = 1024, stride = %arg2*1+1
+    %8 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<1024x!tt.ptr<bf16>>
+    %9 = tt.addptr %8, %7 : tensor<1024x!tt.ptr<bf16>>, tensor<1024xi32>
+    //source=%arg0: offset = %arg2*2048 + pid0, size = 1024, stride = %arg2*1+1
+    %10 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<1024x!tt.ptr<bf16>>
+    %11 = tt.addptr %10, %3 : tensor<1024x!tt.ptr<bf16>>, tensor<1024xi32>
+    //source=%arg1: offset = pid0, size = 1024, stride = 1
+    %16 = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xbf16>
+    tt.store %11, %16 : tensor<1024xbf16>
+    tt.return
+  }
+}
+// mlir2FileCheck.py
+// CHECK-LABEL:  func.func @kernel
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: memref<*xbf16>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_2048_:%.+]] = arith.constant 2048 : index
+// CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : index
+// CHECK-DAG:       [[VAR_0_:%.+]] = arith.index_cast [[PARAM_6_]] : i32 to index
+// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[PARAM_6_]] : i32 to index
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_3_:%.+]] = arith.muli [[VAR_2_]], [[CST_2048_]] : index
+// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_1_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.addi [[VAR_2_]], [[CST_1_]] : index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_4_]]{{.}}, sizes: [1024], strides: {{.}}[[VAR_5_]]{{.}} : memref<*xbf16> to memref<1024xbf16, strided<[?], offset: ?>>
+// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_0_]]{{.}}, sizes: [1024], strides: [1] : memref<*xbf16> to memref<1024xbf16, strided<[1], offset: ?>>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<1024xbf16>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<1024xbf16, strided<[?], offset: ?>> to memref<1024xbf16>
+// CHECK:           [[VAR_6_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<1024xbf16>
+// CHECK:           bufferization.materialize_in_destination [[VAR_6_]] in writable [[VAR_reinterpret_cast_0_]] : (tensor<1024xbf16>, memref<1024xbf16, strided<[1], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/addptr_nested.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_nested.mlir
@@ -1,0 +1,72 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+module {
+  tt.func @kernel(
+    %arg0 : !tt.ptr<bf16>,
+    %arg1 : i32
+  )
+  {
+    %0 = tt.make_range {end = 4 : i32, start = 0 : i32}:tensor<4xi32>
+    // offset = 0, size = 4, stride = 1
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<4xi32>) -> tensor<4x1xi32>
+    // offset = [0,0], size = [4,1], stride = [1,0]
+    %2 = tt.broadcast %1 : (tensor<4x1xi32>) -> tensor<4x256xi32>
+    // offset = [0,0], size = [4,256], stride = [1,0]
+    %arg1splat = tt.splat %arg1 : (i32) -> tensor<4x256xi32>
+    %offset3 = arith.addi %2, %arg1splat : tensor<4x256xi32>
+    // offset = [%arg1,0], size = [4,256], stride = [1,0]
+    %3 = tt.make_range {end = 256 : i32, start = 0 : i32}:tensor<256xi32>
+    // offset = 0, size = 256, stride = 1
+    %4 = tt.expand_dims %3 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
+    // offset = [0,0], size = [1,256], stride = [0,1]
+    %5 = tt.broadcast %4 : (tensor<1x256xi32>) -> tensor<4x256xi32>
+    // offset = [0,0], size = [4,256], stride = [0,1]
+    %6 = arith.constant 5 : i32
+    %splat6 = tt.splat %6 : (i32) -> tensor<4x256xi32>
+    %scale5 = arith.muli %5, %splat6 : tensor<4x256xi32>
+    // offset = [0,0], size = [4,256], stride = [0,5]
+    %7 = arith.addi %offset3, %scale5: tensor<4x256xi32>
+    // offset = [%arg1, 0], size = [4, 256], stride = [1, 5]
+    %8 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<4x256x!tt.ptr<bf16>>
+    %9 = tt.addptr %8, %7 : tensor<4x256x!tt.ptr<bf16>>, tensor<4x256xi32>
+    // source: %arg0, offset = [%arg1, 0], size = [4, 256], stride = [1, 5]
+    %10 = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<4x256xbf16>
+    %12 = tt.addptr %9, %7 : tensor<4x256x!tt.ptr<bf16>>, tensor<4x256xi32>
+    // source: %arg0, offset = [%arg1+%arg1, 0], size = [4, 256], stride = [2, 10]
+    %13 = tt.load %12 {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<4x256xbf16>
+    %14 = arith.addf %10, %13 : tensor<4x256xbf16>
+    %16 = tt.addptr %12, %7 : tensor<4x256x!tt.ptr<bf16>>, tensor<4x256xi32>
+    // source: %arg0, offset = [%arg1+%arg1+%arg1, 0], size = [4, 256], stride = [3, 15]
+    tt.store %16, %14 : tensor<4x256xbf16>
+    tt.return
+  }
+}
+// mlir2FileCheck.py
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK-LABEL:  func.func @kernel
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: i32, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_5_:%.+]] = arith.constant 5 : index
+// CHECK-DAG:       [[CST_10_:%.+]] = arith.constant 10 : index
+// CHECK-DAG:       [[CST_15_:%.+]] = arith.constant 15 : index
+// CHECK-DAG:       [[VAR_0_:%.+]] = arith.index_cast [[PARAM_1_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_0_]]{{.}}, sizes: [4, 256], strides: [1, [[CST_5_]]{{.}} : memref<*xbf16> to memref<4x256xbf16, strided<[1, ?], offset: ?>>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<4x256xbf16>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<4x256xbf16, strided<[1, ?], offset: ?>> to memref<4x256xbf16>
+// CHECK-DAG:       [[VAR_1_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<4x256xbf16>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[PARAM_1_]] : i32 to index
+// CHECK:           [[VAR_3_:%.+]] = arith.addi [[VAR_0_]], [[VAR_2_]] : index
+// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_3_]]{{.}}, sizes: [4, 256], strides: [2, [[CST_10_]]{{.}} : memref<*xbf16> to memref<4x256xbf16, strided<[2, ?], offset: ?>>
+// CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc() : memref<4x256xbf16>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_0_]], [[RES_1_]] : memref<4x256xbf16, strided<[2, ?], offset: ?>> to memref<4x256xbf16>
+// CHECK:           [[VAR_4_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<4x256xbf16>
+// CHECK:           [[VAR_5_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_1_]], [[VAR_4_]] : tensor<4x256xbf16>, tensor<4x256xbf16>) outs([[VAR_1_]] : tensor<4x256xbf16>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: bf16, [[IN_1_:%.+]]: bf16, [[IN_2_:%.+]]: bf16):
+// CHECK:             [[VAR_8_:%.+]] = arith.addf [[IN_0_]], [[IN_1_]] : bf16
+// CHECK:             linalg.yield [[VAR_8_]] : bf16
+// CHECK:           } -> tensor<4x256xbf16>
+// CHECK:           [[VAR_6_:%.+]] = arith.index_cast [[PARAM_1_]] : i32 to index
+// CHECK:           [[VAR_7_:%.+]] = arith.addi [[VAR_3_]], [[VAR_6_]] : index
+// CHECK:           [[VAR_reinterpret_cast_2_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_7_]]{{.}}, sizes: [4, 256], strides: [3, [[CST_15_]]{{.}} : memref<*xbf16> to memref<4x256xbf16, strided<[3, ?], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_5_]] in writable [[VAR_reinterpret_cast_2_]] : (tensor<4x256xbf16>, memref<4x256xbf16, strided<[3, ?], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/addptr_nested.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_nested.mlir
@@ -7,26 +7,26 @@ module {
   {
     %0 = tt.make_range {end = 4 : i32, start = 0 : i32}:tensor<4xi32>
     // offset = 0, size = 4, stride = 1
-    %1 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<4xi32>) -> tensor<4x1xi32>
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<4xi32> -> tensor<4x1xi32>
     // offset = [0,0], size = [4,1], stride = [1,0]
-    %2 = tt.broadcast %1 : (tensor<4x1xi32>) -> tensor<4x256xi32>
+    %2 = tt.broadcast %1 : tensor<4x1xi32> -> tensor<4x256xi32>
     // offset = [0,0], size = [4,256], stride = [1,0]
-    %arg1splat = tt.splat %arg1 : (i32) -> tensor<4x256xi32>
+    %arg1splat = tt.splat %arg1 : i32 -> tensor<4x256xi32>
     %offset3 = arith.addi %2, %arg1splat : tensor<4x256xi32>
     // offset = [%arg1,0], size = [4,256], stride = [1,0]
     %3 = tt.make_range {end = 256 : i32, start = 0 : i32}:tensor<256xi32>
     // offset = 0, size = 256, stride = 1
-    %4 = tt.expand_dims %3 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
+    %4 = tt.expand_dims %3 {axis = 0 : i32} : tensor<256xi32> -> tensor<1x256xi32>
     // offset = [0,0], size = [1,256], stride = [0,1]
-    %5 = tt.broadcast %4 : (tensor<1x256xi32>) -> tensor<4x256xi32>
+    %5 = tt.broadcast %4 : tensor<1x256xi32> -> tensor<4x256xi32>
     // offset = [0,0], size = [4,256], stride = [0,1]
     %6 = arith.constant 5 : i32
-    %splat6 = tt.splat %6 : (i32) -> tensor<4x256xi32>
+    %splat6 = tt.splat %6 : i32 -> tensor<4x256xi32>
     %scale5 = arith.muli %5, %splat6 : tensor<4x256xi32>
     // offset = [0,0], size = [4,256], stride = [0,5]
     %7 = arith.addi %offset3, %scale5: tensor<4x256xi32>
     // offset = [%arg1, 0], size = [4, 256], stride = [1, 5]
-    %8 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<4x256x!tt.ptr<bf16>>
+    %8 = tt.splat %arg0 : !tt.ptr<bf16> -> tensor<4x256x!tt.ptr<bf16>>
     %9 = tt.addptr %8, %7 : tensor<4x256x!tt.ptr<bf16>>, tensor<4x256xi32>
     // source: %arg0, offset = [%arg1, 0], size = [4, 256], stride = [1, 5]
     %10 = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<4x256xbf16>

--- a/test/Conversion/StructuredToMemref/addptr_reshape_broadcast.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_reshape_broadcast.mlir
@@ -1,0 +1,46 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// TODO: expand this example to 3D
+module {
+  tt.func @kernel(
+  %arg0 : !tt.ptr<bf16>,
+  %arg1 : !tt.ptr<bf16>
+  )
+  {
+  %0 = tt.make_range {end = 768 : i32, start = 512 : i32}:tensor<256xi32>
+  // offset = [512] size = 256, stride = 1
+  %1 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<256xi32>) -> tensor<256x1xi32>
+  // offset = [512,0], size = [256,1], stride = [1,0]
+  %2 = tt.broadcast %1 : (tensor<256x1xi32>) -> tensor<256x128xi32>
+  // offset = [512,0], size = [256,128], stride = [1,0]
+  %5 = tt.make_range {end = 1152 : i32, start = 1024 : i32}:tensor<128xi32>
+  // offset = 1024, size = 128, stride = 1
+  %6 = tt.expand_dims %5 {axis = 0 : i32} : (tensor<128xi32>) -> tensor<1x128xi32>
+  // offset = [0,1024], size = [1,128], stride = [0,1]
+  %7 = tt.broadcast %6 : (tensor<1x128xi32>) -> tensor<256x128xi32>
+  // offset = [0,1024], size = [256,128], stride = [0,1]
+  %c6 = arith.constant 6 : i32
+  %splat6 = tt.splat %c6 : (i32) -> tensor<256x128xi32>
+  %scale7 = arith.muli %7, %splat6 : tensor<256x128xi32>
+  // offset = [0,6144], size = [256,128], stride = [0,6]
+  %14 = arith.addi %2, %scale7 : tensor<256x128xi32>
+  // offset = [512,6144], size = [256,128], stride = [1,6]
+  %17 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<256x128x!tt.ptr<bf16>>
+  %18 = tt.addptr %17, %14 : tensor<256x128x!tt.ptr<bf16>>, tensor<256x128xi32>
+  %19 = tt.load %18 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<256x128xbf16>
+  tt.store %18, %19 : tensor<256x128xbf16>
+  tt.return
+  }
+}
+// mlir2FileCheck.py
+// CHECK-LABEL:  func.func @kernel
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: memref<*xbf16>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_6_:%.+]] = arith.constant 6 : index
+// CHECK-DAG:       [[CST_6656_:%.+]] = arith.constant 6656 : index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[CST_6656_]]{{.}}, sizes: [256, 128], strides: [1, [[CST_6_]]{{.}} : memref<*xbf16> to memref<256x128xbf16, strided<[1, ?], offset: ?>>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<256x128xbf16>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<256x128xbf16, strided<[1, ?], offset: ?>> to memref<256x128xbf16>
+// CHECK:           [[VAR_0_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<256x128xbf16>
+// CHECK:           bufferization.materialize_in_destination [[VAR_0_]] in writable [[VAR_reinterpret_cast_]] : (tensor<256x128xbf16>, memref<256x128xbf16, strided<[1, ?], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/addptr_reshape_broadcast.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_reshape_broadcast.mlir
@@ -8,23 +8,23 @@ module {
   {
   %0 = tt.make_range {end = 768 : i32, start = 512 : i32}:tensor<256xi32>
   // offset = [512] size = 256, stride = 1
-  %1 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<256xi32>) -> tensor<256x1xi32>
+  %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<256xi32> -> tensor<256x1xi32>
   // offset = [512,0], size = [256,1], stride = [1,0]
-  %2 = tt.broadcast %1 : (tensor<256x1xi32>) -> tensor<256x128xi32>
+  %2 = tt.broadcast %1 : tensor<256x1xi32> -> tensor<256x128xi32>
   // offset = [512,0], size = [256,128], stride = [1,0]
   %5 = tt.make_range {end = 1152 : i32, start = 1024 : i32}:tensor<128xi32>
   // offset = 1024, size = 128, stride = 1
-  %6 = tt.expand_dims %5 {axis = 0 : i32} : (tensor<128xi32>) -> tensor<1x128xi32>
+  %6 = tt.expand_dims %5 {axis = 0 : i32} : tensor<128xi32> -> tensor<1x128xi32>
   // offset = [0,1024], size = [1,128], stride = [0,1]
-  %7 = tt.broadcast %6 : (tensor<1x128xi32>) -> tensor<256x128xi32>
+  %7 = tt.broadcast %6 : tensor<1x128xi32> -> tensor<256x128xi32>
   // offset = [0,1024], size = [256,128], stride = [0,1]
   %c6 = arith.constant 6 : i32
-  %splat6 = tt.splat %c6 : (i32) -> tensor<256x128xi32>
+  %splat6 = tt.splat %c6 : i32 -> tensor<256x128xi32>
   %scale7 = arith.muli %7, %splat6 : tensor<256x128xi32>
   // offset = [0,6144], size = [256,128], stride = [0,6]
   %14 = arith.addi %2, %scale7 : tensor<256x128xi32>
   // offset = [512,6144], size = [256,128], stride = [1,6]
-  %17 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<256x128x!tt.ptr<bf16>>
+  %17 = tt.splat %arg1 : !tt.ptr<bf16> -> tensor<256x128x!tt.ptr<bf16>>
   %18 = tt.addptr %17, %14 : tensor<256x128x!tt.ptr<bf16>>, tensor<256x128xi32>
   %19 = tt.load %18 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<256x128xbf16>
   tt.store %18, %19 : tensor<256x128xbf16>

--- a/test/Conversion/StructuredToMemref/addptr_scalar_broadcast.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_scalar_broadcast.mlir
@@ -1,0 +1,67 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+module {
+  tt.func @kernel (%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: i32, %arg3: i32, %arg4: i32) {
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %arg2 : i32
+    %2 = tt.addptr %arg1, %1 : !tt.ptr<f32>, i32
+    // source = arg1, offset = %1, size = 1, strides = 0
+    %3 = tt.splat %2 : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+    // source = arg1, offset = %1, size = 1024, strides = 0
+    %4 = tt.expand_dims %3 {axis = 1 : i32} : (tensor<1024x!tt.ptr<f32>>) -> tensor<1024x1x!tt.ptr<f32>>
+    // source = arg1, offset = [%1, 0], size = [1024, 1], strides = [0, 0]
+    %5 = tt.broadcast %4 : (tensor<1024x1x!tt.ptr<f32>>) -> tensor<1024x1024x!tt.ptr<f32>>
+    // source = arg1, offset = [%1, 0], size = [1024, 1024], strides = [0, 0]
+    %6 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+    // offset = 0, size = 1024, strides = 1
+    %7 = tt.expand_dims %6 {axis = 0 : i32} : (tensor<1024xi32>) -> tensor<1x1024xi32>
+    // offset = [0, 0], size = [1, 1024], strides = [0, 1]
+    %8 = tt.broadcast %7 : (tensor<1x1024xi32>) -> tensor<1024x1024xi32>
+    // offset = [0, 0], size = [1024, 1024], strides = [0, 1]
+    %9 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+    // offset = 0, size = 1024, strides = 1
+    %10 = tt.expand_dims %9 {axis = 1 : i32} : (tensor<1024xi32>) -> tensor<1024x1xi32>
+    // offset = [0, 0], size = [1024, 1], strides = [1, 0]
+    %11 = tt.broadcast %10 : (tensor<1024x1xi32>) -> tensor<1024x1024xi32>
+    // offset = [0, 0], size = [1024, 1024], strides = [1, 0]
+    %12 = arith.addi %8, %11 : tensor<1024x1024xi32>
+    // offset = [0, 0], size = [1024, 1024], strides = [1, 1]
+    %13 = tt.addptr %5, %12 : tensor<1024x1024x!tt.ptr<f32>>, tensor<1024x1024xi32>
+    // source = arg1, offset = [pid * %arg2, 0], size = [1024, 1024], strides = [1, 1]
+    %14 = tt.load %13 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024x1024xf32>
+    %17 = math.exp %14 : tensor<1024x1024xf32>
+    %18 = arith.muli %0, %arg3 : i32
+    %19 = tt.addptr %arg0, %18 : !tt.ptr<f32>, i32
+    // source = arg0, offset = pid+arg3, size = 1, strides = 0
+    %20 = tt.splat %19 : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+    // source = arg0, offset = pid+arg3, size = 1024, strides = 0
+    %21 = tt.expand_dims %20 {axis = 1 : i32} : (tensor<1024x!tt.ptr<f32>>) -> tensor<1024x1x!tt.ptr<f32>>
+    // source = arg0, offset = [pid+arg3, 0], size = [1024, 1], strides = [0, 0]
+    %22 = tt.broadcast %21 : (tensor<1024x1x!tt.ptr<f32>>) -> tensor<1024x1024x!tt.ptr<f32>>
+    // source = arg0, offset = [pid+arg3, 0], size = [1024, 1024], strides = [0, 0]
+    %23 = tt.addptr %22, %12 : tensor<1024x1024x!tt.ptr<f32>>, tensor<1024x1024xi32>
+    // source = arg0, offset = [pid+arg3, 0], size = [1024, 1024], strides = [1, 1]
+    tt.store %23, %17 : tensor<1024x1024xf32>
+    tt.return
+  }
+}
+// mlir2FileCheck.py
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK-LABEL:  func.func @kernel
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32> {tt.divisibility = 16 : i32}, [[PARAM_1_:%.+]]: memref<*xf32> {tt.divisibility = 16 : i32}, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32, [[PARAM_10_:%.+]]: i32) {
+// CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_8_]], [[PARAM_2_]] : i32
+// CHECK:           [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [1024, 1024], strides: [1, 1] : memref<*xf32> to memref<1024x1024xf32, strided<[1, 1], offset: ?>>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<1024x1024xf32>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<1024x1024xf32, strided<[1, 1], offset: ?>> to memref<1024x1024xf32>
+// CHECK:           [[VAR_2_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<1024x1024xf32>
+// CHECK:           [[VAR_3_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_2_]] : tensor<1024x1024xf32>) outs([[VAR_2_]] : tensor<1024x1024xf32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
+// CHECK:             [[VAR_6_:%.+]] = math.exp [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_6_]] : f32
+// CHECK:           } -> tensor<1024x1024xf32>
+// CHECK:           [[VAR_4_:%.+]] = arith.muli [[PARAM_8_]], [[PARAM_3_]] : i32
+// CHECK:           [[VAR_5_:%.+]] = arith.index_cast [[VAR_4_]] : i32 to index
+// CHECK:           [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_5_]]{{.}}, sizes: [1024, 1024], strides: [1, 1] : memref<*xf32> to memref<1024x1024xf32, strided<[1, 1], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_3_]] in writable [[VAR_reinterpret_cast_0_]] : (tensor<1024x1024xf32>, memref<1024x1024xf32, strided<[1, 1], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/addptr_scalar_broadcast.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_scalar_broadcast.mlir
@@ -5,23 +5,23 @@ module {
     %1 = arith.muli %0, %arg2 : i32
     %2 = tt.addptr %arg1, %1 : !tt.ptr<f32>, i32
     // source = arg1, offset = %1, size = 1, strides = 0
-    %3 = tt.splat %2 : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+    %3 = tt.splat %2 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
     // source = arg1, offset = %1, size = 1024, strides = 0
-    %4 = tt.expand_dims %3 {axis = 1 : i32} : (tensor<1024x!tt.ptr<f32>>) -> tensor<1024x1x!tt.ptr<f32>>
+    %4 = tt.expand_dims %3 {axis = 1 : i32} : tensor<1024x!tt.ptr<f32>> -> tensor<1024x1x!tt.ptr<f32>>
     // source = arg1, offset = [%1, 0], size = [1024, 1], strides = [0, 0]
-    %5 = tt.broadcast %4 : (tensor<1024x1x!tt.ptr<f32>>) -> tensor<1024x1024x!tt.ptr<f32>>
+    %5 = tt.broadcast %4 : tensor<1024x1x!tt.ptr<f32>> -> tensor<1024x1024x!tt.ptr<f32>>
     // source = arg1, offset = [%1, 0], size = [1024, 1024], strides = [0, 0]
     %6 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
     // offset = 0, size = 1024, strides = 1
-    %7 = tt.expand_dims %6 {axis = 0 : i32} : (tensor<1024xi32>) -> tensor<1x1024xi32>
+    %7 = tt.expand_dims %6 {axis = 0 : i32} : tensor<1024xi32> -> tensor<1x1024xi32>
     // offset = [0, 0], size = [1, 1024], strides = [0, 1]
-    %8 = tt.broadcast %7 : (tensor<1x1024xi32>) -> tensor<1024x1024xi32>
+    %8 = tt.broadcast %7 : tensor<1x1024xi32> -> tensor<1024x1024xi32>
     // offset = [0, 0], size = [1024, 1024], strides = [0, 1]
     %9 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
     // offset = 0, size = 1024, strides = 1
-    %10 = tt.expand_dims %9 {axis = 1 : i32} : (tensor<1024xi32>) -> tensor<1024x1xi32>
+    %10 = tt.expand_dims %9 {axis = 1 : i32} : tensor<1024xi32> -> tensor<1024x1xi32>
     // offset = [0, 0], size = [1024, 1], strides = [1, 0]
-    %11 = tt.broadcast %10 : (tensor<1024x1xi32>) -> tensor<1024x1024xi32>
+    %11 = tt.broadcast %10 : tensor<1024x1xi32> -> tensor<1024x1024xi32>
     // offset = [0, 0], size = [1024, 1024], strides = [1, 0]
     %12 = arith.addi %8, %11 : tensor<1024x1024xi32>
     // offset = [0, 0], size = [1024, 1024], strides = [1, 1]
@@ -32,11 +32,11 @@ module {
     %18 = arith.muli %0, %arg3 : i32
     %19 = tt.addptr %arg0, %18 : !tt.ptr<f32>, i32
     // source = arg0, offset = pid+arg3, size = 1, strides = 0
-    %20 = tt.splat %19 : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+    %20 = tt.splat %19 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
     // source = arg0, offset = pid+arg3, size = 1024, strides = 0
-    %21 = tt.expand_dims %20 {axis = 1 : i32} : (tensor<1024x!tt.ptr<f32>>) -> tensor<1024x1x!tt.ptr<f32>>
+    %21 = tt.expand_dims %20 {axis = 1 : i32} : tensor<1024x!tt.ptr<f32>> -> tensor<1024x1x!tt.ptr<f32>>
     // source = arg0, offset = [pid+arg3, 0], size = [1024, 1], strides = [0, 0]
-    %22 = tt.broadcast %21 : (tensor<1024x1x!tt.ptr<f32>>) -> tensor<1024x1024x!tt.ptr<f32>>
+    %22 = tt.broadcast %21 : tensor<1024x1x!tt.ptr<f32>> -> tensor<1024x1024x!tt.ptr<f32>>
     // source = arg0, offset = [pid+arg3, 0], size = [1024, 1024], strides = [0, 0]
     %23 = tt.addptr %22, %12 : tensor<1024x1024x!tt.ptr<f32>>, tensor<1024x1024xi32>
     // source = arg0, offset = [pid+arg3, 0], size = [1024, 1024], strides = [1, 1]

--- a/test/Conversion/StructuredToMemref/addptr_scalar_for.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_scalar_for.mlir
@@ -1,0 +1,82 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+module {
+  tt.func @kernel (%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: i32, %arg3: i32, %arg4: i32) {
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %arg2 : i32
+    %2 = tt.addptr %arg1, %1 : !tt.ptr<f32>, i32
+    // source = %arg1, offset = %1, size = 1, strides = 0
+    %cf0 = arith.constant 0.000000e+00 : f32
+    %tensor_cf0 = tt.splat %cf0 : (f32) -> tensor<1024xf32>
+    %c0 = arith.constant 0 : index
+    %c12 = arith.constant 12 : index
+    %c3 = arith.constant 3 : index
+    %_ptr, %sum_out = scf.for %i = %c0 to %c12 step %c3 iter_args(%ptr_iter = %2, %sum_iter = %tensor_cf0) ->  (!tt.ptr<f32>, tensor<1024xf32>) {
+      %3 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+      // offset = 0, size = 1024, strides = 1
+      %4 = tt.splat %ptr_iter : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+      // source = %arg1, offset = %1, size = 1024, strides = 0
+      %5 = tt.addptr %4, %3 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+      // source = %arg1, offset = %1, size = 1024, strides = 1
+      %8 = tt.load %5 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xf32>
+      %9 = math.exp %8 : tensor<1024xf32>
+      %sum_next = arith.addf %sum_iter, %9 : tensor<1024xf32>
+      %cast_i = arith.index_cast %i : index to i32
+      %ptr_next = tt.addptr %ptr_iter, %cast_i : !tt.ptr<f32>, i32
+      // source = %arg1, offset = %1 + %i, size = 1, strides = 0
+      scf.yield %ptr_next, %sum_next : !tt.ptr<f32>, tensor<1024xf32>
+    }
+    %10 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+    %18 = arith.muli %0, %arg3 : i32
+    %19 = tt.addptr %arg0, %18 : !tt.ptr<f32>, i32
+    %20 = tt.splat %19 : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+    %21 = tt.addptr %20, %10 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+    tt.store %21, %sum_out : tensor<1024xf32>
+    tt.return
+  }
+}
+
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func @kernel
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32> {tt.divisibility = 16 : i32}, [[PARAM_1_:%.+]]: memref<*xf32> {tt.divisibility = 16 : i32}, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32, [[PARAM_10_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
+// CHECK-DAG:       [[CST_12_:%.+]] = arith.constant 12 : index
+// CHECK-DAG:       [[CST_3_:%.+]] = arith.constant 3 : index
+// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: [0], sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<1024xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_1_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[VAR_0_]] : tensor<1024xf32>) -> tensor<1024xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.muli [[PARAM_8_]], [[PARAM_2_]] : i32
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
+// CHECK-DAG:       [[VAR_4_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
+// CHECK:           [[base_buffer_:%.+]], [[offset_:%.+]], [[sizes_:%.+]], [[VAR_strides_:%.+]] = memref.extract_strided_metadata [[VAR_reinterpret_cast_]] : memref<1xf32, strided<[1], offset: ?>> -> memref<f32>, index, index, index
+// CHECK:           [[VAR_5_:%.+]] = arith.addi [[offset_]], [[VAR_4_]] : index
+// CHECK:           [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[base_buffer_]] to offset: {{.}}[[VAR_5_]]{{.}}, sizes: [1], strides: [1] : memref<f32> to memref<1xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_6_:%.+]]:3 = scf.for [[VAR_arg11_:%.+]] = [[CST_0_]] to [[CST_12_]] step [[CST_3_]] iter_args([[VAR_arg12_:%.+]] = [[VAR_reinterpret_cast_0_]], [[VAR_arg13_:%.+]] = [[VAR_1_]], [[VAR_arg14_:%.+]] = [[VAR_3_]]) -> (memref<1xf32, strided<[1], offset: ?>>, tensor<1024xf32>, index) {
+// CHECK-DAG:         [[VAR_reinterpret_cast_2_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_arg14_]]{{.}}, sizes: [1024], strides: [1] : memref<*xf32> to memref<1024xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[RES_:%.+]] = memref.alloc() : memref<1024xf32>
+// CHECK:             memref.copy [[VAR_reinterpret_cast_2_]], [[RES_]] : memref<1024xf32, strided<[1], offset: ?>> to memref<1024xf32>
+// CHECK:             [[VAR_9_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<1024xf32>
+// CHECK:             [[VAR_10_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_9_]] : tensor<1024xf32>) outs([[VAR_9_]] : tensor<1024xf32>) {
+// CHECK:             ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
+// CHECK:               [[VAR_14_:%.+]] = math.exp [[IN_0_]] : f32
+// CHECK:               linalg.yield [[VAR_14_]] : f32
+// CHECK:             } -> tensor<1024xf32>
+// CHECK:             [[VAR_11_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_arg13_]], [[VAR_10_]] : tensor<1024xf32>, tensor<1024xf32>) outs([[VAR_arg13_]] : tensor<1024xf32>) {
+// CHECK:             ^bb0([[IN_2_:%.+]]: f32, [[IN_3_:%.+]]: f32, [[IN_4_:%.+]]: f32):
+// CHECK:               [[VAR_14_1_:%.+]] = arith.addf [[IN_2_]], [[IN_3_]] : f32
+// CHECK:               linalg.yield [[VAR_14_1_]] : f32
+// CHECK:             } -> tensor<1024xf32>
+// CHECK:             [[base_buffer_3_:%.+]], [[offset_4_:%.+]], [[sizes_5_:%.+]], [[VAR_strides_6_:%.+]] = memref.extract_strided_metadata [[VAR_arg12_]] : memref<1xf32, strided<[1], offset: ?>> -> memref<f32>, index, index, index
+// CHECK:             [[VAR_12_:%.+]] = arith.addi [[offset_4_]], [[VAR_arg11_]] : index
+// CHECK-DAG:         [[VAR_reinterpret_cast_7_:%.+]] = memref.reinterpret_cast [[base_buffer_3_]] to offset: {{.}}[[VAR_12_]]{{.}}, sizes: [1], strides: [1] : memref<f32> to memref<1xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_13_:%.+]] = arith.addi [[VAR_arg14_]], [[VAR_arg11_]] : index
+// CHECK:             scf.yield [[VAR_reinterpret_cast_7_]], [[VAR_11_]], [[VAR_13_]] : memref<1xf32, strided<[1], offset: ?>>, tensor<1024xf32>, index
+// CHECK:           }
+// CHECK:           [[VAR_7_:%.+]] = arith.muli [[PARAM_8_]], [[PARAM_3_]] : i32
+// CHECK:           [[VAR_8_:%.+]] = arith.index_cast [[VAR_7_]] : i32 to index
+// CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_8_]]{{.}}, sizes: [1024], strides: [1] : memref<*xf32> to memref<1024xf32, strided<[1], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_6_]]#1 in writable [[VAR_reinterpret_cast_1_]] : (tensor<1024xf32>, memref<1024xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/addptr_scalar_for.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_scalar_for.mlir
@@ -6,14 +6,14 @@ module {
     %2 = tt.addptr %arg1, %1 : !tt.ptr<f32>, i32
     // source = %arg1, offset = %1, size = 1, strides = 0
     %cf0 = arith.constant 0.000000e+00 : f32
-    %tensor_cf0 = tt.splat %cf0 : (f32) -> tensor<1024xf32>
+    %tensor_cf0 = tt.splat %cf0 : f32 -> tensor<1024xf32>
     %c0 = arith.constant 0 : index
     %c12 = arith.constant 12 : index
     %c3 = arith.constant 3 : index
     %_ptr, %sum_out = scf.for %i = %c0 to %c12 step %c3 iter_args(%ptr_iter = %2, %sum_iter = %tensor_cf0) ->  (!tt.ptr<f32>, tensor<1024xf32>) {
       %3 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
       // offset = 0, size = 1024, strides = 1
-      %4 = tt.splat %ptr_iter : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+      %4 = tt.splat %ptr_iter : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
       // source = %arg1, offset = %1, size = 1024, strides = 0
       %5 = tt.addptr %4, %3 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
       // source = %arg1, offset = %1, size = 1024, strides = 1
@@ -28,7 +28,7 @@ module {
     %10 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
     %18 = arith.muli %0, %arg3 : i32
     %19 = tt.addptr %arg0, %18 : !tt.ptr<f32>, i32
-    %20 = tt.splat %19 : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+    %20 = tt.splat %19 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
     %21 = tt.addptr %20, %10 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
     tt.store %21, %sum_out : tensor<1024xf32>
     tt.return

--- a/test/Conversion/StructuredToMemref/addptr_scalar_for_2d.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_scalar_for_2d.mlir
@@ -5,20 +5,20 @@ module {
     %1 = arith.muli %0, %arg2 : i32
     %2 = tt.addptr %arg1, %1 : !tt.ptr<f32>, i32
     %cf0 = arith.constant 0.000000e+00 : f32
-    %tensor_cf0 = tt.splat %cf0 : (f32) -> tensor<128x128xf32>
+    %tensor_cf0 = tt.splat %cf0 : f32 -> tensor<128x128xf32>
     %c0 = arith.constant 0 : index
     %c12 = arith.constant 12 : index
     %c3 = arith.constant 3 : index
     %sum_out, %_ptr = scf.for %i = %c0 to %c12 step %c3 iter_args(%sum_iter = %tensor_cf0,  %ptr_iter = %2) ->  (tensor<128x128xf32>, !tt.ptr<f32> ) {
-      %3 = tt.splat %ptr_iter : (!tt.ptr<f32>) -> tensor<128x128x!tt.ptr<f32>>
+      %3 = tt.splat %ptr_iter : !tt.ptr<f32> -> tensor<128x128x!tt.ptr<f32>>
       // source = %arg1, offset = [%1, 0], size = [128, 128], strides = [0, 0]
       %4 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
-      %5 = tt.expand_dims %4 {axis = 0 : i32} : (tensor<128xi32>) -> tensor<1x128xi32>
-      %6 = tt.broadcast %5 : (tensor<1x128xi32>) -> tensor<128x128xi32>
+      %5 = tt.expand_dims %4 {axis = 0 : i32} : tensor<128xi32> -> tensor<1x128xi32>
+      %6 = tt.broadcast %5 : tensor<1x128xi32> -> tensor<128x128xi32>
       // offset = [0, 0], size = [128, 128], strides = [0, 1]
       %7 = tt.make_range {end = 256 : i32, start = 128 : i32} : tensor<128xi32>
-      %8 = tt.expand_dims %7 {axis = 1 : i32} : (tensor<128xi32>) -> tensor<128x1xi32>
-      %9 = tt.broadcast %8 : (tensor<128x1xi32>) -> tensor<128x128xi32>
+      %8 = tt.expand_dims %7 {axis = 1 : i32} : tensor<128xi32> -> tensor<128x1xi32>
+      %9 = tt.broadcast %8 : tensor<128x1xi32> -> tensor<128x128xi32>
       // offset = [128, 0], size = [128, 128], strides = [1, 0]
       %10 = arith.addi %6, %9 : tensor<128x128xi32>
       // offset = [128, 0], size = [128, 128], strides = [1, 1]
@@ -33,19 +33,19 @@ module {
       scf.yield %sum_next, %ptr_next : tensor<128x128xf32>, !tt.ptr<f32>
     }
     %4 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
-    %5 = tt.expand_dims %4 {axis = 0 : i32} : (tensor<128xi32>) -> tensor<1x128xi32>
-    %6 = tt.broadcast %5 : (tensor<1x128xi32>) -> tensor<128x128xi32>
+    %5 = tt.expand_dims %4 {axis = 0 : i32} : tensor<128xi32> -> tensor<1x128xi32>
+    %6 = tt.broadcast %5 : tensor<1x128xi32> -> tensor<128x128xi32>
     // offset = [0, 0], size = [128, 128], strides = [0, 1]
     %7 = tt.make_range {end = 256 : i32, start = 128 : i32} : tensor<128xi32>
-    %8 = tt.expand_dims %7 {axis = 1 : i32} : (tensor<128xi32>) -> tensor<128x1xi32>
-    %9 = tt.broadcast %8 : (tensor<128x1xi32>) -> tensor<128x128xi32>
+    %8 = tt.expand_dims %7 {axis = 1 : i32} : tensor<128xi32> -> tensor<128x1xi32>
+    %9 = tt.broadcast %8 : tensor<128x1xi32> -> tensor<128x128xi32>
     // offset = [128, 0], size = [128, 128], strides = [1, 0]
     %10 = arith.addi %6, %9 : tensor<128x128xi32>
     // offset = [128, 0], size = [128, 128], strides = [1, 1]
     %18 = arith.muli %0, %arg3 : i32
     %19 = tt.addptr %arg0, %18 : !tt.ptr<f32>, i32
     // source = arg0, offset = %18, size = 1, strides = 0
-    %20 = tt.splat %19 : (!tt.ptr<f32>) -> tensor<128x128x!tt.ptr<f32>>
+    %20 = tt.splat %19 : !tt.ptr<f32> -> tensor<128x128x!tt.ptr<f32>>
     // source = arg0, offset = [%18, 0], size = [128, 128], strides = [0, 0]
     %21 = tt.addptr %20, %10 : tensor<128x128x!tt.ptr<f32>>, tensor<128x128xi32>
     // source = %arg0, offset = [%18 + 128, 0], size = [128, 128], strides = [1, 1]

--- a/test/Conversion/StructuredToMemref/addptr_scalar_loopback.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_scalar_loopback.mlir
@@ -1,0 +1,32 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+
+module {
+  tt.func @kernel(
+  %arg0 : !tt.ptr<bf16>,
+  %arg1 : !tt.ptr<bf16>,
+  %arg2 : i32
+  ) {
+    %0 = tt.addptr %arg0, %arg2 : !tt.ptr<bf16>, i32
+    %1 = tt.addptr %arg1, %arg2 : !tt.ptr<bf16>, i32
+    %10 = tt.load %0 {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: bf16
+    tt.store %1, %10 : bf16
+    tt.return
+  }
+}
+
+// CHECK-LABEL:  func.func @kernel
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: memref<*xbf16>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: [0], sizes: [1], strides: [1] : memref<*xbf16> to memref<1xbf16, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [1], strides: [1] : memref<*xbf16> to memref<1xbf16, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_0_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[base_buffer_:%.+]], [[offset_:%.+]], [[sizes_:%.+]], [[VAR_strides_:%.+]] = memref.extract_strided_metadata [[VAR_reinterpret_cast_0_]] : memref<1xbf16, strided<[1], offset: ?>> -> memref<bf16>, index, index, index
+// CHECK:           [[VAR_1_:%.+]] = arith.addi [[offset_]], [[VAR_0_]] : index
+// CHECK-DAG:       [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[base_buffer_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [1], strides: [1] : memref<bf16> to memref<1xbf16, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[base_buffer_2_:%.+]], [[offset_3_:%.+]], [[sizes_4_:%.+]], [[VAR_strides_5_:%.+]] = memref.extract_strided_metadata [[VAR_reinterpret_cast_]] : memref<1xbf16, strided<[1], offset: ?>> -> memref<bf16>, index, index, index
+// CHECK:           [[VAR_3_:%.+]] = arith.addi [[offset_3_]], [[VAR_2_]] : index
+// CHECK-DAG:       [[VAR_reinterpret_cast_6_:%.+]] = memref.reinterpret_cast [[base_buffer_2_]] to offset: {{.}}[[VAR_3_]]{{.}}, sizes: [1], strides: [1] : memref<bf16> to memref<1xbf16, strided<[1], offset: ?>>
+// CHECK-DAG:       [[LOAD_VAR_reinterpret_cast_1_MEM_:%.+]] = affine.load [[VAR_reinterpret_cast_1_]][0] : memref<1xbf16, strided<[1], offset: ?>>
+// CHECK:           affine.store [[LOAD_VAR_reinterpret_cast_1_MEM_]], [[VAR_reinterpret_cast_6_]][0] : memref<1xbf16, strided<[1], offset: ?>>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/addptr_scalar_nested.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_scalar_nested.mlir
@@ -1,0 +1,59 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+module {
+  tt.func @kernel (%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: i32, %arg3: i32, %arg4: i32) {
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %arg2 : i32
+    %2 = tt.addptr %arg1, %1 : !tt.ptr<f32>, i32
+    // source = arg1, offset = %1, size = 1, strides = 0
+    %3 = arith.muli %0, %arg3 : i32
+    %4 = tt.addptr %2, %3 : !tt.ptr<f32>, i32
+    // source = arg1, offset = %1+%3, size = 1, strides = 0
+    %5 = arith.muli %0, %arg4 : i32
+    %6 = tt.addptr %4, %5 : !tt.ptr<f32>, i32
+    // source = arg1, offset = %1+%3+%5, size = 1, strides = 0
+    %7 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+    // offset = 0, size = 1024, strides = 1
+    %8 = tt.splat %6 : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+    // source = arg1, offset = %1, size = 1024, strides = 0
+    %9 = tt.addptr %8, %7 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+    // source = arg1, offset = %1+%3+%5, size = 1024, strides = 1
+    %10 = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xf32>
+    %17 = math.exp %10 : tensor<1024xf32>
+    %18 = arith.muli %0, %arg3 : i32
+    %19 = tt.addptr %arg0, %18 : !tt.ptr<f32>, i32
+    // source = arg0, offset = %18, size = 1, strides = 0
+    %20 = tt.splat %19 : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+    // source = arg0, offset = %18, size = 1024, strides = 0
+    %21 = tt.addptr %20, %7 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+    // source = arg0, offset = %18, size = 1024, strides = 1
+    tt.store %21, %17 : tensor<1024xf32>
+    tt.return
+  }
+}
+// mlir2FileCheck.py
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func @kernel
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32> {tt.divisibility = 16 : i32}, [[PARAM_1_:%.+]]: memref<*xf32> {tt.divisibility = 16 : i32}, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32, [[PARAM_10_:%.+]]: i32) {
+// CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_8_]], [[PARAM_2_]] : i32
+// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.muli [[PARAM_8_]], [[PARAM_3_]] : i32
+// CHECK:           [[VAR_3_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
+// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_1_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.muli [[PARAM_8_]], [[PARAM_4_]] : i32
+// CHECK:           [[VAR_6_:%.+]] = arith.index_cast [[VAR_5_]] : i32 to index
+// CHECK:           [[VAR_7_:%.+]] = arith.addi [[VAR_4_]], [[VAR_6_]] : index
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_7_]]{{.}}, sizes: [1024], strides: [1] : memref<*xf32> to memref<1024xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<1024xf32>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<1024xf32, strided<[1], offset: ?>> to memref<1024xf32>
+// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<1024xf32>
+// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<1024xf32>) outs([[VAR_8_]] : tensor<1024xf32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
+// CHECK:             [[VAR_12_:%.+]] = math.exp [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_12_]] : f32
+// CHECK:           } -> tensor<1024xf32>
+// CHECK:           [[VAR_10_:%.+]] = arith.muli [[PARAM_8_]], [[PARAM_3_]] : i32
+// CHECK:           [[VAR_11_:%.+]] = arith.index_cast [[VAR_10_]] : i32 to index
+// CHECK:           [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_11_]]{{.}}, sizes: [1024], strides: [1] : memref<*xf32> to memref<1024xf32, strided<[1], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_0_]] : (tensor<1024xf32>, memref<1024xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/addptr_scalar_nested.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_scalar_nested.mlir
@@ -13,7 +13,7 @@ module {
     // source = arg1, offset = %1+%3+%5, size = 1, strides = 0
     %7 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
     // offset = 0, size = 1024, strides = 1
-    %8 = tt.splat %6 : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+    %8 = tt.splat %6 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
     // source = arg1, offset = %1, size = 1024, strides = 0
     %9 = tt.addptr %8, %7 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
     // source = arg1, offset = %1+%3+%5, size = 1024, strides = 1
@@ -22,7 +22,7 @@ module {
     %18 = arith.muli %0, %arg3 : i32
     %19 = tt.addptr %arg0, %18 : !tt.ptr<f32>, i32
     // source = arg0, offset = %18, size = 1, strides = 0
-    %20 = tt.splat %19 : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+    %20 = tt.splat %19 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
     // source = arg0, offset = %18, size = 1024, strides = 0
     %21 = tt.addptr %20, %7 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
     // source = arg0, offset = %18, size = 1024, strides = 1

--- a/test/Conversion/StructuredToMemref/addptr_scalar_splat.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_scalar_splat.mlir
@@ -1,0 +1,47 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+module {
+  tt.func @kernel (%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: i32, %arg3: i32, %arg4: i32) {
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %arg2 : i32
+    %2 = tt.addptr %arg1, %1 : !tt.ptr<f32>, i32
+    // source = %arg1, offset = %1, size = 1, strides = 0
+    %3 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+    // offset = 0, size = 1024, strides = 1
+    %4 = tt.splat %2 : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+    // source = %arg1, offset = %1, size = 1024, strides = 0
+    %5 = tt.addptr %4, %3 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+    // source = %arg1, offset = %1, size = 1024, strides = 1
+    %8 = tt.load %5 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xf32>
+    %17 = math.exp %8 : tensor<1024xf32>
+    %18 = arith.muli %0, %arg3 : i32
+    %19 = tt.addptr %arg0, %18 : !tt.ptr<f32>, i32
+    // source = %arg0, offset = %18, size = 1, strides = 0
+    %20 = tt.splat %19 : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+    // source = %arg0, offset = %18, size = 1024, strides = 0
+    %21 = tt.addptr %20, %3 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+    // source = %arg0, offset = %18, size = 1024, strides = 1
+    tt.store %21, %17 : tensor<1024xf32>
+    tt.return
+  }
+}
+// mlir2FileCheck.py
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func @kernel
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32> {tt.divisibility = 16 : i32}, [[PARAM_1_:%.+]]: memref<*xf32> {tt.divisibility = 16 : i32}, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32, [[PARAM_10_:%.+]]: i32) {
+// CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_8_]], [[PARAM_2_]] : i32
+// CHECK:           [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [1024], strides: [1] : memref<*xf32> to memref<1024xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<1024xf32>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<1024xf32, strided<[1], offset: ?>> to memref<1024xf32>
+// CHECK:           [[VAR_2_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<1024xf32>
+// CHECK:           [[VAR_3_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_2_]] : tensor<1024xf32>) outs([[VAR_2_]] : tensor<1024xf32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
+// CHECK:             [[VAR_6_:%.+]] = math.exp [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_6_]] : f32
+// CHECK:           } -> tensor<1024xf32>
+// CHECK:           [[VAR_4_:%.+]] = arith.muli [[PARAM_8_]], [[PARAM_3_]] : i32
+// CHECK:           [[VAR_5_:%.+]] = arith.index_cast [[VAR_4_]] : i32 to index
+// CHECK:           [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_5_]]{{.}}, sizes: [1024], strides: [1] : memref<*xf32> to memref<1024xf32, strided<[1], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_3_]] in writable [[VAR_reinterpret_cast_0_]] : (tensor<1024xf32>, memref<1024xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/addptr_scalar_splat.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_scalar_splat.mlir
@@ -7,7 +7,7 @@ module {
     // source = %arg1, offset = %1, size = 1, strides = 0
     %3 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
     // offset = 0, size = 1024, strides = 1
-    %4 = tt.splat %2 : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+    %4 = tt.splat %2 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
     // source = %arg1, offset = %1, size = 1024, strides = 0
     %5 = tt.addptr %4, %3 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
     // source = %arg1, offset = %1, size = 1024, strides = 1
@@ -16,7 +16,7 @@ module {
     %18 = arith.muli %0, %arg3 : i32
     %19 = tt.addptr %arg0, %18 : !tt.ptr<f32>, i32
     // source = %arg0, offset = %18, size = 1, strides = 0
-    %20 = tt.splat %19 : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+    %20 = tt.splat %19 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
     // source = %arg0, offset = %18, size = 1024, strides = 0
     %21 = tt.addptr %20, %3 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
     // source = %arg0, offset = %18, size = 1024, strides = 1

--- a/test/Conversion/StructuredToMemref/addptr_scalar_splat_2d.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_scalar_splat_2d.mlir
@@ -4,16 +4,16 @@ module {
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %arg2 : i32
     %2 = tt.addptr %arg1, %1 : !tt.ptr<f32>, i32
-    %3 = tt.splat %2 : (!tt.ptr<f32>) -> tensor<128x128x!tt.ptr<f32>>
+    %3 = tt.splat %2 : !tt.ptr<f32> -> tensor<128x128x!tt.ptr<f32>>
     // source = %arg1, offset = [%1, 0], size = [128, 128], strides = [0, 0]
     %4 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
-    %5 = tt.expand_dims %4 {axis = 0 : i32} : (tensor<128xi32>) -> tensor<1x128xi32>
-    %6 = tt.broadcast %5 : (tensor<1x128xi32>) -> tensor<128x128xi32>
+    %5 = tt.expand_dims %4 {axis = 0 : i32} : tensor<128xi32> -> tensor<1x128xi32>
+    %6 = tt.broadcast %5 : tensor<1x128xi32> -> tensor<128x128xi32>
     // offset = [0, 0], size = [128, 128], strides = [0, 1]
     %7 = tt.make_range {end = 256 : i32, start = 128 : i32} : tensor<128xi32>
     // offset = 128, size = 128, strides = 1
-    %8 = tt.expand_dims %7 {axis = 1 : i32} : (tensor<128xi32>) -> tensor<128x1xi32>
-    %9 = tt.broadcast %8 : (tensor<128x1xi32>) -> tensor<128x128xi32>
+    %8 = tt.expand_dims %7 {axis = 1 : i32} : tensor<128xi32> -> tensor<128x1xi32>
+    %9 = tt.broadcast %8 : tensor<128x1xi32> -> tensor<128x128xi32>
     // offset = [128, 0], size = [128, 128], strides = [1, 0]
     %10 = arith.addi %6, %9 : tensor<128x128xi32>
     // offset = [128, 0], size = [128, 128], strides = [1, 1]
@@ -24,7 +24,7 @@ module {
     %18 = arith.muli %0, %arg3 : i32
     %19 = tt.addptr %arg0, %18 : !tt.ptr<f32>, i32
     // source = arg0, offset = %18, size = 1, strides = 0
-    %20 = tt.splat %19 : (!tt.ptr<f32>) -> tensor<128x128x!tt.ptr<f32>>
+    %20 = tt.splat %19 : !tt.ptr<f32> -> tensor<128x128x!tt.ptr<f32>>
     // source = arg0, offset = [%18, 0], size = [128, 128], strides = [0, 0]
     %21 = tt.addptr %20, %10 : tensor<128x128x!tt.ptr<f32>>, tensor<128x128xi32>
     // source = %arg0, offset = [%18 + 128, 0], size = [128, 128], strides = [1, 1]

--- a/test/Conversion/StructuredToMemref/addptr_scalar_splat_2d.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_scalar_splat_2d.mlir
@@ -1,0 +1,58 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+module {
+  tt.func @kernel (%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: i32, %arg3: i32, %arg4: i32) {
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %arg2 : i32
+    %2 = tt.addptr %arg1, %1 : !tt.ptr<f32>, i32
+    %3 = tt.splat %2 : (!tt.ptr<f32>) -> tensor<128x128x!tt.ptr<f32>>
+    // source = %arg1, offset = [%1, 0], size = [128, 128], strides = [0, 0]
+    %4 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %5 = tt.expand_dims %4 {axis = 0 : i32} : (tensor<128xi32>) -> tensor<1x128xi32>
+    %6 = tt.broadcast %5 : (tensor<1x128xi32>) -> tensor<128x128xi32>
+    // offset = [0, 0], size = [128, 128], strides = [0, 1]
+    %7 = tt.make_range {end = 256 : i32, start = 128 : i32} : tensor<128xi32>
+    // offset = 128, size = 128, strides = 1
+    %8 = tt.expand_dims %7 {axis = 1 : i32} : (tensor<128xi32>) -> tensor<128x1xi32>
+    %9 = tt.broadcast %8 : (tensor<128x1xi32>) -> tensor<128x128xi32>
+    // offset = [128, 0], size = [128, 128], strides = [1, 0]
+    %10 = arith.addi %6, %9 : tensor<128x128xi32>
+    // offset = [128, 0], size = [128, 128], strides = [1, 1]
+    %11 = tt.addptr %3, %10 : tensor<128x128x!tt.ptr<f32>>, tensor<128x128xi32>
+    // source = %arg1, offset = [%1 + 128, 0], size = [128, 128], strides = [1, 1]
+    %12 = tt.load %11 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128x128xf32>
+    %17 = math.exp %12 : tensor<128x128xf32>
+    %18 = arith.muli %0, %arg3 : i32
+    %19 = tt.addptr %arg0, %18 : !tt.ptr<f32>, i32
+    // source = arg0, offset = %18, size = 1, strides = 0
+    %20 = tt.splat %19 : (!tt.ptr<f32>) -> tensor<128x128x!tt.ptr<f32>>
+    // source = arg0, offset = [%18, 0], size = [128, 128], strides = [0, 0]
+    %21 = tt.addptr %20, %10 : tensor<128x128x!tt.ptr<f32>>, tensor<128x128xi32>
+    // source = %arg0, offset = [%18 + 128, 0], size = [128, 128], strides = [1, 1]
+    tt.store %21, %17 : tensor<128x128xf32>
+    tt.return
+  }
+}
+// mlir2FileCheck.py
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK-LABEL:  func.func @kernel
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32> {tt.divisibility = 16 : i32}, [[PARAM_1_:%.+]]: memref<*xf32> {tt.divisibility = 16 : i32}, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32, [[PARAM_10_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_128_:%.+]] = arith.constant 128 : index
+// CHECK-DAG:       [[VAR_0_:%.+]] = arith.muli [[PARAM_8_]], [[PARAM_2_]] : i32
+// CHECK:           [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK:           [[VAR_2_:%.+]] = arith.addi [[VAR_1_]], [[CST_128_]] : index
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [128, 128], strides: [1, 1] : memref<*xf32> to memref<128x128xf32, strided<[1, 1], offset: ?>>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<128x128xf32>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<128x128xf32, strided<[1, 1], offset: ?>> to memref<128x128xf32>
+// CHECK:           [[VAR_3_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<128x128xf32>
+// CHECK:           [[VAR_4_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_3_]] : tensor<128x128xf32>) outs([[VAR_3_]] : tensor<128x128xf32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
+// CHECK:             [[VAR_8_:%.+]] = math.exp [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_8_]] : f32
+// CHECK:           } -> tensor<128x128xf32>
+// CHECK:           [[VAR_5_:%.+]] = arith.muli [[PARAM_8_]], [[PARAM_3_]] : i32
+// CHECK:           [[VAR_6_:%.+]] = arith.index_cast [[VAR_5_]] : i32 to index
+// CHECK:           [[VAR_7_:%.+]] = arith.addi [[VAR_6_]], [[CST_128_]] : index
+// CHECK:           [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_7_]]{{.}}, sizes: [128, 128], strides: [1, 1] : memref<*xf32> to memref<128x128xf32, strided<[1, 1], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_4_]] in writable [[VAR_reinterpret_cast_0_]] : (tensor<128x128xf32>, memref<128x128xf32, strided<[1, 1], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/arith_not_ptr_arith.mlir
+++ b/test/Conversion/StructuredToMemref/arith_not_ptr_arith.mlir
@@ -1,0 +1,41 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+module {
+  tt.func @kernel(
+    %a : !tt.ptr<i32>,
+    %b : !tt.ptr<i32>
+  ) -> () {
+        // offset calculations
+        %0 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+        // a pointer
+        %8 = tt.splat %a : (!tt.ptr<i32>) -> tensor<1024x!tt.ptr<i32>>
+        %9 = tt.addptr %8, %0 : tensor<1024x!tt.ptr<i32>>, tensor<1024xi32>
+        // b pointer
+        %18 = tt.splat %b : (!tt.ptr<i32>) -> tensor<1024x!tt.ptr<i32>>
+        %19 = tt.addptr %18, %0 : tensor<1024x!tt.ptr<i32>>, tensor<1024xi32>
+        %am = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xi32>
+        %bm = tt.load %19 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xi32>
+        %5 = arith.addi %am, %bm : tensor<1024xi32>
+        tt.store %19, %5 : tensor<1024xi32>
+        tt.return
+    }
+}
+// mlir2FileCheck.py
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func @kernel
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xi32>, [[PARAM_1_:%.+]]: memref<*xi32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32) {
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [1024], strides: [1] : memref<*xi32> to memref<1024xi32, strided<[1]>>
+// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: [0], sizes: [1024], strides: [1] : memref<*xi32> to memref<1024xi32, strided<[1]>>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<1024xi32>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<1024xi32, strided<[1]>> to memref<1024xi32>
+// CHECK-DAG:       [[VAR_0_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<1024xi32>
+// CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc() : memref<1024xi32>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_0_]], [[RES_1_]] : memref<1024xi32, strided<[1]>> to memref<1024xi32>
+// CHECK:           [[VAR_1_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<1024xi32>
+// CHECK:           [[VAR_2_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_0_]], [[VAR_1_]] : tensor<1024xi32>, tensor<1024xi32>) outs([[VAR_0_]] : tensor<1024xi32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: i32, [[IN_1_:%.+]]: i32, [[IN_2_:%.+]]: i32):
+// CHECK:             [[VAR_3_:%.+]] = arith.addi [[IN_0_]], [[IN_1_]] : i32
+// CHECK:             linalg.yield [[VAR_3_]] : i32
+// CHECK:           } -> tensor<1024xi32>
+// CHECK:           bufferization.materialize_in_destination [[VAR_2_]] in writable [[VAR_reinterpret_cast_0_]] : (tensor<1024xi32>, memref<1024xi32, strided<[1]>>) -> ()
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/arith_not_ptr_arith.mlir
+++ b/test/Conversion/StructuredToMemref/arith_not_ptr_arith.mlir
@@ -7,10 +7,10 @@ module {
         // offset calculations
         %0 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
         // a pointer
-        %8 = tt.splat %a : (!tt.ptr<i32>) -> tensor<1024x!tt.ptr<i32>>
+        %8 = tt.splat %a : !tt.ptr<i32> -> tensor<1024x!tt.ptr<i32>>
         %9 = tt.addptr %8, %0 : tensor<1024x!tt.ptr<i32>>, tensor<1024xi32>
         // b pointer
-        %18 = tt.splat %b : (!tt.ptr<i32>) -> tensor<1024x!tt.ptr<i32>>
+        %18 = tt.splat %b : !tt.ptr<i32> -> tensor<1024x!tt.ptr<i32>>
         %19 = tt.addptr %18, %0 : tensor<1024x!tt.ptr<i32>>, tensor<1024xi32>
         %am = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xi32>
         %bm = tt.load %19 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xi32>

--- a/test/Conversion/StructuredToMemref/bitcast.mlir
+++ b/test/Conversion/StructuredToMemref/bitcast.mlir
@@ -1,0 +1,45 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+
+module {
+  tt.func @kernel(%a : !tt.ptr<i32>, %b : !tt.ptr<f32>) -> () {
+    // offset calculations
+    %0 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+
+    // a pointer
+    %8 = tt.splat %a : (!tt.ptr<i32>) -> tensor<1024x!tt.ptr<i32>>
+    %9 = tt.addptr %8, %0 : tensor<1024x!tt.ptr<i32>>, tensor<1024xi32>
+
+    // b pointer
+    %18 = tt.splat %b : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+    %19 = tt.addptr %18, %0 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+
+    %am = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xi32>
+
+    // cast result before doing float add
+    %am_bitcast = tt.bitcast %am : tensor<1024xi32> -> tensor<1024xf32>
+
+
+    tt.store %19, %am_bitcast : tensor<1024xf32>
+    tt.return
+  }
+}
+
+
+// mlir2FileCheck.py
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func @kernel
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xi32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32) {
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [1024], strides: [1] : memref<*xi32> to memref<1024xi32, strided<[1]>>
+// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: [0], sizes: [1024], strides: [1] : memref<*xf32> to memref<1024xf32, strided<[1]>>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<1024xi32>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<1024xi32, strided<[1]>> to memref<1024xi32>
+// CHECK-DAG:       [[VAR_0_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<1024xi32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tensor.empty() : tensor<1024xf32>
+// CHECK:           [[VAR_2_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_0_]] : tensor<1024xi32>) outs([[VAR_1_]] : tensor<1024xf32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: i32, [[IN_1_:%.+]]: f32):
+// CHECK:             [[VAR_3_:%.+]] = arith.bitcast [[IN_0_]] : i32 to f32
+// CHECK:             linalg.yield [[VAR_3_]] : f32
+// CHECK:           } -> tensor<1024xf32>
+// CHECK:           bufferization.materialize_in_destination [[VAR_2_]] in writable [[VAR_reinterpret_cast_0_]] : (tensor<1024xf32>, memref<1024xf32, strided<[1]>>) -> ()
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/bitcast.mlir
+++ b/test/Conversion/StructuredToMemref/bitcast.mlir
@@ -6,11 +6,11 @@ module {
     %0 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
 
     // a pointer
-    %8 = tt.splat %a : (!tt.ptr<i32>) -> tensor<1024x!tt.ptr<i32>>
+    %8 = tt.splat %a : !tt.ptr<i32> -> tensor<1024x!tt.ptr<i32>>
     %9 = tt.addptr %8, %0 : tensor<1024x!tt.ptr<i32>>, tensor<1024xi32>
 
     // b pointer
-    %18 = tt.splat %b : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+    %18 = tt.splat %b : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
     %19 = tt.addptr %18, %0 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
 
     %am = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xi32>

--- a/test/Conversion/StructuredToMemref/block_ptr_advance.mlir
+++ b/test/Conversion/StructuredToMemref/block_ptr_advance.mlir
@@ -1,0 +1,92 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+
+module {
+  tt.func public @matmul_kernel_with_block_pointers_01234567891011(%arg0: !tt.ptr<bf16>, %arg1: !tt.ptr<bf16>, %arg2: !tt.ptr<bf16>, %arg3: i32, %arg4: i32, %arg5: i32, %arg6: i32, %arg7: i32, %arg8: i32, %arg9: i32, %arg10: i32, %arg11: i32, %arg12: i32, %arg13: i32) {
+    %c64_i32 = arith.constant 64 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %cst = arith.constant 0.000000e+00 : bf16
+    %c256_i32 = arith.constant 256 : i32
+    %0 = arith.extsi %arg3 : i32 to i64
+    %1 = arith.extsi %arg5 : i32 to i64
+    %2 = arith.extsi %arg6 : i32 to i64
+    %3 = arith.extsi %arg7 : i32 to i64
+    %4 = tt.make_tensor_ptr %arg0, [%0, %1], [%2, %3], [%arg12, %c0_i32] {order = array<i32: 1, 0>} : <tensor<128x64xbf16>>
+    %5 = tt.advance %4, [%c0_i32, %c64_i32] : <tensor<128x64xbf16>>
+    %6 = tt.splat %cst : (bf16) -> tensor<128x64xbf16>
+    %7:3 = scf.for %arg14 = %c0_i32 to %arg5 step %c64_i32 iter_args(%arg15 = %6, %arg16 = %5, %arg17 = %4) -> (tensor<128x64xbf16>, !tt.ptr<tensor<128x64xbf16>>, !tt.ptr<tensor<128x64xbf16>>)  : i32 {
+      %13 = tt.load %arg16 {boundaryCheck = array<i32: 0, 1>, cache = 1 : i32, evict = 1 : i32, isVolatile = false} : !tt.ptr<tensor<128x64xbf16>> -> tensor<128x64xbf16>
+      %14 = tt.load %arg17 {boundaryCheck = array<i32: 0, 1>, cache = 1 : i32, evict = 1 : i32, isVolatile = false} : !tt.ptr<tensor<128x64xbf16>> -> tensor<128x64xbf16>
+      %15 = arith.addf %13, %14 : tensor<128x64xbf16>
+      %16 = arith.addf %arg15, %15 : tensor<128x64xbf16>
+      %17 = tt.advance %arg16, [%c0_i32, %c64_i32] : <tensor<128x64xbf16>>
+      %18 = tt.advance %arg17, [%c64_i32, %c0_i32] : <tensor<128x64xbf16>>
+      scf.yield %16, %17, %18 : tensor<128x64xbf16>, !tt.ptr<tensor<128x64xbf16>>, !tt.ptr<tensor<128x64xbf16>>
+    }
+    %8 = arith.extsi %arg10 : i32 to i64
+    %9 = arith.extsi %arg11 : i32 to i64
+    %10 = arith.extsi %arg4 : i32 to i64
+    %11 = arith.muli %arg13, %c256_i32 : i32
+    %12 = tt.make_tensor_ptr %arg2, [%0, %10], [%8, %9], [%arg12, %11] {order = array<i32: 1, 0>} : <tensor<128x64xbf16>>
+    tt.store %12, %7#0 {boundaryCheck = array<i32: 0, 1>, cache = 1 : i32, evict = 1 : i32} : !tt.ptr<tensor<128x64xbf16>>, tensor<128x64xbf16>
+    tt.return
+  }
+}
+
+// mlir2FileCheck.py
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK-LABEL:  func.func @matmul_kernel_with_block_pointers_01234567891011
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: memref<*xbf16>, [[PARAM_2_:%.+]]: memref<*xbf16>, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32, [[PARAM_10_:%.+]]: i32, [[PARAM_11_:%.+]]: i32, [[PARAM_12_:%.+]]: i32, [[PARAM_13_:%.+]]: i32, [[PARAM_14_:%.+]]: i32, [[PARAM_15_:%.+]]: i32, [[PARAM_16_:%.+]]: i32, [[PARAM_17_:%.+]]: i32, [[PARAM_18_:%.+]]: i32, [[PARAM_19_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_256_:%.+]] = arith.constant 256 : i32
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : i32
+// CHECK-DAG:       [[CST_64_:%.+]] = arith.constant 64 : i32
+// CHECK-DAG:       [[CST_64_1_:%.+]] = arith.constant 64 : index
+// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : bf16
+// CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<128x64xbf16>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_1_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : bf16) outs([[VAR_0_]] : tensor<128x64xbf16>) -> tensor<128x64xbf16>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[PARAM_6_]] : i32 to index
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[PARAM_12_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_4_:%.+]] = arith.muli [[VAR_3_]], [[VAR_2_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
+// CHECK:           [[VAR_6_:%.+]] = arith.muli [[VAR_5_]], [[CST_64_1_]] : index
+// CHECK-DAG:       [[VAR_7_:%.+]]:3 = scf.for [[VAR_arg20_:%.+]] = [[CST_0_]] to [[PARAM_5_]] step [[CST_64_]] iter_args([[VAR_arg21_:%.+]] = [[VAR_1_]], [[VAR_arg22_:%.+]] = [[VAR_6_]], [[VAR_arg23_:%.+]] = [[VAR_4_]]) -> (tensor<128x64xbf16>, index, index)  : i32 {
+// CHECK-DAG:         [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_arg23_]]{{.}}, sizes: [128, 64], strides: {{.}}[[VAR_2_]], [[VAR_5_]]{{.}} : memref<*xbf16> to memref<128x64xbf16, strided<[?, ?], offset: ?>>
+// CHECK-DAG:         [[VAR_16_:%.+]] = arith.addi [[VAR_4_]], [[VAR_arg22_]] : index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_16_]]{{.}}, sizes: [128, 64], strides: {{.}}[[VAR_2_]], [[VAR_5_]]{{.}} : memref<*xbf16> to memref<128x64xbf16, strided<[?, ?], offset: ?>>
+// CHECK-DAG:         [[RES_:%.+]] = memref.alloc() : memref<128x64xbf16>
+// CHECK:             memref.copy [[VAR_reinterpret_cast_1_]], [[RES_]] : memref<128x64xbf16, strided<[?, ?], offset: ?>> to memref<128x64xbf16>
+// CHECK-DAG:         [[VAR_17_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<128x64xbf16>
+// CHECK-DAG:         [[RES_1_:%.+]] = memref.alloc() : memref<128x64xbf16>
+// CHECK:             memref.copy [[VAR_reinterpret_cast_0_]], [[RES_1_]] : memref<128x64xbf16, strided<[?, ?], offset: ?>> to memref<128x64xbf16>
+// CHECK:             [[VAR_18_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<128x64xbf16>
+// CHECK:             [[VAR_19_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_17_]], [[VAR_18_]] : tensor<128x64xbf16>, tensor<128x64xbf16>) outs([[VAR_17_]] : tensor<128x64xbf16>) {
+// CHECK:             ^bb0([[IN_0_:%.+]]: bf16, [[IN_1_:%.+]]: bf16, [[IN_2_:%.+]]: bf16):
+// CHECK:               [[VAR_25_:%.+]] = arith.addf [[IN_0_]], [[IN_1_]] : bf16
+// CHECK:               linalg.yield [[VAR_25_]] : bf16
+// CHECK:             } -> tensor<128x64xbf16>
+// CHECK:             [[VAR_20_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_arg21_]], [[VAR_19_]] : tensor<128x64xbf16>, tensor<128x64xbf16>) outs([[VAR_arg21_]] : tensor<128x64xbf16>) {
+// CHECK:             ^bb0([[IN_3_:%.+]]: bf16, [[IN_4_:%.+]]: bf16, [[IN_5_:%.+]]: bf16):
+// CHECK:               [[VAR_25_1_:%.+]] = arith.addf [[IN_3_]], [[IN_4_]] : bf16
+// CHECK:               linalg.yield [[VAR_25_1_]] : bf16
+// CHECK:             } -> tensor<128x64xbf16>
+// CHECK:             [[VAR_21_:%.+]] = arith.muli [[VAR_5_]], [[CST_64_1_]] : index
+// CHECK-DAG:         [[VAR_22_:%.+]] = arith.addi [[VAR_21_]], [[VAR_arg22_]] : index
+// CHECK-DAG:         [[VAR_23_:%.+]] = arith.muli [[VAR_2_]], [[CST_64_1_]] : index
+// CHECK:             [[VAR_24_:%.+]] = arith.addi [[VAR_23_]], [[VAR_arg23_]] : index
+// CHECK:             scf.yield [[VAR_20_]], [[VAR_22_]], [[VAR_24_]] : tensor<128x64xbf16>, index, index
+// CHECK:           }
+// CHECK-DAG:       [[VAR_8_:%.+]] = arith.muli [[PARAM_13_]], [[CST_256_]] : i32
+// CHECK-DAG:       [[VAR_9_:%.+]] = arith.index_cast [[PARAM_10_]] : i32 to index
+// CHECK-DAG:       [[VAR_10_:%.+]] = arith.index_cast [[PARAM_12_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_11_:%.+]] = arith.muli [[VAR_10_]], [[VAR_9_]] : index
+// CHECK-DAG:       [[VAR_12_:%.+]] = arith.index_cast [[PARAM_11_]] : i32 to index
+// CHECK-DAG:       [[VAR_13_:%.+]] = arith.index_cast [[VAR_8_]] : i32 to index
+// CHECK:           [[VAR_14_:%.+]] = arith.muli [[VAR_13_]], [[VAR_12_]] : index
+// CHECK:           [[VAR_15_:%.+]] = arith.addi [[VAR_11_]], [[VAR_14_]] : index
+// CHECK:           [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_2_]] to offset: {{.}}[[VAR_15_]]{{.}}, sizes: [128, 64], strides: {{.}}[[VAR_9_]], [[VAR_12_]]{{.}} : memref<*xbf16> to memref<128x64xbf16, strided<[?, ?], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_7_]]#0 in writable [[VAR_reinterpret_cast_]] : (tensor<128x64xbf16>, memref<128x64xbf16, strided<[?, ?], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/block_ptr_advance.mlir
+++ b/test/Conversion/StructuredToMemref/block_ptr_advance.mlir
@@ -12,7 +12,7 @@ module {
     %3 = arith.extsi %arg7 : i32 to i64
     %4 = tt.make_tensor_ptr %arg0, [%0, %1], [%2, %3], [%arg12, %c0_i32] {order = array<i32: 1, 0>} : <tensor<128x64xbf16>>
     %5 = tt.advance %4, [%c0_i32, %c64_i32] : <tensor<128x64xbf16>>
-    %6 = tt.splat %cst : (bf16) -> tensor<128x64xbf16>
+    %6 = tt.splat %cst : bf16 -> tensor<128x64xbf16>
     %7:3 = scf.for %arg14 = %c0_i32 to %arg5 step %c64_i32 iter_args(%arg15 = %6, %arg16 = %5, %arg17 = %4) -> (tensor<128x64xbf16>, !tt.ptr<tensor<128x64xbf16>>, !tt.ptr<tensor<128x64xbf16>>)  : i32 {
       %13 = tt.load %arg16 {boundaryCheck = array<i32: 0, 1>, cache = 1 : i32, evict = 1 : i32, isVolatile = false} : !tt.ptr<tensor<128x64xbf16>> -> tensor<128x64xbf16>
       %14 = tt.load %arg17 {boundaryCheck = array<i32: 0, 1>, cache = 1 : i32, evict = 1 : i32, isVolatile = false} : !tt.ptr<tensor<128x64xbf16>> -> tensor<128x64xbf16>

--- a/test/Conversion/StructuredToMemref/convert_1d_elemwise_arith_binary.mlir
+++ b/test/Conversion/StructuredToMemref/convert_1d_elemwise_arith_binary.mlir
@@ -1,0 +1,74 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+module {
+  tt.func @kernel(
+    %a : !tt.ptr<f32>,
+    %b : !tt.ptr<f32>,
+    %c : tensor<1024x!tt.ptr<f32>>
+  ) -> () {
+        %cst = arith.constant dense<true> : tensor<1024xi1>
+        // offset calculations
+        %0 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+        // a pointer
+        %8 = tt.splat %a : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+        %9 = tt.addptr %8, %0 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+        // b pointer
+        %18 = tt.splat %b : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+        %19 = tt.addptr %18, %0 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+        %am = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xf32>
+        %bm = tt.load %19 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xf32>
+        %1 = arith.addf %am, %bm : tensor<1024xf32>
+        %2 = arith.subf %1, %bm : tensor<1024xf32>
+        %3 = arith.mulf %2, %bm : tensor<1024xf32>
+        %4 = arith.divf %3, %bm : tensor<1024xf32>
+        %5 = arith.cmpf "oeq", %4, %bm : tensor<1024xf32>
+        %6 = arith.select %5, %am, %bm : tensor<1024xi1>, tensor<1024xf32>
+        tt.store %c, %6 {cache = 1 : i32, evict = 1 : i32} : tensor<1024xf32>
+        tt.return
+    }
+}
+// mlir2FileCheck.py
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func @kernel
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: tensor<1024x!tt.ptr<f32, 1>>, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [1024], strides: [1] : memref<*xf32> to memref<1024xf32, strided<[1]>>
+// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: [0], sizes: [1024], strides: [1] : memref<*xf32> to memref<1024xf32, strided<[1]>>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<1024xf32>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<1024xf32, strided<[1]>> to memref<1024xf32>
+// CHECK-DAG:       [[VAR_0_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<1024xf32>
+// CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc() : memref<1024xf32>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_0_]], [[RES_1_]] : memref<1024xf32, strided<[1]>> to memref<1024xf32>
+// CHECK:           [[VAR_1_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<1024xf32>
+// CHECK:           [[VAR_2_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_0_]], [[VAR_1_]] : tensor<1024xf32>, tensor<1024xf32>) outs([[VAR_0_]] : tensor<1024xf32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32, [[IN_2_:%.+]]: f32):
+// CHECK:             [[VAR_9_:%.+]] = arith.addf [[IN_0_]], [[IN_1_]] : f32
+// CHECK:             linalg.yield [[VAR_9_]] : f32
+// CHECK:           } -> tensor<1024xf32>
+// CHECK:           [[VAR_3_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_2_]], [[VAR_1_]] : tensor<1024xf32>, tensor<1024xf32>) outs([[VAR_2_]] : tensor<1024xf32>) {
+// CHECK:           ^bb0([[IN_3_:%.+]]: f32, [[IN_4_:%.+]]: f32, [[IN_5_:%.+]]: f32):
+// CHECK:             [[VAR_9_1_:%.+]] = arith.subf [[IN_3_]], [[IN_4_]] : f32
+// CHECK:             linalg.yield [[VAR_9_1_]] : f32
+// CHECK:           } -> tensor<1024xf32>
+// CHECK:           [[VAR_4_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_3_]], [[VAR_1_]] : tensor<1024xf32>, tensor<1024xf32>) outs([[VAR_3_]] : tensor<1024xf32>) {
+// CHECK:           ^bb0([[IN_6_:%.+]]: f32, [[IN_7_:%.+]]: f32, [[IN_8_:%.+]]: f32):
+// CHECK:             [[VAR_9_2_:%.+]] = arith.mulf [[IN_6_]], [[IN_7_]] : f32
+// CHECK:             linalg.yield [[VAR_9_2_]] : f32
+// CHECK:           } -> tensor<1024xf32>
+// CHECK:           [[VAR_5_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_4_]], [[VAR_1_]] : tensor<1024xf32>, tensor<1024xf32>) outs([[VAR_4_]] : tensor<1024xf32>) {
+// CHECK:           ^bb0([[IN_9_:%.+]]: f32, [[IN_10_:%.+]]: f32, [[IN_11_:%.+]]: f32):
+// CHECK:             [[VAR_9_3_:%.+]] = arith.divf [[IN_9_]], [[IN_10_]] : f32
+// CHECK:             linalg.yield [[VAR_9_3_]] : f32
+// CHECK:           } -> tensor<1024xf32>
+// CHECK:           [[VAR_6_:%.+]] = tensor.empty() : tensor<1024xi1>
+// CHECK:           [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_5_]], [[VAR_1_]] : tensor<1024xf32>, tensor<1024xf32>) outs([[VAR_6_]] : tensor<1024xi1>) {
+// CHECK:           ^bb0([[IN_12_:%.+]]: f32, [[IN_13_:%.+]]: f32, [[IN_14_:%.+]]: i1):
+// CHECK:             [[VAR_9_4_:%.+]] = arith.cmpf oeq, [[IN_12_]], [[IN_13_]] : f32
+// CHECK:             linalg.yield [[VAR_9_4_]] : i1
+// CHECK:           } -> tensor<1024xi1>
+// CHECK:           [[VAR_8_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_7_]], [[VAR_0_]], [[VAR_1_]] : tensor<1024xi1>, tensor<1024xf32>, tensor<1024xf32>) outs([[VAR_0_]] : tensor<1024xf32>) {
+// CHECK:           ^bb0([[IN_15_:%.+]]: i1, [[IN_16_:%.+]]: f32, [[IN_17_:%.+]]: f32, [[IN_18_:%.+]]: f32):
+// CHECK:             [[VAR_9_5_:%.+]] = arith.select [[IN_15_]], [[IN_16_]], [[IN_17_]] : f32
+// CHECK:             linalg.yield [[VAR_9_5_]] : f32
+// CHECK:           } -> tensor<1024xf32>
+// CHECK:           tt.store [[PARAM_2_]], [[VAR_8_]] {cache = 1 : i32, evict = 1 : i32} : tensor<1024xf32>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/convert_1d_elemwise_arith_binary.mlir
+++ b/test/Conversion/StructuredToMemref/convert_1d_elemwise_arith_binary.mlir
@@ -9,10 +9,10 @@ module {
         // offset calculations
         %0 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
         // a pointer
-        %8 = tt.splat %a : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+        %8 = tt.splat %a : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
         %9 = tt.addptr %8, %0 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
         // b pointer
-        %18 = tt.splat %b : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+        %18 = tt.splat %b : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
         %19 = tt.addptr %18, %0 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
         %am = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xf32>
         %bm = tt.load %19 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xf32>

--- a/test/Conversion/StructuredToMemref/convert_1d_elemwise_arith_ternary.mlir
+++ b/test/Conversion/StructuredToMemref/convert_1d_elemwise_arith_ternary.mlir
@@ -9,13 +9,13 @@ module {
     // offset calculations
     %0 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
     // a pointer
-    %8 = tt.splat %a : (!tt.ptr<i1>) -> tensor<1024x!tt.ptr<i1>>
+    %8 = tt.splat %a : !tt.ptr<i1> -> tensor<1024x!tt.ptr<i1>>
     %9 = tt.addptr %8, %0 : tensor<1024x!tt.ptr<i1>>, tensor<1024xi32>
     // b pointer
-    %18 = tt.splat %b : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+    %18 = tt.splat %b : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
     %19 = tt.addptr %18, %0 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
     // c pointer
-    %28 = tt.splat %c : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+    %28 = tt.splat %c : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
     %29 = tt.addptr %28, %0 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
     %am = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xi1>
     %bm = tt.load %19 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xf32>

--- a/test/Conversion/StructuredToMemref/convert_1d_elemwise_arith_ternary.mlir
+++ b/test/Conversion/StructuredToMemref/convert_1d_elemwise_arith_ternary.mlir
@@ -1,0 +1,51 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+module {
+  tt.func @kernel(
+    %a : !tt.ptr<i1>,
+    %b : !tt.ptr<f32>,
+    %c : !tt.ptr<f32>,
+    %d : tensor<1024x!tt.ptr<f32>>
+  ) -> () {
+    // offset calculations
+    %0 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+    // a pointer
+    %8 = tt.splat %a : (!tt.ptr<i1>) -> tensor<1024x!tt.ptr<i1>>
+    %9 = tt.addptr %8, %0 : tensor<1024x!tt.ptr<i1>>, tensor<1024xi32>
+    // b pointer
+    %18 = tt.splat %b : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+    %19 = tt.addptr %18, %0 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+    // c pointer
+    %28 = tt.splat %c : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+    %29 = tt.addptr %28, %0 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+    %am = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xi1>
+    %bm = tt.load %19 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xf32>
+    %cm = tt.load %29 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xf32>
+    %10 = arith.select %am, %bm, %cm : tensor<1024xi1>, tensor<1024xf32>
+    tt.store %d, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<1024xf32>
+    tt.return
+  }
+}
+// mlir2FileCheck.py
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func @kernel
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xi1>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: memref<*xf32>, [[PARAM_3_:%.+]]: tensor<1024x!tt.ptr<f32, 1>>, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32) {
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [1024], strides: [1] : memref<*xi1> to memref<1024xi1, strided<[1]>>
+// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: [0], sizes: [1024], strides: [1] : memref<*xf32> to memref<1024xf32, strided<[1]>>
+// CHECK-DAG:       [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_2_]] to offset: [0], sizes: [1024], strides: [1] : memref<*xf32> to memref<1024xf32, strided<[1]>>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<1024xi1>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<1024xi1, strided<[1]>> to memref<1024xi1>
+// CHECK-DAG:       [[VAR_0_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<1024xi1>
+// CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc() : memref<1024xf32>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_0_]], [[RES_1_]] : memref<1024xf32, strided<[1]>> to memref<1024xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<1024xf32>
+// CHECK-DAG:       [[RES_2_:%.+]] = memref.alloc() : memref<1024xf32>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_1_]], [[RES_2_]] : memref<1024xf32, strided<[1]>> to memref<1024xf32>
+// CHECK:           [[VAR_2_:%.+]] = bufferization.to_tensor [[RES_2_]] restrict writable : memref<1024xf32>
+// CHECK:           [[VAR_3_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_0_]], [[VAR_1_]], [[VAR_2_]] : tensor<1024xi1>, tensor<1024xf32>, tensor<1024xf32>) outs([[VAR_1_]] : tensor<1024xf32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: i1, [[IN_1_:%.+]]: f32, [[IN_2_:%.+]]: f32, [[IN_3_:%.+]]: f32):
+// CHECK:             [[VAR_4_:%.+]] = arith.select [[IN_0_]], [[IN_1_]], [[IN_2_]] : f32
+// CHECK:             linalg.yield [[VAR_4_]] : f32
+// CHECK:           } -> tensor<1024xf32>
+// CHECK:           tt.store [[PARAM_3_]], [[VAR_3_]] {cache = 1 : i32, evict = 1 : i32} : tensor<1024xf32>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/convert_1d_elemwise_arith_unary.mlir
+++ b/test/Conversion/StructuredToMemref/convert_1d_elemwise_arith_unary.mlir
@@ -1,0 +1,90 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+module {
+  tt.func @kernel(
+    %f32ptr : !tt.ptr<f32>,
+    %intptr : !tt.ptr<i32>,
+    %f16ptr : !tt.ptr<f16>,
+    %save0 : tensor<1024x!tt.ptr<bf16>>,
+    %save1 : tensor<1024x!tt.ptr<f32>>,
+    %save2 : tensor<1024x!tt.ptr<f32>>,
+    %save3 : tensor<1024x!tt.ptr<f32>>,
+    %save4 : tensor<1024x!tt.ptr<f32>>
+  ) -> () {
+    // offset calculations
+    %0 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+    // f32ptr pointer
+    %8 = tt.splat %f32ptr : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+    %9 = tt.addptr %8, %0 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+    // intptr pointer
+    %18 = tt.splat %intptr : (!tt.ptr<i32>) -> tensor<1024x!tt.ptr<i32>>
+    %19 = tt.addptr %18, %0 : tensor<1024x!tt.ptr<i32>>, tensor<1024xi32>
+    // f32ptr pointer
+    %28 = tt.splat %f16ptr : (!tt.ptr<f16>) -> tensor<1024x!tt.ptr<f16>>
+    %29 = tt.addptr %28, %0 : tensor<1024x!tt.ptr<f16>>, tensor<1024xi32>
+    %afm = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xf32>
+    %aim = tt.load %19 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xi32>
+    %bfm = tt.load %29 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xf16>
+    %5 = arith.truncf %afm : tensor<1024xf32> to tensor<1024xbf16>
+    %6 = math.exp %afm : tensor<1024xf32>
+    %7 = arith.sitofp %aim : tensor<1024xi32> to tensor<1024xf32>
+    %10 = arith.extf %bfm : tensor<1024xf16> to tensor<1024xf32>
+    %11 = math.sqrt %afm : tensor<1024xf32>
+    tt.store %save0, %5 {cache = 1 : i32, evict = 1 : i32} : tensor<1024xbf16>
+    tt.store %save1, %6 {cache = 1 : i32, evict = 1 : i32} : tensor<1024xf32>
+    tt.store %save2, %7 {cache = 1 : i32, evict = 1 : i32} : tensor<1024xf32>
+    tt.store %save3, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<1024xf32>
+    tt.store %save4, %11 {cache = 1 : i32, evict = 1 : i32} : tensor<1024xf32>
+    tt.return
+  }
+}
+// mlir2FileCheck.py
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func @kernel
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xi32>, [[PARAM_2_:%.+]]: memref<*xf16>, [[PARAM_3_:%.+]]: tensor<1024x!tt.ptr<bf16, 1>>, [[PARAM_4_:%.+]]: tensor<1024x!tt.ptr<f32, 1>>, [[PARAM_5_:%.+]]: tensor<1024x!tt.ptr<f32, 1>>, [[PARAM_6_:%.+]]: tensor<1024x!tt.ptr<f32, 1>>, [[PARAM_7_:%.+]]: tensor<1024x!tt.ptr<f32, 1>>, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32, [[PARAM_10_:%.+]]: i32, [[PARAM_11_:%.+]]: i32, [[PARAM_12_:%.+]]: i32, [[PARAM_13_:%.+]]: i32) {
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [1024], strides: [1] : memref<*xf32> to memref<1024xf32, strided<[1]>>
+// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: [0], sizes: [1024], strides: [1] : memref<*xi32> to memref<1024xi32, strided<[1]>>
+// CHECK-DAG:       [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_2_]] to offset: [0], sizes: [1024], strides: [1] : memref<*xf16> to memref<1024xf16, strided<[1]>>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<1024xf32>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<1024xf32, strided<[1]>> to memref<1024xf32>
+// CHECK-DAG:       [[VAR_0_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<1024xf32>
+// CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc() : memref<1024xi32>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_0_]], [[RES_1_]] : memref<1024xi32, strided<[1]>> to memref<1024xi32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<1024xi32>
+// CHECK-DAG:       [[RES_2_:%.+]] = memref.alloc() : memref<1024xf16>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_1_]], [[RES_2_]] : memref<1024xf16, strided<[1]>> to memref<1024xf16>
+// CHECK-DAG:       [[VAR_2_:%.+]] = bufferization.to_tensor [[RES_2_]] restrict writable : memref<1024xf16>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tensor.empty() : tensor<1024xbf16>
+// CHECK:           [[VAR_4_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_0_]] : tensor<1024xf32>) outs([[VAR_3_]] : tensor<1024xbf16>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: bf16):
+// CHECK:             [[VAR_11_:%.+]] = arith.truncf [[IN_0_]] : f32 to bf16
+// CHECK:             linalg.yield [[VAR_11_]] : bf16
+// CHECK:           } -> tensor<1024xbf16>
+// CHECK:           [[VAR_5_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_0_]] : tensor<1024xf32>) outs([[VAR_0_]] : tensor<1024xf32>) {
+// CHECK:           ^bb0([[IN_2_:%.+]]: f32, [[IN_3_:%.+]]: f32):
+// CHECK:             [[VAR_11_1_:%.+]] = math.exp [[IN_2_]] : f32
+// CHECK:             linalg.yield [[VAR_11_1_]] : f32
+// CHECK:           } -> tensor<1024xf32>
+// CHECK:           [[VAR_6_:%.+]] = tensor.empty() : tensor<1024xf32>
+// CHECK:           [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_1_]] : tensor<1024xi32>) outs([[VAR_6_]] : tensor<1024xf32>) {
+// CHECK:           ^bb0([[IN_4_:%.+]]: i32, [[IN_5_:%.+]]: f32):
+// CHECK:             [[VAR_11_2_:%.+]] = arith.sitofp [[IN_4_]] : i32 to f32
+// CHECK:             linalg.yield [[VAR_11_2_]] : f32
+// CHECK:           } -> tensor<1024xf32>
+// CHECK:           [[VAR_8_:%.+]] = tensor.empty() : tensor<1024xf32>
+// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_2_]] : tensor<1024xf16>) outs([[VAR_8_]] : tensor<1024xf32>) {
+// CHECK:           ^bb0([[IN_6_:%.+]]: f16, [[IN_7_:%.+]]: f32):
+// CHECK:             [[VAR_11_3_:%.+]] = arith.extf [[IN_6_]] : f16 to f32
+// CHECK:             linalg.yield [[VAR_11_3_]] : f32
+// CHECK:           } -> tensor<1024xf32>
+// CHECK:           [[VAR_10_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_0_]] : tensor<1024xf32>) outs([[VAR_0_]] : tensor<1024xf32>) {
+// CHECK:           ^bb0([[IN_8_:%.+]]: f32, [[IN_9_:%.+]]: f32):
+// CHECK:             [[VAR_11_4_:%.+]] = math.sqrt [[IN_8_]] : f32
+// CHECK:             linalg.yield [[VAR_11_4_]] : f32
+// CHECK:           } -> tensor<1024xf32>
+// CHECK:           tt.store [[PARAM_3_]], [[VAR_4_]] {cache = 1 : i32, evict = 1 : i32} : tensor<1024xbf16>
+// CHECK:           tt.store [[PARAM_4_]], [[VAR_5_]] {cache = 1 : i32, evict = 1 : i32} : tensor<1024xf32>
+// CHECK:           tt.store [[PARAM_5_]], [[VAR_7_]] {cache = 1 : i32, evict = 1 : i32} : tensor<1024xf32>
+// CHECK:           tt.store [[PARAM_6_]], [[VAR_9_]] {cache = 1 : i32, evict = 1 : i32} : tensor<1024xf32>
+// CHECK:           tt.store [[PARAM_7_]], [[VAR_10_]] {cache = 1 : i32, evict = 1 : i32} : tensor<1024xf32>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/convert_1d_elemwise_arith_unary.mlir
+++ b/test/Conversion/StructuredToMemref/convert_1d_elemwise_arith_unary.mlir
@@ -13,13 +13,13 @@ module {
     // offset calculations
     %0 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
     // f32ptr pointer
-    %8 = tt.splat %f32ptr : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+    %8 = tt.splat %f32ptr : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
     %9 = tt.addptr %8, %0 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
     // intptr pointer
-    %18 = tt.splat %intptr : (!tt.ptr<i32>) -> tensor<1024x!tt.ptr<i32>>
+    %18 = tt.splat %intptr : !tt.ptr<i32> -> tensor<1024x!tt.ptr<i32>>
     %19 = tt.addptr %18, %0 : tensor<1024x!tt.ptr<i32>>, tensor<1024xi32>
     // f32ptr pointer
-    %28 = tt.splat %f16ptr : (!tt.ptr<f16>) -> tensor<1024x!tt.ptr<f16>>
+    %28 = tt.splat %f16ptr : !tt.ptr<f16> -> tensor<1024x!tt.ptr<f16>>
     %29 = tt.addptr %28, %0 : tensor<1024x!tt.ptr<f16>>, tensor<1024xi32>
     %afm = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xf32>
     %aim = tt.load %19 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xi32>

--- a/test/Conversion/StructuredToMemref/convert_2d_elemwise_arith_binary.mlir
+++ b/test/Conversion/StructuredToMemref/convert_2d_elemwise_arith_binary.mlir
@@ -8,17 +8,17 @@ module {
   ) -> () {
         // offset calculations
         %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
-        %1 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<128xi32>) -> tensor<128x1xi32>
-        %moff = tt.broadcast %1 : (tensor<128x1xi32>) -> tensor<128x128xi32>
+        %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<128xi32> -> tensor<128x1xi32>
+        %moff = tt.broadcast %1 : tensor<128x1xi32> -> tensor<128x128xi32>
         %3 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
-        %4 = tt.expand_dims %3 {axis = 0 : i32} : (tensor<128xi32>) -> tensor<1x128xi32>
-        %koff = tt.broadcast %4 : (tensor<1x128xi32>) -> tensor<128x128xi32>
+        %4 = tt.expand_dims %3 {axis = 0 : i32} : tensor<128xi32> -> tensor<1x128xi32>
+        %koff = tt.broadcast %4 : tensor<1x128xi32> -> tensor<128x128xi32>
         %mkoff = arith.addi %moff, %koff : tensor<128x128xi32>
         // a pointer
-        %8 = tt.splat %a : (!tt.ptr<f32>) -> tensor<128x128x!tt.ptr<f32>>
+        %8 = tt.splat %a : !tt.ptr<f32> -> tensor<128x128x!tt.ptr<f32>>
         %9 = tt.addptr %8, %mkoff : tensor<128x128x!tt.ptr<f32>>, tensor<128x128xi32>
         // b pointer
-        %18 = tt.splat %b : (!tt.ptr<f32>) -> tensor<128x128x!tt.ptr<f32>>
+        %18 = tt.splat %b : !tt.ptr<f32> -> tensor<128x128x!tt.ptr<f32>>
         %19 = tt.addptr %18, %mkoff : tensor<128x128x!tt.ptr<f32>>, tensor<128x128xi32>
         %af = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128x128xf32>
         %bf = tt.load %19 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128x128xf32>

--- a/test/Conversion/StructuredToMemref/convert_2d_elemwise_arith_binary.mlir
+++ b/test/Conversion/StructuredToMemref/convert_2d_elemwise_arith_binary.mlir
@@ -1,0 +1,57 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+module {
+  tt.func @kernel(
+    %a : !tt.ptr<f32>,
+    %b : !tt.ptr<f32>,
+    %c : tensor<128x128x!tt.ptr<f32>>,
+    %d : tensor<128x128x!tt.ptr<f32>>
+  ) -> () {
+        // offset calculations
+        %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+        %1 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<128xi32>) -> tensor<128x1xi32>
+        %moff = tt.broadcast %1 : (tensor<128x1xi32>) -> tensor<128x128xi32>
+        %3 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+        %4 = tt.expand_dims %3 {axis = 0 : i32} : (tensor<128xi32>) -> tensor<1x128xi32>
+        %koff = tt.broadcast %4 : (tensor<1x128xi32>) -> tensor<128x128xi32>
+        %mkoff = arith.addi %moff, %koff : tensor<128x128xi32>
+        // a pointer
+        %8 = tt.splat %a : (!tt.ptr<f32>) -> tensor<128x128x!tt.ptr<f32>>
+        %9 = tt.addptr %8, %mkoff : tensor<128x128x!tt.ptr<f32>>, tensor<128x128xi32>
+        // b pointer
+        %18 = tt.splat %b : (!tt.ptr<f32>) -> tensor<128x128x!tt.ptr<f32>>
+        %19 = tt.addptr %18, %mkoff : tensor<128x128x!tt.ptr<f32>>, tensor<128x128xi32>
+        %af = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128x128xf32>
+        %bf = tt.load %19 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128x128xf32>
+        %res0 = arith.addf %af, %bf : tensor<128x128xf32>
+        %res1 = arith.subf %af, %bf : tensor<128x128xf32>
+        tt.store %c, %res0 {cache = 1 : i32, evict = 1 : i32} : tensor<128x128xf32>
+        tt.store %d, %res1 {cache = 1 : i32, evict = 1 : i32} : tensor<128x128xf32>
+        tt.return
+    }
+}
+// mlir2FileCheck.py
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK-LABEL:  func.func @kernel
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: tensor<128x128x!tt.ptr<f32, 1>>, [[PARAM_3_:%.+]]: tensor<128x128x!tt.ptr<f32, 1>>, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32) {
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [128, 128], strides: [1, 1] : memref<*xf32> to memref<128x128xf32, strided<[1, 1]>>
+// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: [0], sizes: [128, 128], strides: [1, 1] : memref<*xf32> to memref<128x128xf32, strided<[1, 1]>>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<128x128xf32>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<128x128xf32, strided<[1, 1]>> to memref<128x128xf32>
+// CHECK-DAG:       [[VAR_0_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<128x128xf32>
+// CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc() : memref<128x128xf32>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_0_]], [[RES_1_]] : memref<128x128xf32, strided<[1, 1]>> to memref<128x128xf32>
+// CHECK:           [[VAR_1_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<128x128xf32>
+// CHECK:           [[VAR_2_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_0_]], [[VAR_1_]] : tensor<128x128xf32>, tensor<128x128xf32>) outs([[VAR_0_]] : tensor<128x128xf32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32, [[IN_2_:%.+]]: f32):
+// CHECK:             [[VAR_4_:%.+]] = arith.addf [[IN_0_]], [[IN_1_]] : f32
+// CHECK:             linalg.yield [[VAR_4_]] : f32
+// CHECK:           } -> tensor<128x128xf32>
+// CHECK:           [[VAR_3_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_0_]], [[VAR_1_]] : tensor<128x128xf32>, tensor<128x128xf32>) outs([[VAR_0_]] : tensor<128x128xf32>) {
+// CHECK:           ^bb0([[IN_3_:%.+]]: f32, [[IN_4_:%.+]]: f32, [[IN_5_:%.+]]: f32):
+// CHECK:             [[VAR_4_1_:%.+]] = arith.subf [[IN_3_]], [[IN_4_]] : f32
+// CHECK:             linalg.yield [[VAR_4_1_]] : f32
+// CHECK:           } -> tensor<128x128xf32>
+// CHECK:           tt.store [[PARAM_2_]], [[VAR_2_]] {cache = 1 : i32, evict = 1 : i32} : tensor<128x128xf32>
+// CHECK:           tt.store [[PARAM_3_]], [[VAR_3_]] {cache = 1 : i32, evict = 1 : i32} : tensor<128x128xf32>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/convert_2d_elemwise_arith_ternary.mlir
+++ b/test/Conversion/StructuredToMemref/convert_2d_elemwise_arith_ternary.mlir
@@ -8,20 +8,20 @@ module {
   ) -> () {
         // offset calculations
         %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
-        %1 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<128xi32>) -> tensor<128x1xi32>
-        %moff = tt.broadcast %1 : (tensor<128x1xi32>) -> tensor<128x128xi32>
+        %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<128xi32> -> tensor<128x1xi32>
+        %moff = tt.broadcast %1 : tensor<128x1xi32> -> tensor<128x128xi32>
         %3 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
-        %4 = tt.expand_dims %3 {axis = 0 : i32} : (tensor<128xi32>) -> tensor<1x128xi32>
-        %koff = tt.broadcast %4 : (tensor<1x128xi32>) -> tensor<128x128xi32>
+        %4 = tt.expand_dims %3 {axis = 0 : i32} : tensor<128xi32> -> tensor<1x128xi32>
+        %koff = tt.broadcast %4 : tensor<1x128xi32> -> tensor<128x128xi32>
         %mkoff = arith.addi %moff, %koff : tensor<128x128xi32>
         // a pointer
-        %8 = tt.splat %a : (!tt.ptr<i1>) -> tensor<128x128x!tt.ptr<i1>>
+        %8 = tt.splat %a : !tt.ptr<i1> -> tensor<128x128x!tt.ptr<i1>>
         %9 = tt.addptr %8, %mkoff : tensor<128x128x!tt.ptr<i1>>, tensor<128x128xi32>
         // b pointer
-        %18 = tt.splat %b : (!tt.ptr<f32>) -> tensor<128x128x!tt.ptr<f32>>
+        %18 = tt.splat %b : !tt.ptr<f32> -> tensor<128x128x!tt.ptr<f32>>
         %19 = tt.addptr %18, %mkoff : tensor<128x128x!tt.ptr<f32>>, tensor<128x128xi32>
         // c pointer
-        %28 = tt.splat %c : (!tt.ptr<f32>) -> tensor<128x128x!tt.ptr<f32>>
+        %28 = tt.splat %c : !tt.ptr<f32> -> tensor<128x128x!tt.ptr<f32>>
         %29 = tt.addptr %28, %mkoff : tensor<128x128x!tt.ptr<f32>>, tensor<128x128xi32>
         %am = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128x128xi1>
         %bm = tt.load %19 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128x128xf32>

--- a/test/Conversion/StructuredToMemref/convert_2d_elemwise_arith_ternary.mlir
+++ b/test/Conversion/StructuredToMemref/convert_2d_elemwise_arith_ternary.mlir
@@ -1,0 +1,57 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+module {
+    tt.func @kernel(
+                        %a : !tt.ptr<i1>,
+                        %b : !tt.ptr<f32>,
+                        %c : !tt.ptr<f32>,
+                        %d : tensor<128x128x!tt.ptr<f32>>
+  ) -> () {
+        // offset calculations
+        %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+        %1 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<128xi32>) -> tensor<128x1xi32>
+        %moff = tt.broadcast %1 : (tensor<128x1xi32>) -> tensor<128x128xi32>
+        %3 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+        %4 = tt.expand_dims %3 {axis = 0 : i32} : (tensor<128xi32>) -> tensor<1x128xi32>
+        %koff = tt.broadcast %4 : (tensor<1x128xi32>) -> tensor<128x128xi32>
+        %mkoff = arith.addi %moff, %koff : tensor<128x128xi32>
+        // a pointer
+        %8 = tt.splat %a : (!tt.ptr<i1>) -> tensor<128x128x!tt.ptr<i1>>
+        %9 = tt.addptr %8, %mkoff : tensor<128x128x!tt.ptr<i1>>, tensor<128x128xi32>
+        // b pointer
+        %18 = tt.splat %b : (!tt.ptr<f32>) -> tensor<128x128x!tt.ptr<f32>>
+        %19 = tt.addptr %18, %mkoff : tensor<128x128x!tt.ptr<f32>>, tensor<128x128xi32>
+        // c pointer
+        %28 = tt.splat %c : (!tt.ptr<f32>) -> tensor<128x128x!tt.ptr<f32>>
+        %29 = tt.addptr %28, %mkoff : tensor<128x128x!tt.ptr<f32>>, tensor<128x128xi32>
+        %am = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128x128xi1>
+        %bm = tt.load %19 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128x128xf32>
+        %cm = tt.load %29 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128x128xf32>
+        %100 = arith.select %am, %bm, %cm : tensor<128x128xi1>, tensor<128x128xf32>
+        tt.store %d, %100 {cache = 1 : i32, evict = 1 : i32} : tensor<128x128xf32>
+        tt.return
+    }
+}
+// mlir2FileCheck.py
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK-LABEL:  func.func @kernel
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xi1>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: memref<*xf32>, [[PARAM_3_:%.+]]: tensor<128x128x!tt.ptr<f32, 1>>, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32) {
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [128, 128], strides: [1, 1] : memref<*xi1> to memref<128x128xi1, strided<[1, 1]>>
+// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: [0], sizes: [128, 128], strides: [1, 1] : memref<*xf32> to memref<128x128xf32, strided<[1, 1]>>
+// CHECK-DAG:       [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_2_]] to offset: [0], sizes: [128, 128], strides: [1, 1] : memref<*xf32> to memref<128x128xf32, strided<[1, 1]>>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<128x128xi1>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<128x128xi1, strided<[1, 1]>> to memref<128x128xi1>
+// CHECK-DAG:       [[VAR_0_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<128x128xi1>
+// CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc() : memref<128x128xf32>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_0_]], [[RES_1_]] : memref<128x128xf32, strided<[1, 1]>> to memref<128x128xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<128x128xf32>
+// CHECK-DAG:       [[RES_2_:%.+]] = memref.alloc() : memref<128x128xf32>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_1_]], [[RES_2_]] : memref<128x128xf32, strided<[1, 1]>> to memref<128x128xf32>
+// CHECK:           [[VAR_2_:%.+]] = bufferization.to_tensor [[RES_2_]] restrict writable : memref<128x128xf32>
+// CHECK:           [[VAR_3_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_0_]], [[VAR_1_]], [[VAR_2_]] : tensor<128x128xi1>, tensor<128x128xf32>, tensor<128x128xf32>) outs([[VAR_1_]] : tensor<128x128xf32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: i1, [[IN_1_:%.+]]: f32, [[IN_2_:%.+]]: f32, [[IN_3_:%.+]]: f32):
+// CHECK:             [[VAR_4_:%.+]] = arith.select [[IN_0_]], [[IN_1_]], [[IN_2_]] : f32
+// CHECK:             linalg.yield [[VAR_4_]] : f32
+// CHECK:           } -> tensor<128x128xf32>
+// CHECK:           tt.store [[PARAM_3_]], [[VAR_3_]] {cache = 1 : i32, evict = 1 : i32} : tensor<128x128xf32>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/convert_2d_elemwise_arith_unary.mlir
+++ b/test/Conversion/StructuredToMemref/convert_2d_elemwise_arith_unary.mlir
@@ -1,0 +1,96 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+module {
+  tt.func @kernel(
+    %f32ptr : !tt.ptr<f32>,
+    %intptr : !tt.ptr<i32>,
+    %f16ptr : !tt.ptr<f16>,
+    %save0 : tensor<128x128x!tt.ptr<bf16>>,
+    %save1 : tensor<128x128x!tt.ptr<f32>>,
+    %save2 : tensor<128x128x!tt.ptr<f32>>,
+    %save3 : tensor<128x128x!tt.ptr<f32>>,
+    %save4 : tensor<128x128x!tt.ptr<f32>>
+  ) -> () {
+    // offset calculations
+    %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<128xi32>) -> tensor<128x1xi32>
+    %moff = tt.broadcast %1 : (tensor<128x1xi32>) -> tensor<128x128xi32>
+    %3 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %4 = tt.expand_dims %3 {axis = 0 : i32} : (tensor<128xi32>) -> tensor<1x128xi32>
+    %koff = tt.broadcast %4 : (tensor<1x128xi32>) -> tensor<128x128xi32>
+    %mkoff = arith.addi %moff, %koff : tensor<128x128xi32>
+    // f32ptr pointer
+    %8 = tt.splat %f32ptr : (!tt.ptr<f32>) -> tensor<128x128x!tt.ptr<f32>>
+    %9 = tt.addptr %8, %mkoff : tensor<128x128x!tt.ptr<f32>>, tensor<128x128xi32>
+    // intptr pointer
+    %18 = tt.splat %intptr : (!tt.ptr<i32>) -> tensor<128x128x!tt.ptr<i32>>
+    %19 = tt.addptr %18, %mkoff : tensor<128x128x!tt.ptr<i32>>, tensor<128x128xi32>
+    // f16ptr pointer
+    %28 = tt.splat %f16ptr : (!tt.ptr<f16>) -> tensor<128x128x!tt.ptr<f16>>
+    %29 = tt.addptr %28, %mkoff : tensor<128x128x!tt.ptr<f16>>, tensor<128x128xi32>
+    %afm = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128x128xf32>
+    %aim = tt.load %19 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128x128xi32>
+    %bfm = tt.load %29 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128x128xf16>
+    %5 = arith.truncf %afm : tensor<128x128xf32> to tensor<128x128xbf16>
+    %6 = math.exp %afm : tensor<128x128xf32>
+    %7 = arith.sitofp %aim : tensor<128x128xi32> to tensor<128x128xf32>
+    %10 = arith.extf %bfm : tensor<128x128xf16> to tensor<128x128xf32>
+    %11 = math.sqrt %afm : tensor<128x128xf32>
+    tt.store %save0, %5 {cache = 1 : i32, evict = 1 : i32} : tensor<128x128xbf16>
+    tt.store %save1, %6 {cache = 1 : i32, evict = 1 : i32} : tensor<128x128xf32>
+    tt.store %save2, %7 {cache = 1 : i32, evict = 1 : i32} : tensor<128x128xf32>
+    tt.store %save3, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<128x128xf32>
+    tt.store %save4, %11 {cache = 1 : i32, evict = 1 : i32} : tensor<128x128xf32>
+    tt.return
+  }
+}
+// mlir2FileCheck.py
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK-LABEL:  func.func @kernel
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xi32>, [[PARAM_2_:%.+]]: memref<*xf16>, [[PARAM_3_:%.+]]: tensor<128x128x!tt.ptr<bf16, 1>>, [[PARAM_4_:%.+]]: tensor<128x128x!tt.ptr<f32, 1>>, [[PARAM_5_:%.+]]: tensor<128x128x!tt.ptr<f32, 1>>, [[PARAM_6_:%.+]]: tensor<128x128x!tt.ptr<f32, 1>>, [[PARAM_7_:%.+]]: tensor<128x128x!tt.ptr<f32, 1>>, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32, [[PARAM_10_:%.+]]: i32, [[PARAM_11_:%.+]]: i32, [[PARAM_12_:%.+]]: i32, [[PARAM_13_:%.+]]: i32) {
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [128, 128], strides: [1, 1] : memref<*xf32> to memref<128x128xf32, strided<[1, 1]>>
+// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: [0], sizes: [128, 128], strides: [1, 1] : memref<*xi32> to memref<128x128xi32, strided<[1, 1]>>
+// CHECK-DAG:       [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_2_]] to offset: [0], sizes: [128, 128], strides: [1, 1] : memref<*xf16> to memref<128x128xf16, strided<[1, 1]>>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<128x128xf32>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<128x128xf32, strided<[1, 1]>> to memref<128x128xf32>
+// CHECK-DAG:       [[VAR_0_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<128x128xf32>
+// CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc() : memref<128x128xi32>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_0_]], [[RES_1_]] : memref<128x128xi32, strided<[1, 1]>> to memref<128x128xi32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<128x128xi32>
+// CHECK-DAG:       [[RES_2_:%.+]] = memref.alloc() : memref<128x128xf16>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_1_]], [[RES_2_]] : memref<128x128xf16, strided<[1, 1]>> to memref<128x128xf16>
+// CHECK-DAG:       [[VAR_2_:%.+]] = bufferization.to_tensor [[RES_2_]] restrict writable : memref<128x128xf16>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tensor.empty() : tensor<128x128xbf16>
+// CHECK:           [[VAR_4_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_0_]] : tensor<128x128xf32>) outs([[VAR_3_]] : tensor<128x128xbf16>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: bf16):
+// CHECK:             [[VAR_11_:%.+]] = arith.truncf [[IN_0_]] : f32 to bf16
+// CHECK:             linalg.yield [[VAR_11_]] : bf16
+// CHECK:           } -> tensor<128x128xbf16>
+// CHECK:           [[VAR_5_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_0_]] : tensor<128x128xf32>) outs([[VAR_0_]] : tensor<128x128xf32>) {
+// CHECK:           ^bb0([[IN_2_:%.+]]: f32, [[IN_3_:%.+]]: f32):
+// CHECK:             [[VAR_11_1_:%.+]] = math.exp [[IN_2_]] : f32
+// CHECK:             linalg.yield [[VAR_11_1_]] : f32
+// CHECK:           } -> tensor<128x128xf32>
+// CHECK:           [[VAR_6_:%.+]] = tensor.empty() : tensor<128x128xf32>
+// CHECK:           [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_1_]] : tensor<128x128xi32>) outs([[VAR_6_]] : tensor<128x128xf32>) {
+// CHECK:           ^bb0([[IN_4_:%.+]]: i32, [[IN_5_:%.+]]: f32):
+// CHECK:             [[VAR_11_2_:%.+]] = arith.sitofp [[IN_4_]] : i32 to f32
+// CHECK:             linalg.yield [[VAR_11_2_]] : f32
+// CHECK:           } -> tensor<128x128xf32>
+// CHECK:           [[VAR_8_:%.+]] = tensor.empty() : tensor<128x128xf32>
+// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_2_]] : tensor<128x128xf16>) outs([[VAR_8_]] : tensor<128x128xf32>) {
+// CHECK:           ^bb0([[IN_6_:%.+]]: f16, [[IN_7_:%.+]]: f32):
+// CHECK:             [[VAR_11_3_:%.+]] = arith.extf [[IN_6_]] : f16 to f32
+// CHECK:             linalg.yield [[VAR_11_3_]] : f32
+// CHECK:           } -> tensor<128x128xf32>
+// CHECK:           [[VAR_10_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_0_]] : tensor<128x128xf32>) outs([[VAR_0_]] : tensor<128x128xf32>) {
+// CHECK:           ^bb0([[IN_8_:%.+]]: f32, [[IN_9_:%.+]]: f32):
+// CHECK:             [[VAR_11_4_:%.+]] = math.sqrt [[IN_8_]] : f32
+// CHECK:             linalg.yield [[VAR_11_4_]] : f32
+// CHECK:           } -> tensor<128x128xf32>
+// CHECK:           tt.store [[PARAM_3_]], [[VAR_4_]] {cache = 1 : i32, evict = 1 : i32} : tensor<128x128xbf16>
+// CHECK:           tt.store [[PARAM_4_]], [[VAR_5_]] {cache = 1 : i32, evict = 1 : i32} : tensor<128x128xf32>
+// CHECK:           tt.store [[PARAM_5_]], [[VAR_7_]] {cache = 1 : i32, evict = 1 : i32} : tensor<128x128xf32>
+// CHECK:           tt.store [[PARAM_6_]], [[VAR_9_]] {cache = 1 : i32, evict = 1 : i32} : tensor<128x128xf32>
+// CHECK:           tt.store [[PARAM_7_]], [[VAR_10_]] {cache = 1 : i32, evict = 1 : i32} : tensor<128x128xf32>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/convert_2d_elemwise_arith_unary.mlir
+++ b/test/Conversion/StructuredToMemref/convert_2d_elemwise_arith_unary.mlir
@@ -12,20 +12,20 @@ module {
   ) -> () {
     // offset calculations
     %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
-    %1 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<128xi32>) -> tensor<128x1xi32>
-    %moff = tt.broadcast %1 : (tensor<128x1xi32>) -> tensor<128x128xi32>
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<128xi32> -> tensor<128x1xi32>
+    %moff = tt.broadcast %1 : tensor<128x1xi32> -> tensor<128x128xi32>
     %3 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
-    %4 = tt.expand_dims %3 {axis = 0 : i32} : (tensor<128xi32>) -> tensor<1x128xi32>
-    %koff = tt.broadcast %4 : (tensor<1x128xi32>) -> tensor<128x128xi32>
+    %4 = tt.expand_dims %3 {axis = 0 : i32} : tensor<128xi32> -> tensor<1x128xi32>
+    %koff = tt.broadcast %4 : tensor<1x128xi32> -> tensor<128x128xi32>
     %mkoff = arith.addi %moff, %koff : tensor<128x128xi32>
     // f32ptr pointer
-    %8 = tt.splat %f32ptr : (!tt.ptr<f32>) -> tensor<128x128x!tt.ptr<f32>>
+    %8 = tt.splat %f32ptr : !tt.ptr<f32> -> tensor<128x128x!tt.ptr<f32>>
     %9 = tt.addptr %8, %mkoff : tensor<128x128x!tt.ptr<f32>>, tensor<128x128xi32>
     // intptr pointer
-    %18 = tt.splat %intptr : (!tt.ptr<i32>) -> tensor<128x128x!tt.ptr<i32>>
+    %18 = tt.splat %intptr : !tt.ptr<i32> -> tensor<128x128x!tt.ptr<i32>>
     %19 = tt.addptr %18, %mkoff : tensor<128x128x!tt.ptr<i32>>, tensor<128x128xi32>
     // f16ptr pointer
-    %28 = tt.splat %f16ptr : (!tt.ptr<f16>) -> tensor<128x128x!tt.ptr<f16>>
+    %28 = tt.splat %f16ptr : !tt.ptr<f16> -> tensor<128x128x!tt.ptr<f16>>
     %29 = tt.addptr %28, %mkoff : tensor<128x128x!tt.ptr<f16>>, tensor<128x128xi32>
     %afm = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128x128xf32>
     %aim = tt.load %19 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128x128xi32>

--- a/test/Conversion/StructuredToMemref/convert_addi_reduce.mlir
+++ b/test/Conversion/StructuredToMemref/convert_addi_reduce.mlir
@@ -1,0 +1,33 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref  %s | FileCheck %s
+
+module {
+  tt.func public @addi(%arg0: !tt.ptr<i32>) {
+    %cst_0 = arith.constant dense<0> : tensor<4096xi32>
+    %63 = "tt.reduce"(%cst_0) ({
+    ^bb0(%arg14: i32, %arg15: i32):
+      %69 = arith.addi %arg14, %arg15 : i32
+      tt.reduce.return %69 : i32
+    }) {axis = 0 : i32} : (tensor<4096xi32>) -> i32
+    tt.store %arg0, %63 {cache = 1 : i32, evict = 1 : i32} : i32
+    tt.return
+  }
+}
+
+// CHECK-LABEL:  func.func @addi
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xi32>, [[PARAM_1_:%.+]]: i32, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : i32
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [1], strides: [1] : memref<*xi32> to memref<1xi32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<4096xi32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_1_:%.+]] = linalg.fill ins([[CST_0_]] : i32) outs([[VAR_0_]] : tensor<4096xi32>) -> tensor<4096xi32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = bufferization.alloc_tensor() : tensor<i32>
+// CHECK:           [[VAR_inserted_:%.+]] = tensor.insert [[CST_0_]] into [[VAR_2_]][] : tensor<i32>
+// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_1_]] : tensor<4096xi32>) outs([[VAR_inserted_]] : tensor<i32>) dimensions = [0]
+// CHECK:             ([[in_:%.+]]: i32, [[init_:%.+]]: i32) {
+// CHECK:               [[VAR_3_:%.+]] = arith.addi [[in_]], [[init_]] : i32
+// CHECK:               linalg.yield [[VAR_3_]] : i32
+// CHECK:             }
+// CHECK:           [[VAR_extracted_:%.+]] = tensor.extract [[VAR_reduced_]][] : tensor<i32>
+// CHECK:           affine.store [[VAR_extracted_]], [[VAR_reinterpret_cast_]][0] : memref<1xi32, strided<[1], offset: ?>>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/convert_argmin_argmax.mlir
+++ b/test/Conversion/StructuredToMemref/convert_argmin_argmax.mlir
@@ -1,0 +1,149 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref  %s | FileCheck %s
+
+module {
+  tt.func public @argmax_012(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<i32>, %arg2: i32) {
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %arg2 : i32
+    %2 = tt.make_range {end = 4096 : i32, start = 0 : i32} : tensor<4096xi32>
+    %3 = tt.splat %1 : (i32) -> tensor<4096xi32>
+    %4 = arith.addi %3, %2 : tensor<4096xi32>
+    %5 = tt.splat %arg0 : (!tt.ptr<f32>) -> tensor<4096x!tt.ptr<f32>>
+    %6 = tt.addptr %5, %4 : tensor<4096x!tt.ptr<f32>>, tensor<4096xi32>
+    %7 = tt.load %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<4096xf32>
+    %8:2 = "tt.reduce"(%7, %2) <{axis = 0 : i32}> ({
+    ^bb0(%arg9: f32, %arg10: i32, %arg11: f32, %arg12: i32):
+      %11 = arith.cmpf oeq, %arg9, %arg11 : f32
+      %12 = arith.cmpi slt, %arg10, %arg12 : i32
+      %13 = arith.andi %11, %12 : i1
+      %14 = arith.cmpf ogt, %arg9, %arg11 : f32
+      %15 = arith.ori %14, %13 : i1
+      %16 = arith.select %15, %arg9, %arg11 : f32
+      %17 = arith.select %15, %arg10, %arg12 : i32
+      tt.reduce.return %16, %17 : f32, i32
+  }) : (tensor<4096xf32>, tensor<4096xi32>) -> (f32, i32)
+    %9 = tt.addptr %arg1, %0 : !tt.ptr<i32>, i32
+    tt.store %9, %8#1 {cache = 1 : i32, evict = 1 : i32} : i32
+    tt.return
+  }
+}
+
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func @argmax_012
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xi32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_minus_1_:%.+]] = arith.constant -1 : i32
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0xFF800000 : f32
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: [0], sizes: [1], strides: [1] : memref<*xi32> to memref<1xi32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[PARAM_2_]] : i32
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_2_:%.+]] = tensor.empty() : tensor<4096xi32>
+// CHECK:           [[VAR_3_:%.+]] = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel"]} outs([[VAR_2_]] : tensor<4096xi32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: i32):
+// CHECK:             [[VAR_11_:%.+]] = linalg.index 0 : index
+// CHECK:             [[VAR_12_:%.+]] = arith.index_cast [[VAR_11_]] : index to i32
+// CHECK:             linalg.yield [[VAR_12_]] : i32
+// CHECK:           } -> tensor<4096xi32>
+// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [4096], strides: [1] : memref<*xf32> to memref<4096xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<4096xf32>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_0_]], [[RES_]] : memref<4096xf32, strided<[1], offset: ?>> to memref<4096xf32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<4096xf32>
+// CHECK-DAG:       [[VAR_5_:%.+]] = tensor.empty() : tensor<f32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_6_:%.+]] = linalg.fill ins([[CST_0_]] : f32) outs([[VAR_5_]] : tensor<f32>) -> tensor<f32>
+// CHECK-DAG:       [[VAR_7_:%.+]] = tensor.empty() : tensor<i32>
+// CHECK:           [[VAR_8_:%.+]] = linalg.fill ins([[CST_minus_1_]] : i32) outs([[VAR_7_]] : tensor<i32>) -> tensor<i32>
+// CHECK:           [[VAR_reduced_:%.+]]:2 = linalg.reduce ins([[VAR_4_]], [[VAR_3_]] : tensor<4096xf32>, tensor<4096xi32>) outs([[VAR_6_]], [[VAR_8_]] : tensor<f32>, tensor<i32>) dimensions = [0]
+// CHECK:             ([[in_:%.+]]: f32, [[in_2_:%.+]]: i32, [[init_:%.+]]: f32, [[init_3_:%.+]]: i32) {
+// CHECK-DAG:           [[VAR_11_1_:%.+]] = arith.cmpf oeq, [[in_]], [[init_]] : f32
+// CHECK-DAG:           [[VAR_12_1_:%.+]] = arith.cmpi slt, [[in_2_]], [[init_3_]] : i32
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:           [[VAR_13_:%.+]] = arith.andi [[VAR_11_1_]], [[VAR_12_1_]] : i1
+// CHECK-DAG:           [[VAR_14_:%.+]] = arith.cmpf ogt, [[in_]], [[init_]] : f32
+// CHECK:               [[VAR_15_:%.+]] = arith.ori [[VAR_14_]], [[VAR_13_]] : i1
+// CHECK-DAG:           [[VAR_16_:%.+]] = arith.select [[VAR_15_]], [[in_]], [[init_]] : f32
+// CHECK-DAG:           [[VAR_17_:%.+]] = arith.select [[VAR_15_]], [[in_2_]], [[init_3_]] : i32
+// CHECK:               linalg.yield [[VAR_16_]], [[VAR_17_]] : f32, i32
+// CHECK:             }
+// CHECK-DAG:       [[VAR_extracted_:%.+]] = tensor.extract [[VAR_reduced_]]#1[] : tensor<i32>
+// CHECK-DAG:       [[VAR_9_:%.+]] = arith.index_cast [[PARAM_6_]] : i32 to index
+// CHECK:           [[base_buffer_:%.+]], [[offset_:%.+]], [[sizes_:%.+]], [[VAR_strides_:%.+]] = memref.extract_strided_metadata [[VAR_reinterpret_cast_]] : memref<1xi32, strided<[1], offset: ?>> -> memref<i32>, index, index, index
+// CHECK:           [[VAR_10_:%.+]] = arith.addi [[offset_]], [[VAR_9_]] : index
+// CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[base_buffer_]] to offset: {{.}}[[VAR_10_]]{{.}}, sizes: [1], strides: [1] : memref<i32> to memref<1xi32, strided<[1], offset: ?>>
+// CHECK:           affine.store [[VAR_extracted_]], [[VAR_reinterpret_cast_1_]][0] : memref<1xi32, strided<[1], offset: ?>>
+// CHECK:           return
+// CHECK:         }
+
+// -----
+
+module {
+  tt.func public @argmin_012(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<i32>, %arg2: i32) {
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %arg2 : i32
+    %2 = tt.make_range {end = 4096 : i32, start = 0 : i32} : tensor<4096xi32>
+    %3 = tt.splat %1 : (i32) -> tensor<4096xi32>
+    %4 = arith.addi %3, %2 : tensor<4096xi32>
+    %5 = tt.splat %arg0 : (!tt.ptr<f32>) -> tensor<4096x!tt.ptr<f32>>
+    %6 = tt.addptr %5, %4 : tensor<4096x!tt.ptr<f32>>, tensor<4096xi32>
+    %7 = tt.load %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<4096xf32>
+    %8:2 = "tt.reduce"(%7, %2) <{axis = 0 : i32}> ({
+    ^bb0(%arg9: f32, %arg10: i32, %arg11: f32, %arg12: i32):
+      %11 = arith.cmpf oeq, %arg9, %arg11 : f32
+      %12 = arith.cmpi slt, %arg10, %arg12 : i32
+      %13 = arith.andi %11, %12 : i1
+      %14 = arith.cmpf olt, %arg9, %arg11 : f32
+      %15 = arith.ori %14, %13 : i1
+      %16 = arith.select %15, %arg9, %arg11 : f32
+      %17 = arith.select %15, %arg10, %arg12 : i32
+      tt.reduce.return %16, %17 : f32, i32
+  }) : (tensor<4096xf32>, tensor<4096xi32>) -> (f32, i32)
+    %9 = tt.addptr %arg1, %0 : !tt.ptr<i32>, i32
+    tt.store %9, %8#1 {cache = 1 : i32, evict = 1 : i32} : i32
+    tt.return
+  }
+}
+
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func @argmin_012
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xi32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_minus_1_:%.+]] = arith.constant -1 : i32
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0x7F800000 : f32
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: [0], sizes: [1], strides: [1] : memref<*xi32> to memref<1xi32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[PARAM_2_]] : i32
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_2_:%.+]] = tensor.empty() : tensor<4096xi32>
+// CHECK:           [[VAR_3_:%.+]] = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel"]} outs([[VAR_2_]] : tensor<4096xi32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: i32):
+// CHECK:             [[VAR_11_:%.+]] = linalg.index 0 : index
+// CHECK:             [[VAR_12_:%.+]] = arith.index_cast [[VAR_11_]] : index to i32
+// CHECK:             linalg.yield [[VAR_12_]] : i32
+// CHECK:           } -> tensor<4096xi32>
+// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [4096], strides: [1] : memref<*xf32> to memref<4096xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<4096xf32>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_0_]], [[RES_]] : memref<4096xf32, strided<[1], offset: ?>> to memref<4096xf32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<4096xf32>
+// CHECK-DAG:       [[VAR_5_:%.+]] = tensor.empty() : tensor<f32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_6_:%.+]] = linalg.fill ins([[CST_0_]] : f32) outs([[VAR_5_]] : tensor<f32>) -> tensor<f32>
+// CHECK-DAG:       [[VAR_7_:%.+]] = tensor.empty() : tensor<i32>
+// CHECK:           [[VAR_8_:%.+]] = linalg.fill ins([[CST_minus_1_]] : i32) outs([[VAR_7_]] : tensor<i32>) -> tensor<i32>
+// CHECK:           [[VAR_reduced_:%.+]]:2 = linalg.reduce ins([[VAR_4_]], [[VAR_3_]] : tensor<4096xf32>, tensor<4096xi32>) outs([[VAR_6_]], [[VAR_8_]] : tensor<f32>, tensor<i32>) dimensions = [0]
+// CHECK:             ([[in_:%.+]]: f32, [[in_2_:%.+]]: i32, [[init_:%.+]]: f32, [[init_3_:%.+]]: i32) {
+// CHECK-DAG:           [[VAR_11_1_:%.+]] = arith.cmpf oeq, [[in_]], [[init_]] : f32
+// CHECK-DAG:           [[VAR_12_1_:%.+]] = arith.cmpi slt, [[in_2_]], [[init_3_]] : i32
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:           [[VAR_13_:%.+]] = arith.andi [[VAR_11_1_]], [[VAR_12_1_]] : i1
+// CHECK-DAG:           [[VAR_14_:%.+]] = arith.cmpf olt, [[in_]], [[init_]] : f32
+// CHECK:               [[VAR_15_:%.+]] = arith.ori [[VAR_14_]], [[VAR_13_]] : i1
+// CHECK-DAG:           [[VAR_16_:%.+]] = arith.select [[VAR_15_]], [[in_]], [[init_]] : f32
+// CHECK-DAG:           [[VAR_17_:%.+]] = arith.select [[VAR_15_]], [[in_2_]], [[init_3_]] : i32
+// CHECK:               linalg.yield [[VAR_16_]], [[VAR_17_]] : f32, i32
+// CHECK:             }
+// CHECK-DAG:       [[VAR_extracted_:%.+]] = tensor.extract [[VAR_reduced_]]#1[] : tensor<i32>
+// CHECK-DAG:       [[VAR_9_:%.+]] = arith.index_cast [[PARAM_6_]] : i32 to index
+// CHECK:           [[base_buffer_:%.+]], [[offset_:%.+]], [[sizes_:%.+]], [[VAR_strides_:%.+]] = memref.extract_strided_metadata [[VAR_reinterpret_cast_]] : memref<1xi32, strided<[1], offset: ?>> -> memref<i32>, index, index, index
+// CHECK:           [[VAR_10_:%.+]] = arith.addi [[offset_]], [[VAR_9_]] : index
+// CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[base_buffer_]] to offset: {{.}}[[VAR_10_]]{{.}}, sizes: [1], strides: [1] : memref<i32> to memref<1xi32, strided<[1], offset: ?>>
+// CHECK:           affine.store [[VAR_extracted_]], [[VAR_reinterpret_cast_1_]][0] : memref<1xi32, strided<[1], offset: ?>>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/convert_argmin_argmax.mlir
+++ b/test/Conversion/StructuredToMemref/convert_argmin_argmax.mlir
@@ -5,9 +5,9 @@ module {
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %arg2 : i32
     %2 = tt.make_range {end = 4096 : i32, start = 0 : i32} : tensor<4096xi32>
-    %3 = tt.splat %1 : (i32) -> tensor<4096xi32>
+    %3 = tt.splat %1 : i32 -> tensor<4096xi32>
     %4 = arith.addi %3, %2 : tensor<4096xi32>
-    %5 = tt.splat %arg0 : (!tt.ptr<f32>) -> tensor<4096x!tt.ptr<f32>>
+    %5 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<4096x!tt.ptr<f32>>
     %6 = tt.addptr %5, %4 : tensor<4096x!tt.ptr<f32>>, tensor<4096xi32>
     %7 = tt.load %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<4096xf32>
     %8:2 = "tt.reduce"(%7, %2) <{axis = 0 : i32}> ({
@@ -80,9 +80,9 @@ module {
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %arg2 : i32
     %2 = tt.make_range {end = 4096 : i32, start = 0 : i32} : tensor<4096xi32>
-    %3 = tt.splat %1 : (i32) -> tensor<4096xi32>
+    %3 = tt.splat %1 : i32 -> tensor<4096xi32>
     %4 = arith.addi %3, %2 : tensor<4096xi32>
-    %5 = tt.splat %arg0 : (!tt.ptr<f32>) -> tensor<4096x!tt.ptr<f32>>
+    %5 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<4096x!tt.ptr<f32>>
     %6 = tt.addptr %5, %4 : tensor<4096x!tt.ptr<f32>>, tensor<4096xi32>
     %7 = tt.load %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<4096xf32>
     %8:2 = "tt.reduce"(%7, %2) <{axis = 0 : i32}> ({

--- a/test/Conversion/StructuredToMemref/convert_argmin_argmax_2d.mlir
+++ b/test/Conversion/StructuredToMemref/convert_argmin_argmax_2d.mlir
@@ -20,19 +20,19 @@
 module {
   tt.func public @test_argmax(%arg0: !tt.ptr<f32, 1>, %arg1: !tt.ptr<f32, 1>, %arg2: i32, %arg3: i32) attributes {noinline = false} {
     %0 = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32>
-    %1 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<4xi32>) -> tensor<4x1xi32>
-    %2 = tt.splat %arg2 : (i32) -> tensor<4x1xi32>
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<4xi32> -> tensor<4x1xi32>
+    %2 = tt.splat %arg2 : i32 -> tensor<4x1xi32>
     %3 = arith.muli %1, %2 : tensor<4x1xi32>
-    %4 = tt.expand_dims %0 {axis = 0 : i32} : (tensor<4xi32>) -> tensor<1x4xi32>
-    %5 = tt.splat %arg3 : (i32) -> tensor<1x4xi32>
+    %4 = tt.expand_dims %0 {axis = 0 : i32} : tensor<4xi32> -> tensor<1x4xi32>
+    %5 = tt.splat %arg3 : i32 -> tensor<1x4xi32>
     %6 = arith.muli %4, %5 : tensor<1x4xi32>
-    %7 = tt.broadcast %3 : (tensor<4x1xi32>) -> tensor<4x4xi32>
-    %8 = tt.broadcast %6 : (tensor<1x4xi32>) -> tensor<4x4xi32>
+    %7 = tt.broadcast %3 : tensor<4x1xi32> -> tensor<4x4xi32>
+    %8 = tt.broadcast %6 : tensor<1x4xi32> -> tensor<4x4xi32>
     %9 = arith.addi %7, %8 : tensor<4x4xi32>
-    %10 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<4x4x!tt.ptr<f32, 1>>
+    %10 = tt.splat %arg0 : !tt.ptr<f32, 1> -> tensor<4x4x!tt.ptr<f32, 1>>
     %11 = tt.addptr %10, %9 : tensor<4x4x!tt.ptr<f32, 1>>, tensor<4x4xi32>
     %12 = tt.load %11 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<4x4xf32>
-    %13 = tt.broadcast %4 : (tensor<1x4xi32>) -> tensor<4x4xi32>
+    %13 = tt.broadcast %4 : tensor<1x4xi32> -> tensor<4x4xi32>
     %14:2 = "tt.reduce"(%12, %13) <{axis = 1 : i32}> ({
     ^bb0(%arg4: f32, %arg5: i32, %arg6: f32, %arg7: i32):
       %18 = arith.cmpf oeq, %arg4, %arg6 : f32
@@ -44,7 +44,7 @@ module {
       %24 = arith.select %22, %arg5, %arg7 : i32
       tt.reduce.return %23, %24 : f32, i32
     }) : (tensor<4x4xf32>, tensor<4x4xi32>) -> (tensor<4xf32>, tensor<4xi32>)
-    %15 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<4x!tt.ptr<f32, 1>>
+    %15 = tt.splat %arg1 : !tt.ptr<f32, 1> -> tensor<4x!tt.ptr<f32, 1>>
     %16 = tt.addptr %15, %0 : tensor<4x!tt.ptr<f32, 1>>, tensor<4xi32>
     %17 = arith.sitofp %14#1 : tensor<4xi32> to tensor<4xf32>
     tt.store %16, %17 {cache = 1 : i32, evict = 1 : i32} : tensor<4xf32>
@@ -129,19 +129,19 @@ module {
 module {
   tt.func public @test_argmin(%arg0: !tt.ptr<f32, 1>, %arg1: !tt.ptr<f32, 1>, %arg2: i32, %arg3: i32) attributes {noinline = false} {
     %0 = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32>
-    %1 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<4xi32>) -> tensor<4x1xi32>
-    %2 = tt.splat %arg2 : (i32) -> tensor<4x1xi32>
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<4xi32> -> tensor<4x1xi32>
+    %2 = tt.splat %arg2 : i32 -> tensor<4x1xi32>
     %3 = arith.muli %1, %2 : tensor<4x1xi32>
-    %4 = tt.expand_dims %0 {axis = 0 : i32} : (tensor<4xi32>) -> tensor<1x4xi32>
-    %5 = tt.splat %arg3 : (i32) -> tensor<1x4xi32>
+    %4 = tt.expand_dims %0 {axis = 0 : i32} : tensor<4xi32> -> tensor<1x4xi32>
+    %5 = tt.splat %arg3 : i32 -> tensor<1x4xi32>
     %6 = arith.muli %4, %5 : tensor<1x4xi32>
-    %7 = tt.broadcast %3 : (tensor<4x1xi32>) -> tensor<4x4xi32>
-    %8 = tt.broadcast %6 : (tensor<1x4xi32>) -> tensor<4x4xi32>
+    %7 = tt.broadcast %3 : tensor<4x1xi32> -> tensor<4x4xi32>
+    %8 = tt.broadcast %6 : tensor<1x4xi32> -> tensor<4x4xi32>
     %9 = arith.addi %7, %8 : tensor<4x4xi32>
-    %10 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<4x4x!tt.ptr<f32, 1>>
+    %10 = tt.splat %arg0 : !tt.ptr<f32, 1> -> tensor<4x4x!tt.ptr<f32, 1>>
     %11 = tt.addptr %10, %9 : tensor<4x4x!tt.ptr<f32, 1>>, tensor<4x4xi32>
     %12 = tt.load %11 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<4x4xf32>
-    %13 = tt.broadcast %4 : (tensor<1x4xi32>) -> tensor<4x4xi32>
+    %13 = tt.broadcast %4 : tensor<1x4xi32> -> tensor<4x4xi32>
     %14:2 = "tt.reduce"(%12, %13) <{axis = 1 : i32}> ({
     ^bb0(%arg4: f32, %arg5: i32, %arg6: f32, %arg7: i32):
       %18 = arith.cmpf oeq, %arg4, %arg6 : f32
@@ -153,7 +153,7 @@ module {
       %24 = arith.select %22, %arg5, %arg7 : i32
       tt.reduce.return %23, %24 : f32, i32
     }) : (tensor<4x4xf32>, tensor<4x4xi32>) -> (tensor<4xf32>, tensor<4xi32>)
-    %15 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<4x!tt.ptr<f32, 1>>
+    %15 = tt.splat %arg1 : !tt.ptr<f32, 1> -> tensor<4x!tt.ptr<f32, 1>>
     %16 = tt.addptr %15, %0 : tensor<4x!tt.ptr<f32, 1>>, tensor<4xi32>
     %17 = arith.sitofp %14#1 : tensor<4xi32> to tensor<4xf32>
     tt.store %16, %17 {cache = 1 : i32, evict = 1 : i32} : tensor<4xf32>

--- a/test/Conversion/StructuredToMemref/convert_argmin_argmax_2d.mlir
+++ b/test/Conversion/StructuredToMemref/convert_argmin_argmax_2d.mlir
@@ -1,0 +1,216 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref  %s | FileCheck %s
+
+// @triton.jit
+// def test(
+//     a_ptr, c_ptr, stride_am, stride_an
+// ):
+//     offs_am = tl.arange(0, 4)
+//     offs_an = tl.arange(0, 4)
+//     a_ptrs = a_ptr + (offs_am[:, None] * stride_am + offs_an[None, :] * stride_an)
+//     a = tl.load(a_ptrs)
+//     m = tl.argmax(a, axis=1)
+//     tl.store(c_ptr + tl.arange(0, 4), m)
+//
+// ret = triton.compiler.compile(
+//     test,
+//     signature=" *fp32,*fp32,i32,i32",
+//     print_triton_ir_only=True,
+// )
+
+module {
+  tt.func public @test_argmax(%arg0: !tt.ptr<f32, 1>, %arg1: !tt.ptr<f32, 1>, %arg2: i32, %arg3: i32) attributes {noinline = false} {
+    %0 = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32>
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<4xi32>) -> tensor<4x1xi32>
+    %2 = tt.splat %arg2 : (i32) -> tensor<4x1xi32>
+    %3 = arith.muli %1, %2 : tensor<4x1xi32>
+    %4 = tt.expand_dims %0 {axis = 0 : i32} : (tensor<4xi32>) -> tensor<1x4xi32>
+    %5 = tt.splat %arg3 : (i32) -> tensor<1x4xi32>
+    %6 = arith.muli %4, %5 : tensor<1x4xi32>
+    %7 = tt.broadcast %3 : (tensor<4x1xi32>) -> tensor<4x4xi32>
+    %8 = tt.broadcast %6 : (tensor<1x4xi32>) -> tensor<4x4xi32>
+    %9 = arith.addi %7, %8 : tensor<4x4xi32>
+    %10 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<4x4x!tt.ptr<f32, 1>>
+    %11 = tt.addptr %10, %9 : tensor<4x4x!tt.ptr<f32, 1>>, tensor<4x4xi32>
+    %12 = tt.load %11 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<4x4xf32>
+    %13 = tt.broadcast %4 : (tensor<1x4xi32>) -> tensor<4x4xi32>
+    %14:2 = "tt.reduce"(%12, %13) <{axis = 1 : i32}> ({
+    ^bb0(%arg4: f32, %arg5: i32, %arg6: f32, %arg7: i32):
+      %18 = arith.cmpf oeq, %arg4, %arg6 : f32
+      %19 = arith.cmpi slt, %arg5, %arg7 : i32
+      %20 = arith.andi %18, %19 : i1
+      %21 = arith.cmpf ogt, %arg4, %arg6 : f32
+      %22 = arith.ori %21, %20 : i1
+      %23 = arith.select %22, %arg4, %arg6 : f32
+      %24 = arith.select %22, %arg5, %arg7 : i32
+      tt.reduce.return %23, %24 : f32, i32
+    }) : (tensor<4x4xf32>, tensor<4x4xi32>) -> (tensor<4xf32>, tensor<4xi32>)
+    %15 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<4x!tt.ptr<f32, 1>>
+    %16 = tt.addptr %15, %0 : tensor<4x!tt.ptr<f32, 1>>, tensor<4xi32>
+    %17 = arith.sitofp %14#1 : tensor<4xi32> to tensor<4xf32>
+    tt.store %16, %17 {cache = 1 : i32, evict = 1 : i32} : tensor<4xf32>
+    tt.return
+  }
+}
+
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-DAG:   [[MAP_1_:#.+]] = affine_map<(d0, d1) -> (0, d1)>
+// CHECK-DAG:   [[MAP_2_:#.+]] = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK-LABEL:  func.func @test_argmax
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_minus_1_:%.+]] = arith.constant -1 : i32
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0xFF800000 : f32
+// CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<4xi32>
+// CHECK:           [[VAR_1_:%.+]] = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel"]} outs([[VAR_0_]] : tensor<4xi32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: i32):
+// CHECK:             [[VAR_13_:%.+]] = linalg.index 0 : index
+// CHECK:             [[VAR_14_:%.+]] = arith.index_cast [[VAR_13_]] : index to i32
+// CHECK:             linalg.yield [[VAR_14_]] : i32
+// CHECK:           } -> tensor<4xi32>
+// CHECK-DAG:       [[VAR_expanded_:%.+]] = tensor.expand_shape [[VAR_1_]] {{.}}[0, 1]{{.}} : tensor<4xi32> into tensor<1x4xi32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [4, 4], strides: {{.}}[[VAR_2_]], [[VAR_3_]]{{.}} : memref<*xf32> to memref<4x4xf32, strided<[?, ?]>>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<4x4xf32>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<4x4xf32, strided<[?, ?]>> to memref<4x4xf32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<4x4xf32>
+// CHECK-DAG:       [[VAR_5_:%.+]] = tensor.empty() : tensor<4x4xi32>
+// CHECK:           [[VAR_6_:%.+]] = linalg.generic {indexing_maps = [#map1, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_]] : tensor<1x4xi32>) outs([[VAR_5_]] : tensor<4x4xi32>) attrs =  {broadcastDims = array<i64: 0>} {
+// CHECK:           ^bb0([[IN_1_:%.+]]: i32, [[IN_2_:%.+]]: i32):
+// CHECK:             linalg.yield [[IN_1_]] : i32
+// CHECK:           } -> tensor<4x4xi32>
+// CHECK:           [[VAR_7_:%.+]] = tensor.empty() : tensor<4xf32>
+// CHECK-DAG:       [[VAR_8_:%.+]] = linalg.fill ins([[CST_0_]] : f32) outs([[VAR_7_]] : tensor<4xf32>) -> tensor<4xf32>
+// CHECK-DAG:       [[VAR_9_:%.+]] = tensor.empty() : tensor<4xi32>
+// CHECK:           [[VAR_10_:%.+]] = linalg.fill ins([[CST_minus_1_]] : i32) outs([[VAR_9_]] : tensor<4xi32>) -> tensor<4xi32>
+// CHECK:           [[VAR_reduced_:%.+]]:2 = linalg.reduce ins([[VAR_4_]], [[VAR_6_]] : tensor<4x4xf32>, tensor<4x4xi32>) outs([[VAR_8_]], [[VAR_10_]] : tensor<4xf32>, tensor<4xi32>) dimensions = [1]
+// CHECK:             ([[IN_1_:%.+]]: f32, [[in_1_:%.+]]: i32, [[init_:%.+]]: f32, [[init_2_:%.+]]: i32) {
+// CHECK-DAG:           [[VAR_13_1_:%.+]] = arith.cmpf oeq, [[IN_1_]], [[init_]] : f32
+// CHECK-DAG:           [[VAR_14_1_:%.+]] = arith.cmpi slt, [[in_1_]], [[init_2_]] : i32
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:           [[VAR_15_:%.+]] = arith.andi [[VAR_13_1_]], [[VAR_14_1_]] : i1
+// CHECK-DAG:           [[VAR_16_:%.+]] = arith.cmpf ogt, [[IN_1_]], [[init_]] : f32
+// CHECK:               [[VAR_17_:%.+]] = arith.ori [[VAR_16_]], [[VAR_15_]] : i1
+// CHECK-DAG:           [[VAR_18_:%.+]] = arith.select [[VAR_17_]], [[IN_1_]], [[init_]] : f32
+// CHECK-DAG:           [[VAR_19_:%.+]] = arith.select [[VAR_17_]], [[in_1_]], [[init_2_]] : i32
+// CHECK:               linalg.yield [[VAR_18_]], [[VAR_19_]] : f32, i32
+// CHECK:             }
+// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: [0], sizes: [4], strides: [1] : memref<*xf32> to memref<4xf32, strided<[1]>>
+// CHECK-DAG:       [[VAR_11_:%.+]] = tensor.empty() : tensor<4xf32>
+// CHECK:           [[VAR_12_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_reduced_]]#1 : tensor<4xi32>) outs([[VAR_11_]] : tensor<4xf32>) {
+// CHECK:           ^bb0([[IN_3_:%.+]]: i32, [[IN_4_:%.+]]: f32):
+// CHECK:             [[VAR_13_2_:%.+]] = arith.sitofp [[IN_3_]] : i32 to f32
+// CHECK:             linalg.yield [[VAR_13_2_]] : f32
+// CHECK:           } -> tensor<4xf32>
+// CHECK:           bufferization.materialize_in_destination [[VAR_12_]] in writable [[VAR_reinterpret_cast_0_]] : (tensor<4xf32>, memref<4xf32, strided<[1]>>) -> ()
+// CHECK:           return
+// CHECK:         }
+
+
+// -----
+
+// @triton.jit
+// def test(
+//     a_ptr, c_ptr, stride_am, stride_an
+// ):
+//     offs_am = tl.arange(0, 4)
+//     offs_an = tl.arange(0, 4)
+//     a_ptrs = a_ptr + (offs_am[:, None] * stride_am + offs_an[None, :] * stride_an)
+//     a = tl.load(a_ptrs)
+//     m = tl.argmin(a, axis=1)
+//     tl.store(c_ptr + tl.arange(0, 4), m)
+//
+// ret = triton.compiler.compile(
+//     test,
+//     signature=" *fp32,*fp32,i32,i32",
+//     print_triton_ir_only=True,
+// )
+
+module {
+  tt.func public @test_argmin(%arg0: !tt.ptr<f32, 1>, %arg1: !tt.ptr<f32, 1>, %arg2: i32, %arg3: i32) attributes {noinline = false} {
+    %0 = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32>
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<4xi32>) -> tensor<4x1xi32>
+    %2 = tt.splat %arg2 : (i32) -> tensor<4x1xi32>
+    %3 = arith.muli %1, %2 : tensor<4x1xi32>
+    %4 = tt.expand_dims %0 {axis = 0 : i32} : (tensor<4xi32>) -> tensor<1x4xi32>
+    %5 = tt.splat %arg3 : (i32) -> tensor<1x4xi32>
+    %6 = arith.muli %4, %5 : tensor<1x4xi32>
+    %7 = tt.broadcast %3 : (tensor<4x1xi32>) -> tensor<4x4xi32>
+    %8 = tt.broadcast %6 : (tensor<1x4xi32>) -> tensor<4x4xi32>
+    %9 = arith.addi %7, %8 : tensor<4x4xi32>
+    %10 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<4x4x!tt.ptr<f32, 1>>
+    %11 = tt.addptr %10, %9 : tensor<4x4x!tt.ptr<f32, 1>>, tensor<4x4xi32>
+    %12 = tt.load %11 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<4x4xf32>
+    %13 = tt.broadcast %4 : (tensor<1x4xi32>) -> tensor<4x4xi32>
+    %14:2 = "tt.reduce"(%12, %13) <{axis = 1 : i32}> ({
+    ^bb0(%arg4: f32, %arg5: i32, %arg6: f32, %arg7: i32):
+      %18 = arith.cmpf oeq, %arg4, %arg6 : f32
+      %19 = arith.cmpi slt, %arg5, %arg7 : i32
+      %20 = arith.andi %18, %19 : i1
+      %21 = arith.cmpf olt, %arg4, %arg6 : f32
+      %22 = arith.ori %21, %20 : i1
+      %23 = arith.select %22, %arg4, %arg6 : f32
+      %24 = arith.select %22, %arg5, %arg7 : i32
+      tt.reduce.return %23, %24 : f32, i32
+    }) : (tensor<4x4xf32>, tensor<4x4xi32>) -> (tensor<4xf32>, tensor<4xi32>)
+    %15 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<4x!tt.ptr<f32, 1>>
+    %16 = tt.addptr %15, %0 : tensor<4x!tt.ptr<f32, 1>>, tensor<4xi32>
+    %17 = arith.sitofp %14#1 : tensor<4xi32> to tensor<4xf32>
+    tt.store %16, %17 {cache = 1 : i32, evict = 1 : i32} : tensor<4xf32>
+    tt.return
+  }
+}
+
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-DAG:   [[MAP_1_:#.+]] = affine_map<(d0, d1) -> (0, d1)>
+// CHECK-DAG:   [[MAP_2_:#.+]] = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK-LABEL:  func.func @test_argmin
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_minus_1_:%.+]] = arith.constant -1 : i32
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0x7F800000 : f32
+// CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<4xi32>
+// CHECK:           [[VAR_1_:%.+]] = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel"]} outs([[VAR_0_]] : tensor<4xi32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: i32):
+// CHECK:             [[VAR_13_:%.+]] = linalg.index 0 : index
+// CHECK:             [[VAR_14_:%.+]] = arith.index_cast [[VAR_13_]] : index to i32
+// CHECK:             linalg.yield [[VAR_14_]] : i32
+// CHECK:           } -> tensor<4xi32>
+// CHECK-DAG:       [[VAR_expanded_:%.+]] = tensor.expand_shape [[VAR_1_]] {{.}}[0, 1]{{.}} : tensor<4xi32> into tensor<1x4xi32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [4, 4], strides: {{.}}[[VAR_2_]], [[VAR_3_]]{{.}} : memref<*xf32> to memref<4x4xf32, strided<[?, ?]>>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<4x4xf32>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<4x4xf32, strided<[?, ?]>> to memref<4x4xf32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<4x4xf32>
+// CHECK-DAG:       [[VAR_5_:%.+]] = tensor.empty() : tensor<4x4xi32>
+// CHECK:           [[VAR_6_:%.+]] = linalg.generic {indexing_maps = [#map1, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_]] : tensor<1x4xi32>) outs([[VAR_5_]] : tensor<4x4xi32>) attrs =  {broadcastDims = array<i64: 0>} {
+// CHECK:           ^bb0([[IN_1_:%.+]]: i32, [[IN_2_:%.+]]: i32):
+// CHECK:             linalg.yield [[IN_1_]] : i32
+// CHECK:           } -> tensor<4x4xi32>
+// CHECK:           [[VAR_7_:%.+]] = tensor.empty() : tensor<4xf32>
+// CHECK-DAG:       [[VAR_8_:%.+]] = linalg.fill ins([[CST_0_]] : f32) outs([[VAR_7_]] : tensor<4xf32>) -> tensor<4xf32>
+// CHECK-DAG:       [[VAR_9_:%.+]] = tensor.empty() : tensor<4xi32>
+// CHECK:           [[VAR_10_:%.+]] = linalg.fill ins([[CST_minus_1_]] : i32) outs([[VAR_9_]] : tensor<4xi32>) -> tensor<4xi32>
+// CHECK:           [[VAR_reduced_:%.+]]:2 = linalg.reduce ins([[VAR_4_]], [[VAR_6_]] : tensor<4x4xf32>, tensor<4x4xi32>) outs([[VAR_8_]], [[VAR_10_]] : tensor<4xf32>, tensor<4xi32>) dimensions = [1]
+// CHECK:             ([[IN_1_:%.+]]: f32, [[in_1_:%.+]]: i32, [[init_:%.+]]: f32, [[init_2_:%.+]]: i32) {
+// CHECK-DAG:           [[VAR_13_1_:%.+]] = arith.cmpf oeq, [[IN_1_]], [[init_]] : f32
+// CHECK-DAG:           [[VAR_14_1_:%.+]] = arith.cmpi slt, [[in_1_]], [[init_2_]] : i32
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:           [[VAR_15_:%.+]] = arith.andi [[VAR_13_1_]], [[VAR_14_1_]] : i1
+// CHECK-DAG:           [[VAR_16_:%.+]] = arith.cmpf olt, [[IN_1_]], [[init_]] : f32
+// CHECK:               [[VAR_17_:%.+]] = arith.ori [[VAR_16_]], [[VAR_15_]] : i1
+// CHECK-DAG:           [[VAR_18_:%.+]] = arith.select [[VAR_17_]], [[IN_1_]], [[init_]] : f32
+// CHECK-DAG:           [[VAR_19_:%.+]] = arith.select [[VAR_17_]], [[in_1_]], [[init_2_]] : i32
+// CHECK:               linalg.yield [[VAR_18_]], [[VAR_19_]] : f32, i32
+// CHECK:             }
+// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: [0], sizes: [4], strides: [1] : memref<*xf32> to memref<4xf32, strided<[1]>>
+// CHECK-DAG:       [[VAR_11_:%.+]] = tensor.empty() : tensor<4xf32>
+// CHECK:           [[VAR_12_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_reduced_]]#1 : tensor<4xi32>) outs([[VAR_11_]] : tensor<4xf32>) {
+// CHECK:           ^bb0([[IN_3_:%.+]]: i32, [[IN_4_:%.+]]: f32):
+// CHECK:             [[VAR_13_2_:%.+]] = arith.sitofp [[IN_3_]] : i32 to f32
+// CHECK:             linalg.yield [[VAR_13_2_]] : f32
+// CHECK:           } -> tensor<4xf32>
+// CHECK:           bufferization.materialize_in_destination [[VAR_12_]] in writable [[VAR_reinterpret_cast_0_]] : (tensor<4xf32>, memref<4xf32, strided<[1]>>) -> ()
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/convert_extern_elementwise.mlir
+++ b/test/Conversion/StructuredToMemref/convert_extern_elementwise.mlir
@@ -1,0 +1,1462 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref  %s | FileCheck %s
+
+module {
+  tt.func public @atan2_kernel_0123(%arg0: !tt.ptr<f32, 1>, %arg1: !tt.ptr<f32, 1>, %arg2: !tt.ptr<f32, 1>, %arg3: i32) attributes {noinline = false} {
+    %c32_i32 = arith.constant 32 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c32_i32 : i32
+    %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %4 = arith.addi %3, %2 : tensor<32xi32>
+    %5 = tt.splat %arg3 : (i32) -> tensor<32xi32>
+    %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
+    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
+    %10 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %11 = tt.addptr %10, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    %12 = tt.load %11, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
+    %13 = tt.extern_elementwise %9, %12 {libname = "", libpath = "", pure = true, symbol = "__nv_atan2f"} : (tensor<32xf32>, tensor<32xf32>) -> tensor<32xf32>
+    %14 = tt.splat %arg2 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %15 = tt.addptr %14, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    tt.store %15, %13 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
+    tt.return
+  }
+}
+
+// -----
+
+module {
+  tt.func public @pow_kernel_0123(%arg0: !tt.ptr<f32, 1>, %arg1: !tt.ptr<f32, 1>, %arg2: !tt.ptr<f32, 1>, %arg3: i32) attributes {noinline = false} {
+    %c32_i32 = arith.constant 32 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c32_i32 : i32
+    %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %4 = arith.addi %3, %2 : tensor<32xi32>
+    %5 = tt.splat %arg3 : (i32) -> tensor<32xi32>
+    %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
+    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
+    %10 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %11 = tt.addptr %10, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    %12 = tt.load %11, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
+    %13 = tt.extern_elementwise %9, %12 {libname = "", libpath = "", pure = true, symbol = "__nv_powf"} : (tensor<32xf32>, tensor<32xf32>) -> tensor<32xf32>
+    %14 = tt.splat %arg2 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %15 = tt.addptr %14, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    tt.store %15, %13 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
+    tt.return
+  }
+}
+
+// -----
+
+module {
+  tt.func public @fabs_kernel_012(%arg0: !tt.ptr<f32, 1>, %arg1: !tt.ptr<f32, 1>, %arg2: i32) attributes {noinline = false} {
+    %c32_i32 = arith.constant 32 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c32_i32 : i32
+    %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %4 = arith.addi %3, %2 : tensor<32xi32>
+    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
+    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_fabsf"} : (tensor<32xf32>) -> tensor<32xf32>
+    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
+    tt.return
+  }
+}
+
+
+// -----
+
+module {
+  tt.func public @sin_kernel_012(%arg0: !tt.ptr<f32, 1>, %arg1: !tt.ptr<f32, 1>, %arg2: i32) attributes {noinline = false} {
+    %c32_i32 = arith.constant 32 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c32_i32 : i32
+    %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %4 = arith.addi %3, %2 : tensor<32xi32>
+    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
+    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_sinf"} : (tensor<32xf32>) -> tensor<32xf32>
+    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
+    tt.return
+  }
+}
+
+
+// -----
+
+module {
+  tt.func public @cos_kernel_012(%arg0: !tt.ptr<f32, 1>, %arg1: !tt.ptr<f32, 1>, %arg2: i32) attributes {noinline = false} {
+    %c32_i32 = arith.constant 32 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c32_i32 : i32
+    %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %4 = arith.addi %3, %2 : tensor<32xi32>
+    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
+    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_cosf"} : (tensor<32xf32>) -> tensor<32xf32>
+    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
+    tt.return
+  }
+}
+
+
+// -----
+
+module {
+  tt.func public @tan_kernel_012(%arg0: !tt.ptr<f32, 1>, %arg1: !tt.ptr<f32, 1>, %arg2: i32) attributes {noinline = false} {
+    %c32_i32 = arith.constant 32 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c32_i32 : i32
+    %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %4 = arith.addi %3, %2 : tensor<32xi32>
+    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
+    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_tanf"} : (tensor<32xf32>) -> tensor<32xf32>
+    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
+    tt.return
+  }
+}
+
+
+// -----
+
+module {
+  tt.func public @asin_kernel_012(%arg0: !tt.ptr<f32, 1>, %arg1: !tt.ptr<f32, 1>, %arg2: i32) attributes {noinline = false} {
+    %c32_i32 = arith.constant 32 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c32_i32 : i32
+    %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %4 = arith.addi %3, %2 : tensor<32xi32>
+    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
+    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_asinf"} : (tensor<32xf32>) -> tensor<32xf32>
+    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
+    tt.return
+  }
+}
+
+
+// -----
+
+module {
+  tt.func public @acos_kernel_012(%arg0: !tt.ptr<f32, 1>, %arg1: !tt.ptr<f32, 1>, %arg2: i32) attributes {noinline = false} {
+    %c32_i32 = arith.constant 32 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c32_i32 : i32
+    %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %4 = arith.addi %3, %2 : tensor<32xi32>
+    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
+    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_acosf"} : (tensor<32xf32>) -> tensor<32xf32>
+    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
+    tt.return
+  }
+}
+
+
+// -----
+
+module {
+  tt.func public @atan_kernel_012(%arg0: !tt.ptr<f32, 1>, %arg1: !tt.ptr<f32, 1>, %arg2: i32) attributes {noinline = false} {
+    %c32_i32 = arith.constant 32 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c32_i32 : i32
+    %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %4 = arith.addi %3, %2 : tensor<32xi32>
+    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
+    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_atanf"} : (tensor<32xf32>) -> tensor<32xf32>
+    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
+    tt.return
+  }
+}
+
+
+// -----
+
+module {
+  tt.func public @sinh_kernel_012(%arg0: !tt.ptr<f32, 1>, %arg1: !tt.ptr<f32, 1>, %arg2: i32) attributes {noinline = false} {
+    %c32_i32 = arith.constant 32 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c32_i32 : i32
+    %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %4 = arith.addi %3, %2 : tensor<32xi32>
+    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
+    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_sinhf"} : (tensor<32xf32>) -> tensor<32xf32>
+    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
+    tt.return
+  }
+}
+
+
+// -----
+
+module {
+  tt.func public @cosh_kernel_012(%arg0: !tt.ptr<f32, 1>, %arg1: !tt.ptr<f32, 1>, %arg2: i32) attributes {noinline = false} {
+    %c32_i32 = arith.constant 32 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c32_i32 : i32
+    %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %4 = arith.addi %3, %2 : tensor<32xi32>
+    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
+    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_coshf"} : (tensor<32xf32>) -> tensor<32xf32>
+    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
+    tt.return
+  }
+}
+
+
+// -----
+
+module {
+  tt.func public @tanh_kernel_012(%arg0: !tt.ptr<f32, 1>, %arg1: !tt.ptr<f32, 1>, %arg2: i32) attributes {noinline = false} {
+    %c32_i32 = arith.constant 32 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c32_i32 : i32
+    %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %4 = arith.addi %3, %2 : tensor<32xi32>
+    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
+    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_tanhf"} : (tensor<32xf32>) -> tensor<32xf32>
+    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
+    tt.return
+  }
+}
+
+
+// -----
+
+module {
+  tt.func public @asinh_kernel_012(%arg0: !tt.ptr<f32, 1>, %arg1: !tt.ptr<f32, 1>, %arg2: i32) attributes {noinline = false} {
+    %c32_i32 = arith.constant 32 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c32_i32 : i32
+    %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %4 = arith.addi %3, %2 : tensor<32xi32>
+    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
+    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_asinhf"} : (tensor<32xf32>) -> tensor<32xf32>
+    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
+    tt.return
+  }
+}
+
+
+// -----
+
+module {
+  tt.func public @acosh_kernel_012(%arg0: !tt.ptr<f32, 1>, %arg1: !tt.ptr<f32, 1>, %arg2: i32) attributes {noinline = false} {
+    %c32_i32 = arith.constant 32 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c32_i32 : i32
+    %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %4 = arith.addi %3, %2 : tensor<32xi32>
+    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
+    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_acoshf"} : (tensor<32xf32>) -> tensor<32xf32>
+    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
+    tt.return
+  }
+}
+
+
+// -----
+
+module {
+  tt.func public @atanh_kernel_012(%arg0: !tt.ptr<f32, 1>, %arg1: !tt.ptr<f32, 1>, %arg2: i32) attributes {noinline = false} {
+    %c32_i32 = arith.constant 32 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c32_i32 : i32
+    %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %4 = arith.addi %3, %2 : tensor<32xi32>
+    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
+    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_atanhf"} : (tensor<32xf32>) -> tensor<32xf32>
+    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
+    tt.return
+  }
+}
+
+
+// -----
+
+module {
+  tt.func public @log_kernel_012(%arg0: !tt.ptr<f32, 1>, %arg1: !tt.ptr<f32, 1>, %arg2: i32) attributes {noinline = false} {
+    %c32_i32 = arith.constant 32 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c32_i32 : i32
+    %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %4 = arith.addi %3, %2 : tensor<32xi32>
+    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
+    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_logf"} : (tensor<32xf32>) -> tensor<32xf32>
+    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
+    tt.return
+  }
+}
+
+
+// -----
+
+module {
+  tt.func public @log10_kernel_012(%arg0: !tt.ptr<f32, 1>, %arg1: !tt.ptr<f32, 1>, %arg2: i32) attributes {noinline = false} {
+    %c32_i32 = arith.constant 32 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c32_i32 : i32
+    %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %4 = arith.addi %3, %2 : tensor<32xi32>
+    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
+    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_log10f"} : (tensor<32xf32>) -> tensor<32xf32>
+    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
+    tt.return
+  }
+}
+
+
+// -----
+
+module {
+  tt.func public @log1p_kernel_012(%arg0: !tt.ptr<f32, 1>, %arg1: !tt.ptr<f32, 1>, %arg2: i32) attributes {noinline = false} {
+    %c32_i32 = arith.constant 32 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c32_i32 : i32
+    %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %4 = arith.addi %3, %2 : tensor<32xi32>
+    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
+    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_log1pf"} : (tensor<32xf32>) -> tensor<32xf32>
+    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
+    tt.return
+  }
+}
+
+
+// -----
+
+module {
+  tt.func public @exp_kernel_012(%arg0: !tt.ptr<f32, 1>, %arg1: !tt.ptr<f32, 1>, %arg2: i32) attributes {noinline = false} {
+    %c32_i32 = arith.constant 32 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c32_i32 : i32
+    %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %4 = arith.addi %3, %2 : tensor<32xi32>
+    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
+    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_expf"} : (tensor<32xf32>) -> tensor<32xf32>
+    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
+    tt.return
+  }
+}
+
+
+// -----
+
+module {
+  tt.func public @exp2_kernel_012(%arg0: !tt.ptr<f32, 1>, %arg1: !tt.ptr<f32, 1>, %arg2: i32) attributes {noinline = false} {
+    %c32_i32 = arith.constant 32 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c32_i32 : i32
+    %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %4 = arith.addi %3, %2 : tensor<32xi32>
+    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
+    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_exp2f"} : (tensor<32xf32>) -> tensor<32xf32>
+    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
+    tt.return
+  }
+}
+
+
+// -----
+
+module {
+  tt.func public @erf_kernel_012(%arg0: !tt.ptr<f32, 1>, %arg1: !tt.ptr<f32, 1>, %arg2: i32) attributes {noinline = false} {
+    %c32_i32 = arith.constant 32 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c32_i32 : i32
+    %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %4 = arith.addi %3, %2 : tensor<32xi32>
+    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
+    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_erff"} : (tensor<32xf32>) -> tensor<32xf32>
+    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
+    tt.return
+  }
+}
+
+
+// -----
+
+module {
+  tt.func public @sqrt_kernel_012(%arg0: !tt.ptr<f32, 1>, %arg1: !tt.ptr<f32, 1>, %arg2: i32) attributes {noinline = false} {
+    %c32_i32 = arith.constant 32 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c32_i32 : i32
+    %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %4 = arith.addi %3, %2 : tensor<32xi32>
+    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
+    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_sqrtf"} : (tensor<32xf32>) -> tensor<32xf32>
+    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
+    tt.return
+  }
+}
+
+
+// -----
+
+module {
+  tt.func public @rsqrt_kernel_012(%arg0: !tt.ptr<f32, 1>, %arg1: !tt.ptr<f32, 1>, %arg2: i32) attributes {noinline = false} {
+    %c32_i32 = arith.constant 32 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c32_i32 : i32
+    %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %4 = arith.addi %3, %2 : tensor<32xi32>
+    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
+    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_rsqrtf"} : (tensor<32xf32>) -> tensor<32xf32>
+    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
+    tt.return
+  }
+}
+
+
+// -----
+
+module {
+  tt.func public @ceil_kernel_012(%arg0: !tt.ptr<f32, 1>, %arg1: !tt.ptr<f32, 1>, %arg2: i32) attributes {noinline = false} {
+    %c32_i32 = arith.constant 32 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c32_i32 : i32
+    %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %4 = arith.addi %3, %2 : tensor<32xi32>
+    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
+    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_ceilf"} : (tensor<32xf32>) -> tensor<32xf32>
+    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
+    tt.return
+  }
+}
+
+
+// -----
+
+module {
+  tt.func public @floor_kernel_012(%arg0: !tt.ptr<f32, 1>, %arg1: !tt.ptr<f32, 1>, %arg2: i32) attributes {noinline = false} {
+    %c32_i32 = arith.constant 32 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c32_i32 : i32
+    %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %4 = arith.addi %3, %2 : tensor<32xi32>
+    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
+    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_floorf"} : (tensor<32xf32>) -> tensor<32xf32>
+    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
+    tt.return
+  }
+}
+
+
+// -----
+
+module {
+  tt.func public @trunc_kernel_012(%arg0: !tt.ptr<f32, 1>, %arg1: !tt.ptr<f32, 1>, %arg2: i32) attributes {noinline = false} {
+    %c32_i32 = arith.constant 32 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c32_i32 : i32
+    %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %4 = arith.addi %3, %2 : tensor<32xi32>
+    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
+    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
+    %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_truncf"} : (tensor<32xf32>) -> tensor<32xf32>
+    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
+    tt.return
+  }
+}
+
+// mlir2FileCheck.py
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func @atan2_kernel_0123
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: memref<*xf32>, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
+// CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
+// CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_7_]], [[CST_32_]] : i32
+// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_3_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_4_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.addi [[VAR_4_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_6_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
+// CHECK:           [[VAR_7_:%.+]] = arith.minsi [[VAR_5_]], [[VAR_6_]] : index
+// CHECK-DAG:       [[VAR_8_:%.+]] = arith.subi [[VAR_7_]], [[VAR_4_]] : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_8_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_8_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:       [[VAR_9_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK-DAG:       [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_10_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_11_:%.+]] = arith.addi [[VAR_10_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_12_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
+// CHECK:           [[VAR_13_:%.+]] = arith.minsi [[VAR_11_]], [[VAR_12_]] : index
+// CHECK-DAG:       [[VAR_14_:%.+]] = arith.subi [[VAR_13_]], [[VAR_10_]] : index
+// CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc() : memref<32xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_subview_3_:%.+]] = memref.subview [[VAR_reinterpret_cast_1_]][0] {{.}}[[VAR_14_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_4_:%.+]] = memref.subview [[RES_1_]][0] {{.}}[[VAR_14_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK:           memref.copy [[VAR_subview_3_]], [[VAR_subview_4_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK:           [[VAR_15_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_16_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_9_]], [[VAR_15_]] : tensor<32xf32>, tensor<32xf32>) outs([[VAR_9_]] : tensor<32xf32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32, [[IN_2_:%.+]]: f32):
+// CHECK:             [[VAR_17_:%.+]] = math.atan2 [[IN_0_]], [[IN_1_]] : f32
+// CHECK:             linalg.yield [[VAR_17_]] : f32
+// CHECK:           } -> tensor<32xf32>
+// CHECK:           [[VAR_reinterpret_cast_5_:%.+]] = memref.reinterpret_cast [[PARAM_2_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_16_]] in writable [[VAR_reinterpret_cast_5_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func @pow_kernel_0123
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: memref<*xf32>, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
+// CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
+// CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_7_]], [[CST_32_]] : i32
+// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_3_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_4_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.addi [[VAR_4_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_6_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
+// CHECK:           [[VAR_7_:%.+]] = arith.minsi [[VAR_5_]], [[VAR_6_]] : index
+// CHECK-DAG:       [[VAR_8_:%.+]] = arith.subi [[VAR_7_]], [[VAR_4_]] : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_8_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_8_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:       [[VAR_9_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK-DAG:       [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_10_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_11_:%.+]] = arith.addi [[VAR_10_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_12_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
+// CHECK:           [[VAR_13_:%.+]] = arith.minsi [[VAR_11_]], [[VAR_12_]] : index
+// CHECK-DAG:       [[VAR_14_:%.+]] = arith.subi [[VAR_13_]], [[VAR_10_]] : index
+// CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc() : memref<32xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_subview_3_:%.+]] = memref.subview [[VAR_reinterpret_cast_1_]][0] {{.}}[[VAR_14_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_4_:%.+]] = memref.subview [[RES_1_]][0] {{.}}[[VAR_14_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK:           memref.copy [[VAR_subview_3_]], [[VAR_subview_4_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK:           [[VAR_15_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_16_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_9_]], [[VAR_15_]] : tensor<32xf32>, tensor<32xf32>) outs([[VAR_9_]] : tensor<32xf32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32, [[IN_2_:%.+]]: f32):
+// CHECK:             [[VAR_17_:%.+]] = math.powf [[IN_0_]], [[IN_1_]] : f32
+// CHECK:             linalg.yield [[VAR_17_]] : f32
+// CHECK:           } -> tensor<32xf32>
+// CHECK:           [[VAR_reinterpret_cast_5_:%.+]] = memref.reinterpret_cast [[PARAM_2_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_16_]] in writable [[VAR_reinterpret_cast_5_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func @fabs_kernel_012
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
+// CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
+// CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
+// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
+// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
+// CHECK:             [[VAR_10_:%.+]] = math.absf [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:           } -> tensor<32xf32>
+// CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func @sin_kernel_012
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
+// CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
+// CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
+// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
+// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
+// CHECK:             [[VAR_10_:%.+]] = math.sin [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:           } -> tensor<32xf32>
+// CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func @cos_kernel_012
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
+// CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
+// CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
+// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
+// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
+// CHECK:             [[VAR_10_:%.+]] = math.cos [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:           } -> tensor<32xf32>
+// CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func @tan_kernel_012
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
+// CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
+// CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
+// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
+// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
+// CHECK:             [[VAR_10_:%.+]] = math.tan [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:           } -> tensor<32xf32>
+// CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func @asin_kernel_012
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
+// CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
+// CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
+// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
+// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
+// CHECK:             [[VAR_10_:%.+]] = math.asin [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:           } -> tensor<32xf32>
+// CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func @acos_kernel_012
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
+// CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
+// CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
+// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
+// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
+// CHECK:             [[VAR_10_:%.+]] = math.acos [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:           } -> tensor<32xf32>
+// CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func @atan_kernel_012
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
+// CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
+// CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
+// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
+// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
+// CHECK:             [[VAR_10_:%.+]] = math.atan [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:           } -> tensor<32xf32>
+// CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func @sinh_kernel_012
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
+// CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
+// CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
+// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
+// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
+// CHECK:             [[VAR_10_:%.+]] = math.sinh [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:           } -> tensor<32xf32>
+// CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func @cosh_kernel_012
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
+// CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
+// CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
+// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
+// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
+// CHECK:             [[VAR_10_:%.+]] = math.cosh [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:           } -> tensor<32xf32>
+// CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func @tanh_kernel_012
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
+// CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
+// CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
+// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
+// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
+// CHECK:             [[VAR_10_:%.+]] = math.tanh [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:           } -> tensor<32xf32>
+// CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func @asinh_kernel_012
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
+// CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
+// CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
+// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
+// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
+// CHECK:             [[VAR_10_:%.+]] = math.asinh [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:           } -> tensor<32xf32>
+// CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func @acosh_kernel_012
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
+// CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
+// CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
+// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
+// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
+// CHECK:             [[VAR_10_:%.+]] = math.acosh [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:           } -> tensor<32xf32>
+// CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func @atanh_kernel_012
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
+// CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
+// CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
+// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
+// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
+// CHECK:             [[VAR_10_:%.+]] = math.atanh [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:           } -> tensor<32xf32>
+// CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func @log_kernel_012
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
+// CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
+// CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
+// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
+// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
+// CHECK:             [[VAR_10_:%.+]] = math.log [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:           } -> tensor<32xf32>
+// CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func @log10_kernel_012
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
+// CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
+// CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
+// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
+// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
+// CHECK:             [[VAR_10_:%.+]] = math.log10 [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:           } -> tensor<32xf32>
+// CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func @log1p_kernel_012
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
+// CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
+// CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
+// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
+// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
+// CHECK:             [[VAR_10_:%.+]] = math.log1p [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:           } -> tensor<32xf32>
+// CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func @exp_kernel_012
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
+// CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
+// CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
+// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
+// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
+// CHECK:             [[VAR_10_:%.+]] = math.exp [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:           } -> tensor<32xf32>
+// CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func @exp2_kernel_012
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
+// CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
+// CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
+// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
+// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
+// CHECK:             [[VAR_10_:%.+]] = math.exp2 [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:           } -> tensor<32xf32>
+// CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func @erf_kernel_012
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
+// CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
+// CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
+// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
+// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
+// CHECK:             [[VAR_10_:%.+]] = math.erf [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:           } -> tensor<32xf32>
+// CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func @sqrt_kernel_012
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
+// CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
+// CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
+// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
+// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
+// CHECK:             [[VAR_10_:%.+]] = math.sqrt [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:           } -> tensor<32xf32>
+// CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func @rsqrt_kernel_012
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
+// CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
+// CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
+// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
+// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
+// CHECK:             [[VAR_10_:%.+]] = math.rsqrt [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:           } -> tensor<32xf32>
+// CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func @ceil_kernel_012
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
+// CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
+// CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
+// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
+// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
+// CHECK:             [[VAR_10_:%.+]] = math.ceil [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:           } -> tensor<32xf32>
+// CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func @floor_kernel_012
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
+// CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
+// CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
+// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
+// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
+// CHECK:             [[VAR_10_:%.+]] = math.floor [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:           } -> tensor<32xf32>
+// CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func @trunc_kernel_012
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
+// CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
+// CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
+// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
+// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
+// CHECK:             [[VAR_10_:%.+]] = math.trunc [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:           } -> tensor<32xf32>
+// CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/convert_extern_elementwise.mlir
+++ b/test/Conversion/StructuredToMemref/convert_extern_elementwise.mlir
@@ -6,18 +6,18 @@ module {
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %c32_i32 : i32
     %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
-    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %3 = tt.splat %1 : i32 -> tensor<32xi32>
     %4 = arith.addi %3, %2 : tensor<32xi32>
-    %5 = tt.splat %arg3 : (i32) -> tensor<32xi32>
+    %5 = tt.splat %arg3 : i32 -> tensor<32xi32>
     %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
-    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %7 = tt.splat %arg0 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
-    %10 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %10 = tt.splat %arg1 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %11 = tt.addptr %10, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %12 = tt.load %11, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
     %13 = tt.extern_elementwise %9, %12 {libname = "", libpath = "", pure = true, symbol = "__nv_atan2f"} : (tensor<32xf32>, tensor<32xf32>) -> tensor<32xf32>
-    %14 = tt.splat %arg2 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %14 = tt.splat %arg2 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %15 = tt.addptr %14, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %15, %13 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
     tt.return
@@ -32,18 +32,18 @@ module {
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %c32_i32 : i32
     %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
-    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %3 = tt.splat %1 : i32 -> tensor<32xi32>
     %4 = arith.addi %3, %2 : tensor<32xi32>
-    %5 = tt.splat %arg3 : (i32) -> tensor<32xi32>
+    %5 = tt.splat %arg3 : i32 -> tensor<32xi32>
     %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
-    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %7 = tt.splat %arg0 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
-    %10 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %10 = tt.splat %arg1 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %11 = tt.addptr %10, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %12 = tt.load %11, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
     %13 = tt.extern_elementwise %9, %12 {libname = "", libpath = "", pure = true, symbol = "__nv_powf"} : (tensor<32xf32>, tensor<32xf32>) -> tensor<32xf32>
-    %14 = tt.splat %arg2 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %14 = tt.splat %arg2 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %15 = tt.addptr %14, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %15, %13 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
     tt.return
@@ -58,15 +58,15 @@ module {
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %c32_i32 : i32
     %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
-    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %3 = tt.splat %1 : i32 -> tensor<32xi32>
     %4 = arith.addi %3, %2 : tensor<32xi32>
-    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %5 = tt.splat %arg2 : i32 -> tensor<32xi32>
     %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
-    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %7 = tt.splat %arg0 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
     %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_fabsf"} : (tensor<32xf32>) -> tensor<32xf32>
-    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %11 = tt.splat %arg1 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
     tt.return
@@ -82,15 +82,15 @@ module {
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %c32_i32 : i32
     %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
-    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %3 = tt.splat %1 : i32 -> tensor<32xi32>
     %4 = arith.addi %3, %2 : tensor<32xi32>
-    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %5 = tt.splat %arg2 : i32 -> tensor<32xi32>
     %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
-    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %7 = tt.splat %arg0 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
     %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_sinf"} : (tensor<32xf32>) -> tensor<32xf32>
-    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %11 = tt.splat %arg1 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
     tt.return
@@ -106,15 +106,15 @@ module {
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %c32_i32 : i32
     %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
-    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %3 = tt.splat %1 : i32 -> tensor<32xi32>
     %4 = arith.addi %3, %2 : tensor<32xi32>
-    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %5 = tt.splat %arg2 : i32 -> tensor<32xi32>
     %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
-    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %7 = tt.splat %arg0 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
     %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_cosf"} : (tensor<32xf32>) -> tensor<32xf32>
-    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %11 = tt.splat %arg1 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
     tt.return
@@ -130,15 +130,15 @@ module {
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %c32_i32 : i32
     %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
-    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %3 = tt.splat %1 : i32 -> tensor<32xi32>
     %4 = arith.addi %3, %2 : tensor<32xi32>
-    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %5 = tt.splat %arg2 : i32 -> tensor<32xi32>
     %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
-    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %7 = tt.splat %arg0 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
     %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_tanf"} : (tensor<32xf32>) -> tensor<32xf32>
-    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %11 = tt.splat %arg1 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
     tt.return
@@ -154,15 +154,15 @@ module {
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %c32_i32 : i32
     %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
-    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %3 = tt.splat %1 : i32 -> tensor<32xi32>
     %4 = arith.addi %3, %2 : tensor<32xi32>
-    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %5 = tt.splat %arg2 : i32 -> tensor<32xi32>
     %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
-    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %7 = tt.splat %arg0 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
     %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_asinf"} : (tensor<32xf32>) -> tensor<32xf32>
-    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %11 = tt.splat %arg1 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
     tt.return
@@ -178,15 +178,15 @@ module {
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %c32_i32 : i32
     %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
-    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %3 = tt.splat %1 : i32 -> tensor<32xi32>
     %4 = arith.addi %3, %2 : tensor<32xi32>
-    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %5 = tt.splat %arg2 : i32 -> tensor<32xi32>
     %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
-    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %7 = tt.splat %arg0 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
     %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_acosf"} : (tensor<32xf32>) -> tensor<32xf32>
-    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %11 = tt.splat %arg1 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
     tt.return
@@ -202,15 +202,15 @@ module {
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %c32_i32 : i32
     %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
-    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %3 = tt.splat %1 : i32 -> tensor<32xi32>
     %4 = arith.addi %3, %2 : tensor<32xi32>
-    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %5 = tt.splat %arg2 : i32 -> tensor<32xi32>
     %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
-    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %7 = tt.splat %arg0 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
     %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_atanf"} : (tensor<32xf32>) -> tensor<32xf32>
-    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %11 = tt.splat %arg1 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
     tt.return
@@ -226,15 +226,15 @@ module {
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %c32_i32 : i32
     %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
-    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %3 = tt.splat %1 : i32 -> tensor<32xi32>
     %4 = arith.addi %3, %2 : tensor<32xi32>
-    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %5 = tt.splat %arg2 : i32 -> tensor<32xi32>
     %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
-    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %7 = tt.splat %arg0 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
     %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_sinhf"} : (tensor<32xf32>) -> tensor<32xf32>
-    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %11 = tt.splat %arg1 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
     tt.return
@@ -250,15 +250,15 @@ module {
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %c32_i32 : i32
     %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
-    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %3 = tt.splat %1 : i32 -> tensor<32xi32>
     %4 = arith.addi %3, %2 : tensor<32xi32>
-    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %5 = tt.splat %arg2 : i32 -> tensor<32xi32>
     %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
-    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %7 = tt.splat %arg0 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
     %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_coshf"} : (tensor<32xf32>) -> tensor<32xf32>
-    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %11 = tt.splat %arg1 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
     tt.return
@@ -274,15 +274,15 @@ module {
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %c32_i32 : i32
     %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
-    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %3 = tt.splat %1 : i32 -> tensor<32xi32>
     %4 = arith.addi %3, %2 : tensor<32xi32>
-    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %5 = tt.splat %arg2 : i32 -> tensor<32xi32>
     %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
-    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %7 = tt.splat %arg0 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
     %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_tanhf"} : (tensor<32xf32>) -> tensor<32xf32>
-    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %11 = tt.splat %arg1 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
     tt.return
@@ -298,15 +298,15 @@ module {
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %c32_i32 : i32
     %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
-    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %3 = tt.splat %1 : i32 -> tensor<32xi32>
     %4 = arith.addi %3, %2 : tensor<32xi32>
-    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %5 = tt.splat %arg2 : i32 -> tensor<32xi32>
     %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
-    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %7 = tt.splat %arg0 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
     %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_asinhf"} : (tensor<32xf32>) -> tensor<32xf32>
-    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %11 = tt.splat %arg1 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
     tt.return
@@ -322,15 +322,15 @@ module {
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %c32_i32 : i32
     %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
-    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %3 = tt.splat %1 : i32 -> tensor<32xi32>
     %4 = arith.addi %3, %2 : tensor<32xi32>
-    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %5 = tt.splat %arg2 : i32 -> tensor<32xi32>
     %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
-    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %7 = tt.splat %arg0 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
     %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_acoshf"} : (tensor<32xf32>) -> tensor<32xf32>
-    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %11 = tt.splat %arg1 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
     tt.return
@@ -346,15 +346,15 @@ module {
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %c32_i32 : i32
     %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
-    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %3 = tt.splat %1 : i32 -> tensor<32xi32>
     %4 = arith.addi %3, %2 : tensor<32xi32>
-    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %5 = tt.splat %arg2 : i32 -> tensor<32xi32>
     %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
-    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %7 = tt.splat %arg0 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
     %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_atanhf"} : (tensor<32xf32>) -> tensor<32xf32>
-    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %11 = tt.splat %arg1 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
     tt.return
@@ -370,15 +370,15 @@ module {
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %c32_i32 : i32
     %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
-    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %3 = tt.splat %1 : i32 -> tensor<32xi32>
     %4 = arith.addi %3, %2 : tensor<32xi32>
-    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %5 = tt.splat %arg2 : i32 -> tensor<32xi32>
     %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
-    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %7 = tt.splat %arg0 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
     %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_logf"} : (tensor<32xf32>) -> tensor<32xf32>
-    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %11 = tt.splat %arg1 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
     tt.return
@@ -394,15 +394,15 @@ module {
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %c32_i32 : i32
     %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
-    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %3 = tt.splat %1 : i32 -> tensor<32xi32>
     %4 = arith.addi %3, %2 : tensor<32xi32>
-    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %5 = tt.splat %arg2 : i32 -> tensor<32xi32>
     %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
-    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %7 = tt.splat %arg0 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
     %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_log10f"} : (tensor<32xf32>) -> tensor<32xf32>
-    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %11 = tt.splat %arg1 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
     tt.return
@@ -418,15 +418,15 @@ module {
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %c32_i32 : i32
     %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
-    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %3 = tt.splat %1 : i32 -> tensor<32xi32>
     %4 = arith.addi %3, %2 : tensor<32xi32>
-    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %5 = tt.splat %arg2 : i32 -> tensor<32xi32>
     %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
-    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %7 = tt.splat %arg0 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
     %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_log1pf"} : (tensor<32xf32>) -> tensor<32xf32>
-    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %11 = tt.splat %arg1 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
     tt.return
@@ -442,15 +442,15 @@ module {
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %c32_i32 : i32
     %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
-    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %3 = tt.splat %1 : i32 -> tensor<32xi32>
     %4 = arith.addi %3, %2 : tensor<32xi32>
-    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %5 = tt.splat %arg2 : i32 -> tensor<32xi32>
     %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
-    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %7 = tt.splat %arg0 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
     %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_expf"} : (tensor<32xf32>) -> tensor<32xf32>
-    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %11 = tt.splat %arg1 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
     tt.return
@@ -466,15 +466,15 @@ module {
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %c32_i32 : i32
     %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
-    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %3 = tt.splat %1 : i32 -> tensor<32xi32>
     %4 = arith.addi %3, %2 : tensor<32xi32>
-    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %5 = tt.splat %arg2 : i32 -> tensor<32xi32>
     %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
-    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %7 = tt.splat %arg0 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
     %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_exp2f"} : (tensor<32xf32>) -> tensor<32xf32>
-    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %11 = tt.splat %arg1 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
     tt.return
@@ -490,15 +490,15 @@ module {
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %c32_i32 : i32
     %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
-    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %3 = tt.splat %1 : i32 -> tensor<32xi32>
     %4 = arith.addi %3, %2 : tensor<32xi32>
-    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %5 = tt.splat %arg2 : i32 -> tensor<32xi32>
     %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
-    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %7 = tt.splat %arg0 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
     %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_erff"} : (tensor<32xf32>) -> tensor<32xf32>
-    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %11 = tt.splat %arg1 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
     tt.return
@@ -514,15 +514,15 @@ module {
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %c32_i32 : i32
     %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
-    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %3 = tt.splat %1 : i32 -> tensor<32xi32>
     %4 = arith.addi %3, %2 : tensor<32xi32>
-    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %5 = tt.splat %arg2 : i32 -> tensor<32xi32>
     %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
-    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %7 = tt.splat %arg0 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
     %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_sqrtf"} : (tensor<32xf32>) -> tensor<32xf32>
-    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %11 = tt.splat %arg1 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
     tt.return
@@ -538,15 +538,15 @@ module {
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %c32_i32 : i32
     %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
-    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %3 = tt.splat %1 : i32 -> tensor<32xi32>
     %4 = arith.addi %3, %2 : tensor<32xi32>
-    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %5 = tt.splat %arg2 : i32 -> tensor<32xi32>
     %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
-    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %7 = tt.splat %arg0 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
     %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_rsqrtf"} : (tensor<32xf32>) -> tensor<32xf32>
-    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %11 = tt.splat %arg1 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
     tt.return
@@ -562,15 +562,15 @@ module {
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %c32_i32 : i32
     %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
-    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %3 = tt.splat %1 : i32 -> tensor<32xi32>
     %4 = arith.addi %3, %2 : tensor<32xi32>
-    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %5 = tt.splat %arg2 : i32 -> tensor<32xi32>
     %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
-    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %7 = tt.splat %arg0 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
     %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_ceilf"} : (tensor<32xf32>) -> tensor<32xf32>
-    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %11 = tt.splat %arg1 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
     tt.return
@@ -586,15 +586,15 @@ module {
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %c32_i32 : i32
     %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
-    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %3 = tt.splat %1 : i32 -> tensor<32xi32>
     %4 = arith.addi %3, %2 : tensor<32xi32>
-    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %5 = tt.splat %arg2 : i32 -> tensor<32xi32>
     %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
-    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %7 = tt.splat %arg0 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
     %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_floorf"} : (tensor<32xf32>) -> tensor<32xf32>
-    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %11 = tt.splat %arg1 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
     tt.return
@@ -610,15 +610,15 @@ module {
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %c32_i32 : i32
     %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
-    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %3 = tt.splat %1 : i32 -> tensor<32xi32>
     %4 = arith.addi %3, %2 : tensor<32xi32>
-    %5 = tt.splat %arg2 : (i32) -> tensor<32xi32>
+    %5 = tt.splat %arg2 : i32 -> tensor<32xi32>
     %6 = arith.cmpi slt, %4, %5 : tensor<32xi32>
-    %7 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %7 = tt.splat %arg0 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %8 = tt.addptr %7, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
     %10 = tt.extern_elementwise %9 {libname = "", libpath = "", pure = true, symbol = "__nv_truncf"} : (tensor<32xf32>) -> tensor<32xf32>
-    %11 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %11 = tt.splat %arg1 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %12 = tt.addptr %11, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     tt.store %12, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<32xf32>
     tt.return

--- a/test/Conversion/StructuredToMemref/convert_minmax.mlir
+++ b/test/Conversion/StructuredToMemref/convert_minmax.mlir
@@ -1,0 +1,71 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref  %s | FileCheck %s
+module {
+  tt.func public @minmax_olt(%arg0: !tt.ptr<f32>, %arg1: f32, %arg2: f32) {
+    %0 = arith.cmpf olt, %arg1, %arg2 : f32
+    %1 = arith.select %0, %arg1, %arg2 : f32
+    tt.store %arg0, %1 {cache = 1 : i32, evict = 1 : i32} : f32
+    tt.return
+  }
+}
+
+// -----
+
+module {
+  tt.func public @minmax_ole(%arg0: !tt.ptr<f32>, %arg1: f32, %arg2: f32) {
+    %0 = arith.cmpf ole, %arg1, %arg2 : f32
+    %1 = arith.select %0, %arg1, %arg2 : f32
+    tt.store %arg0, %1 {cache = 1 : i32, evict = 1 : i32} : f32
+    tt.return
+  }
+}
+
+// -----
+
+module {
+  tt.func public @minmax_ogt(%arg0: !tt.ptr<f32>, %arg1: f32, %arg2: f32) {
+    %0 = arith.cmpf ogt, %arg1, %arg2 : f32
+    %1 = arith.select %0, %arg1, %arg2 : f32
+    tt.store %arg0, %1 {cache = 1 : i32, evict = 1 : i32} : f32
+    tt.return
+  }
+}
+
+// -----
+
+module {
+  tt.func public @minmax_oge(%arg0: !tt.ptr<f32>, %arg1: f32, %arg2: f32) {
+    %0 = arith.cmpf oge, %arg1, %arg2 : f32
+    %1 = arith.select %0, %arg1, %arg2 : f32
+    tt.store %arg0, %1 {cache = 1 : i32, evict = 1 : i32} : f32
+    tt.return
+  }
+}
+// mlir2FileCheck.py
+// CHECK-LABEL:  func.func @minmax_olt
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: f32, [[PARAM_2_:%.+]]: f32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_0_:%.+]] = arith.minimumf [[PARAM_1_]], [[PARAM_2_]] : f32
+// CHECK:           affine.store [[VAR_0_]], [[VAR_reinterpret_cast_]][0] : memref<1xf32, strided<[1], offset: ?>>
+// CHECK:           return
+// CHECK:         }
+// CHECK-LABEL:  func.func @minmax_ole
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: f32, [[PARAM_2_:%.+]]: f32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_0_:%.+]] = arith.minimumf [[PARAM_1_]], [[PARAM_2_]] : f32
+// CHECK:           affine.store [[VAR_0_]], [[VAR_reinterpret_cast_]][0] : memref<1xf32, strided<[1], offset: ?>>
+// CHECK:           return
+// CHECK:         }
+// CHECK-LABEL:  func.func @minmax_ogt
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: f32, [[PARAM_2_:%.+]]: f32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_0_:%.+]] = arith.maximumf [[PARAM_1_]], [[PARAM_2_]] : f32
+// CHECK:           affine.store [[VAR_0_]], [[VAR_reinterpret_cast_]][0] : memref<1xf32, strided<[1], offset: ?>>
+// CHECK:           return
+// CHECK:         }
+// CHECK-LABEL:  func.func @minmax_oge
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: f32, [[PARAM_2_:%.+]]: f32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_0_:%.+]] = arith.maximumf [[PARAM_1_]], [[PARAM_2_]] : f32
+// CHECK:           affine.store [[VAR_0_]], [[VAR_reinterpret_cast_]][0] : memref<1xf32, strided<[1], offset: ?>>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/convert_minmax_fp_reduce.mlir
+++ b/test/Conversion/StructuredToMemref/convert_minmax_fp_reduce.mlir
@@ -1,0 +1,71 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref  %s | FileCheck %s
+
+module {
+  tt.func public @maxnumf(%arg0: !tt.ptr<f32>) {
+    %cst_0 = arith.constant dense<0.000000e+00> : tensor<4096xf32>
+    %63 = "tt.reduce"(%cst_0) ({
+    ^bb0(%arg14: f32, %arg15: f32):
+      %69 = arith.maxnumf %arg14, %arg15 : f32
+      tt.reduce.return %69 : f32
+    }) {axis = 0 : i32} : (tensor<4096xf32>) -> f32
+    tt.store %arg0, %63 {cache = 1 : i32, evict = 1 : i32} : f32
+    tt.return
+  }
+}
+
+// CHECK-LABEL:  func.func @maxnumf
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: i32, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0xFF800000 : f32
+// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<4096xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_1_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[VAR_0_]] : tensor<4096xf32>) -> tensor<4096xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = bufferization.alloc_tensor() : tensor<f32>
+// CHECK:           [[VAR_inserted_:%.+]] = tensor.insert [[CST_0_]] into [[VAR_2_]][] : tensor<f32>
+// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_1_]] : tensor<4096xf32>) outs([[VAR_inserted_]] : tensor<f32>) dimensions = [0]
+// CHECK:             ([[in_:%.+]]: f32, [[init_:%.+]]: f32) {
+// CHECK:               [[VAR_3_:%.+]] = arith.maxnumf [[in_]], [[init_]] : f32
+// CHECK:               linalg.yield [[VAR_3_]] : f32
+// CHECK:             }
+// CHECK:           [[VAR_extracted_:%.+]] = tensor.extract [[VAR_reduced_]][] : tensor<f32>
+// CHECK:           affine.store [[VAR_extracted_]], [[VAR_reinterpret_cast_]][0] : memref<1xf32, strided<[1], offset: ?>>
+// CHECK:           return
+// CHECK:         }
+
+
+// -----
+
+
+module {
+  tt.func public @minnumf(%arg0: !tt.ptr<f32>) {
+    %cst_0 = arith.constant dense<0.000000e+00> : tensor<4096xf32>
+    %63 = "tt.reduce"(%cst_0) ({
+    ^bb0(%arg14: f32, %arg15: f32):
+      %69 = arith.minnumf %arg14, %arg15 : f32
+      tt.reduce.return %69 : f32
+    }) {axis = 0 : i32} : (tensor<4096xf32>) -> f32
+    tt.store %arg0, %63 {cache = 1 : i32, evict = 1 : i32} : f32
+    tt.return
+  }
+}
+
+// CHECK-LABEL:  func.func @minnumf
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: i32, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0x7F800000 : f32
+// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<4096xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_1_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[VAR_0_]] : tensor<4096xf32>) -> tensor<4096xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = bufferization.alloc_tensor() : tensor<f32>
+// CHECK:           [[VAR_inserted_:%.+]] = tensor.insert [[CST_0_]] into [[VAR_2_]][] : tensor<f32>
+// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_1_]] : tensor<4096xf32>) outs([[VAR_inserted_]] : tensor<f32>) dimensions = [0]
+// CHECK:             ([[in_:%.+]]: f32, [[init_:%.+]]: f32) {
+// CHECK:               [[VAR_3_:%.+]] = arith.minnumf [[in_]], [[init_]] : f32
+// CHECK:               linalg.yield [[VAR_3_]] : f32
+// CHECK:             }
+// CHECK:           [[VAR_extracted_:%.+]] = tensor.extract [[VAR_reduced_]][] : tensor<f32>
+// CHECK:           affine.store [[VAR_extracted_]], [[VAR_reinterpret_cast_]][0] : memref<1xf32, strided<[1], offset: ?>>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/convert_minmax_reduce.mlir
+++ b/test/Conversion/StructuredToMemref/convert_minmax_reduce.mlir
@@ -1,0 +1,146 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref  %s | FileCheck %s
+module {
+  tt.func public @minmax_sgt(%arg0: !tt.ptr<i32>) {
+    %cst_0 = arith.constant dense<0> : tensor<4096xi32>
+    %63 = "tt.reduce"(%cst_0) ({
+    ^bb0(%arg14: i32, %arg15: i32):
+      %69 = arith.cmpi sgt, %arg14, %arg15 : i32
+      %70 = arith.select %69, %arg14, %arg15 : i32
+      tt.reduce.return %70 : i32
+    }) {axis = 0 : i32} : (tensor<4096xi32>) -> i32
+    tt.store %arg0, %63 {cache = 1 : i32, evict = 1 : i32} : i32
+    tt.return
+  }
+}
+
+// CHECK-LABEL:  func.func @minmax_sgt
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xi32>, [[PARAM_1_:%.+]]: i32, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_minus_2147483648_:%.+]] = arith.constant -2147483648 : i32
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : i32
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [1], strides: [1] : memref<*xi32> to memref<1xi32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<4096xi32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_1_:%.+]] = linalg.fill ins([[CST_0_]] : i32) outs([[VAR_0_]] : tensor<4096xi32>) -> tensor<4096xi32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = bufferization.alloc_tensor() : tensor<i32>
+// CHECK:           [[VAR_inserted_:%.+]] = tensor.insert [[CST_minus_2147483648_]] into [[VAR_2_]][] : tensor<i32>
+// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_1_]] : tensor<4096xi32>) outs([[VAR_inserted_]] : tensor<i32>) dimensions = [0]
+// CHECK:             ([[in_:%.+]]: i32, [[init_:%.+]]: i32) {
+// CHECK:               [[VAR_3_:%.+]] = arith.maxsi [[in_]], [[init_]] : i32
+// CHECK:               linalg.yield [[VAR_3_]] : i32
+// CHECK:             }
+// CHECK:           [[VAR_extracted_:%.+]] = tensor.extract [[VAR_reduced_]][] : tensor<i32>
+// CHECK:           affine.store [[VAR_extracted_]], [[VAR_reinterpret_cast_]][0] : memref<1xi32, strided<[1], offset: ?>>
+// CHECK:           return
+// CHECK:         }
+
+
+// -----
+
+module {
+  tt.func public @minmax_ugt(%arg0: !tt.ptr<i32>) {
+    %cst_0 = arith.constant dense<0> : tensor<4096xi32>
+    %63 = "tt.reduce"(%cst_0) ({
+    ^bb0(%arg14: i32, %arg15: i32):
+      %69 = arith.cmpi ugt, %arg14, %arg15 : i32
+      %70 = arith.select %69, %arg14, %arg15 : i32
+      tt.reduce.return %70 : i32
+    }) {axis = 0 : i32} : (tensor<4096xi32>) -> i32
+    tt.store %arg0, %63 {cache = 1 : i32, evict = 1 : i32} : i32
+    tt.return
+  }
+}
+
+
+// CHECK-LABEL:  func.func @minmax_ugt
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xi32>, [[PARAM_1_:%.+]]: i32, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : i32
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [1], strides: [1] : memref<*xi32> to memref<1xi32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<4096xi32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_1_:%.+]] = linalg.fill ins([[CST_0_]] : i32) outs([[VAR_0_]] : tensor<4096xi32>) -> tensor<4096xi32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = bufferization.alloc_tensor() : tensor<i32>
+// CHECK:           [[VAR_inserted_:%.+]] = tensor.insert [[CST_0_]] into [[VAR_2_]][] : tensor<i32>
+// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_1_]] : tensor<4096xi32>) outs([[VAR_inserted_]] : tensor<i32>) dimensions = [0]
+// CHECK:             ([[in_:%.+]]: i32, [[init_:%.+]]: i32) {
+// CHECK:               [[VAR_3_:%.+]] = arith.maxui [[in_]], [[init_]] : i32
+// CHECK:               linalg.yield [[VAR_3_]] : i32
+// CHECK:             }
+// CHECK:           [[VAR_extracted_:%.+]] = tensor.extract [[VAR_reduced_]][] : tensor<i32>
+// CHECK:           affine.store [[VAR_extracted_]], [[VAR_reinterpret_cast_]][0] : memref<1xi32, strided<[1], offset: ?>>
+// CHECK:           return
+// CHECK:         }
+
+
+// -----
+
+module {
+  tt.func public @minmax_slt(%arg0: !tt.ptr<i32>) {
+    %cst_0 = arith.constant dense<0> : tensor<4096xi32>
+    %63 = "tt.reduce"(%cst_0) ({
+    ^bb0(%arg14: i32, %arg15: i32):
+      %69 = arith.cmpi slt, %arg14, %arg15 : i32
+      %70 = arith.select %69, %arg14, %arg15 : i32
+      tt.reduce.return %70 : i32
+    }) {axis = 0 : i32} : (tensor<4096xi32>) -> i32
+    tt.store %arg0, %63 {cache = 1 : i32, evict = 1 : i32} : i32
+    tt.return
+  }
+}
+
+// CHECK-LABEL:  func.func @minmax_slt
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xi32>, [[PARAM_1_:%.+]]: i32, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_2147483647_:%.+]] = arith.constant 2147483647 : i32
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : i32
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [1], strides: [1] : memref<*xi32> to memref<1xi32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<4096xi32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_1_:%.+]] = linalg.fill ins([[CST_0_]] : i32) outs([[VAR_0_]] : tensor<4096xi32>) -> tensor<4096xi32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = bufferization.alloc_tensor() : tensor<i32>
+// CHECK:           [[VAR_inserted_:%.+]] = tensor.insert [[CST_2147483647_]] into [[VAR_2_]][] : tensor<i32>
+// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_1_]] : tensor<4096xi32>) outs([[VAR_inserted_]] : tensor<i32>) dimensions = [0]
+// CHECK:             ([[in_:%.+]]: i32, [[init_:%.+]]: i32) {
+// CHECK:               [[VAR_3_:%.+]] = arith.minsi [[in_]], [[init_]] : i32
+// CHECK:               linalg.yield [[VAR_3_]] : i32
+// CHECK:             }
+// CHECK:           [[VAR_extracted_:%.+]] = tensor.extract [[VAR_reduced_]][] : tensor<i32>
+// CHECK:           affine.store [[VAR_extracted_]], [[VAR_reinterpret_cast_]][0] : memref<1xi32, strided<[1], offset: ?>>
+// CHECK:           return
+// CHECK:         }
+
+
+
+// -----
+
+module {
+  tt.func public @minmax_ult(%arg0: !tt.ptr<i32>) {
+    %cst_0 = arith.constant dense<0> : tensor<4096xi32>
+    %63 = "tt.reduce"(%cst_0) ({
+    ^bb0(%arg14: i32, %arg15: i32):
+      %69 = arith.cmpi ult, %arg14, %arg15 : i32
+      %70 = arith.select %69, %arg14, %arg15 : i32
+      tt.reduce.return %70 : i32
+    }) {axis = 0 : i32} : (tensor<4096xi32>) -> i32
+    tt.store %arg0, %63 {cache = 1 : i32, evict = 1 : i32} : i32
+    tt.return
+  }
+}
+
+// CHECK-LABEL:  func.func @minmax_ult
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xi32>, [[PARAM_1_:%.+]]: i32, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_minus_1_:%.+]] = arith.constant -1 : i32
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : i32
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [1], strides: [1] : memref<*xi32> to memref<1xi32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<4096xi32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_1_:%.+]] = linalg.fill ins([[CST_0_]] : i32) outs([[VAR_0_]] : tensor<4096xi32>) -> tensor<4096xi32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = bufferization.alloc_tensor() : tensor<i32>
+// CHECK:           [[VAR_inserted_:%.+]] = tensor.insert [[CST_minus_1_]] into [[VAR_2_]][] : tensor<i32>
+// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_1_]] : tensor<4096xi32>) outs([[VAR_inserted_]] : tensor<i32>) dimensions = [0]
+// CHECK:             ([[in_:%.+]]: i32, [[init_:%.+]]: i32) {
+// CHECK:               [[VAR_3_:%.+]] = arith.minui [[in_]], [[init_]] : i32
+// CHECK:               linalg.yield [[VAR_3_]] : i32
+// CHECK:             }
+// CHECK:           [[VAR_extracted_:%.+]] = tensor.extract [[VAR_reduced_]][] : tensor<i32>
+// CHECK:           affine.store [[VAR_extracted_]], [[VAR_reinterpret_cast_]][0] : memref<1xi32, strided<[1], offset: ?>>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/convert_splat_float.mlir
+++ b/test/Conversion/StructuredToMemref/convert_splat_float.mlir
@@ -1,0 +1,24 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+module {
+    tt.func @kernel(%fin : f32,
+                    %bin : bf16,
+                    %save0 : tensor<1024x!tt.ptr<f32>>,
+                    %save1 : tensor<128x256x!tt.ptr<bf16>>) -> () {
+        %0 = tt.splat %fin : (f32) -> (tensor<1024xf32>)
+        %1 = tt.splat %bin : (bf16) -> (tensor<128x256xbf16>)
+        tt.store %save0, %0 {cache = 1 : i32, evict = 1 : i32} : tensor<1024xf32>
+        tt.store %save1, %1 {cache = 1 : i32, evict = 1 : i32} : tensor<128x256xbf16>
+        tt.return
+    }
+}
+// mlir2FileCheck.py
+// CHECK-LABEL:  func.func @kernel
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: f32, [[PARAM_1_:%.+]]: bf16, [[PARAM_2_:%.+]]: tensor<1024x!tt.ptr<f32, 1>>, [[PARAM_3_:%.+]]: tensor<128x256x!tt.ptr<bf16, 1>>, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32) {
+// CHECK:           [[VAR_0_:%.+]] = tensor.empty() : tensor<1024xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = linalg.fill ins([[PARAM_0_]] : f32) outs([[VAR_0_]] : tensor<1024xf32>) -> tensor<1024xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tensor.empty() : tensor<128x256xbf16>
+// CHECK:           [[VAR_3_:%.+]] = linalg.fill ins([[PARAM_1_]] : bf16) outs([[VAR_2_]] : tensor<128x256xbf16>) -> tensor<128x256xbf16>
+// CHECK:           tt.store [[PARAM_2_]], [[VAR_1_]] {cache = 1 : i32, evict = 1 : i32} : tensor<1024xf32>
+// CHECK:           tt.store [[PARAM_3_]], [[VAR_3_]] {cache = 1 : i32, evict = 1 : i32} : tensor<128x256xbf16>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/convert_splat_float.mlir
+++ b/test/Conversion/StructuredToMemref/convert_splat_float.mlir
@@ -4,8 +4,8 @@ module {
                     %bin : bf16,
                     %save0 : tensor<1024x!tt.ptr<f32>>,
                     %save1 : tensor<128x256x!tt.ptr<bf16>>) -> () {
-        %0 = tt.splat %fin : (f32) -> (tensor<1024xf32>)
-        %1 = tt.splat %bin : (bf16) -> (tensor<128x256xbf16>)
+        %0 = tt.splat %fin : f32 -> tensor<1024xf32>
+        %1 = tt.splat %bin : bf16 -> tensor<128x256xbf16>
         tt.store %save0, %0 {cache = 1 : i32, evict = 1 : i32} : tensor<1024xf32>
         tt.store %save1, %1 {cache = 1 : i32, evict = 1 : i32} : tensor<128x256xbf16>
         tt.return

--- a/test/Conversion/StructuredToMemref/convert_tensor_reshape.mlir
+++ b/test/Conversion/StructuredToMemref/convert_tensor_reshape.mlir
@@ -1,0 +1,55 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+module {
+  tt.func public @bcast_kernel_01(%arg0: !tt.ptr<f32, 1>, %arg1: !tt.ptr<f32, 1>) attributes {noinline = false} {
+    %c32_i32 = arith.constant 32 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c32_i32 : i32
+    %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %4 = arith.addi %3, %2 : tensor<32xi32>
+    %5 = tt.make_range {end = 2048 : i32, start = 0 : i32} : tensor<2048xi32>
+    %6 = tt.splat %1 : (i32) -> tensor<2048xi32>
+    %7 = arith.addi %6, %5 : tensor<2048xi32>
+    %8 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %9 = tt.addptr %8, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
+    %10 = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
+    %11 = tt.reshape %10 {allow_reorder = false} : tensor<32xf32> -> tensor<1x32xf32>
+    %12 = tt.broadcast %11 : (tensor<1x32xf32>) -> tensor<64x32xf32>
+    %13 = tt.reshape %12 {allow_reorder = false} : tensor<64x32xf32> -> tensor<2048xf32>
+    %14 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<2048x!tt.ptr<f32, 1>>
+    %15 = tt.addptr %14, %7 : tensor<2048x!tt.ptr<f32, 1>>, tensor<2048xi32>
+    tt.store %15, %13 {cache = 1 : i32, evict = 1 : i32} : tensor<2048xf32>
+    tt.return
+  }
+}
+
+
+// mlir2FileCheck.py
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0, d1) -> (0, d1)>
+// CHECK-DAG:   [[MAP_1_:#.+]] = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK-LABEL:  func.func @bcast_kernel_01
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_2048_:%.+]] = arith.constant 2048 : i64
+// CHECK-DAG:       [[VAR_cst_:%.+]] = arith.constant dense<[1, 32]> : tensor<2xi64>
+// CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
+// CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_5_]], [[CST_32_]] : i32
+// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<32xf32, strided<[1], offset: ?>> to memref<32xf32>
+// CHECK:           [[VAR_3_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK-DAG:       [[VAR_reshape_:%.+]] = tensor.reshape [[VAR_3_]]([[VAR_cst_]]) : (tensor<32xf32>, tensor<2xi64>) -> tensor<1x32xf32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = tensor.empty() : tensor<64x32xf32>
+// CHECK:           [[VAR_5_:%.+]] = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel"]} ins([[VAR_reshape_]] : tensor<1x32xf32>) outs([[VAR_4_]] : tensor<64x32xf32>) attrs =  {broadcastDims = array<i64: 0>} {
+// CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
+// CHECK:             linalg.yield [[IN_0_]] : f32
+// CHECK:           } -> tensor<64x32xf32>
+// CHECK:           [[VAR_6_:%.+]] = tensor.empty() : tensor<1xi64>
+// CHECK:           [[VAR_7_:%.+]] = linalg.fill ins([[CST_2048_]] : i64) outs([[VAR_6_]] : tensor<1xi64>) -> tensor<1xi64>
+// CHECK-DAG:       [[VAR_reshape_0_:%.+]] = tensor.reshape [[VAR_5_]]([[VAR_7_]]) : (tensor<64x32xf32>, tensor<1xi64>) -> tensor<2048xf32>
+// CHECK-DAG:       [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [2048], strides: [1] : memref<*xf32> to memref<2048xf32, strided<[1], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_reshape_0_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<2048xf32>, memref<2048xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/convert_tensor_reshape.mlir
+++ b/test/Conversion/StructuredToMemref/convert_tensor_reshape.mlir
@@ -5,18 +5,18 @@ module {
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %c32_i32 : i32
     %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
-    %3 = tt.splat %1 : (i32) -> tensor<32xi32>
+    %3 = tt.splat %1 : i32 -> tensor<32xi32>
     %4 = arith.addi %3, %2 : tensor<32xi32>
     %5 = tt.make_range {end = 2048 : i32, start = 0 : i32} : tensor<2048xi32>
-    %6 = tt.splat %1 : (i32) -> tensor<2048xi32>
+    %6 = tt.splat %1 : i32 -> tensor<2048xi32>
     %7 = arith.addi %6, %5 : tensor<2048xi32>
-    %8 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<32x!tt.ptr<f32, 1>>
+    %8 = tt.splat %arg0 : !tt.ptr<f32, 1> -> tensor<32x!tt.ptr<f32, 1>>
     %9 = tt.addptr %8, %4 : tensor<32x!tt.ptr<f32, 1>>, tensor<32xi32>
     %10 = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32xf32>
     %11 = tt.reshape %10 {allow_reorder = false} : tensor<32xf32> -> tensor<1x32xf32>
-    %12 = tt.broadcast %11 : (tensor<1x32xf32>) -> tensor<64x32xf32>
+    %12 = tt.broadcast %11 : tensor<1x32xf32> -> tensor<64x32xf32>
     %13 = tt.reshape %12 {allow_reorder = false} : tensor<64x32xf32> -> tensor<2048xf32>
-    %14 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<2048x!tt.ptr<f32, 1>>
+    %14 = tt.splat %arg1 : !tt.ptr<f32, 1> -> tensor<2048x!tt.ptr<f32, 1>>
     %15 = tt.addptr %14, %7 : tensor<2048x!tt.ptr<f32, 1>>, tensor<2048xi32>
     tt.store %15, %13 {cache = 1 : i32, evict = 1 : i32} : tensor<2048xf32>
     tt.return

--- a/test/Conversion/StructuredToMemref/cumsum.mlir
+++ b/test/Conversion/StructuredToMemref/cumsum.mlir
@@ -1,0 +1,69 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+
+// @triton.jit
+// def test_cumsum_op(
+//     input_ptr, output_ptr, n_columns
+// ):
+//     row = tl.program_id(axis=0)
+//     row_start = row * n_columns
+//     columns = tl.arange(0, 4096)
+//     offsets = row_start + columns
+//     data = tl.load(input_ptr + offsets)
+//     result = tl.cumsum(data, axis=0)
+//     tl.store(output_ptr + offsets, result)
+//
+// ret = triton.compiler.compile(
+//     test_cumsum_op,
+//     signature=" *fp32,*i32,i32",
+//     print_triton_ir_only=True,
+// )
+// print(ret.asm["ttir"])
+
+module {
+  tt.func public @test_cumsum_op_012(%arg0: !tt.ptr<f32, 1>, %arg1: !tt.ptr<i32, 1>, %arg2: i32) attributes {noinline = false} {
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %arg2 : i32
+    %2 = tt.make_range {end = 4096 : i32, start = 0 : i32} : tensor<4096xi32>
+    %3 = tt.splat %1 : (i32) -> tensor<4096xi32>
+    %4 = arith.addi %3, %2 : tensor<4096xi32>
+    %5 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<4096x!tt.ptr<f32, 1>>
+    %6 = tt.addptr %5, %4 : tensor<4096x!tt.ptr<f32, 1>>, tensor<4096xi32>
+    %7 = tt.load %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<4096xf32>
+    %8 = "tt.scan"(%7) <{axis = 0 : i32}> ({
+    ^bb0(%arg3: f32, %arg4: f32):
+      %12 = arith.addf %arg3, %arg4 : f32
+      tt.scan.return %12 : f32
+    }) : (tensor<4096xf32>) -> tensor<4096xf32>
+    %9 = tt.splat %arg1 : (!tt.ptr<i32, 1>) -> tensor<4096x!tt.ptr<i32, 1>>
+    %10 = tt.addptr %9, %4 : tensor<4096x!tt.ptr<i32, 1>>, tensor<4096xi32>
+    %11 = arith.fptosi %8 : tensor<4096xf32> to tensor<4096xi32>
+    tt.store %10, %11 {cache = 1 : i32, evict = 1 : i32} : tensor<4096xi32>
+    tt.return
+  }
+}
+
+// mlir2FileCheck.py
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func @test_cumsum_op_012
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xi32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[PARAM_2_]] : i32
+// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [4096], strides: [1] : memref<*xf32> to memref<4096xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<4096xf32>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<4096xf32, strided<[1], offset: ?>> to memref<4096xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<4096xf32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = tensor.empty() : tensor<4096xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_5_:%.+]] = ttx.cumsum {axis = 0 : ui32, operandSegmentSizes = array<i32: 1, 1>} ins([[VAR_3_]] : tensor<4096xf32>) outs([[VAR_4_]] : tensor<4096xf32>) -> tensor<4096xf32>
+// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [4096], strides: [1] : memref<*xi32> to memref<4096xi32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_6_:%.+]] = tensor.empty() : tensor<4096xi32>
+// CHECK:           [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_5_]] : tensor<4096xf32>) outs([[VAR_6_]] : tensor<4096xi32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: i32):
+// CHECK:             [[VAR_8_:%.+]] = arith.fptosi [[IN_0_]] : f32 to i32
+// CHECK:             linalg.yield [[VAR_8_]] : i32
+// CHECK:           } -> tensor<4096xi32>
+// CHECK:           bufferization.materialize_in_destination [[VAR_7_]] in writable [[VAR_reinterpret_cast_0_]] : (tensor<4096xi32>, memref<4096xi32, strided<[1], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/cumsum.mlir
+++ b/test/Conversion/StructuredToMemref/cumsum.mlir
@@ -24,9 +24,9 @@ module {
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %arg2 : i32
     %2 = tt.make_range {end = 4096 : i32, start = 0 : i32} : tensor<4096xi32>
-    %3 = tt.splat %1 : (i32) -> tensor<4096xi32>
+    %3 = tt.splat %1 : i32 -> tensor<4096xi32>
     %4 = arith.addi %3, %2 : tensor<4096xi32>
-    %5 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<4096x!tt.ptr<f32, 1>>
+    %5 = tt.splat %arg0 : !tt.ptr<f32, 1> -> tensor<4096x!tt.ptr<f32, 1>>
     %6 = tt.addptr %5, %4 : tensor<4096x!tt.ptr<f32, 1>>, tensor<4096xi32>
     %7 = tt.load %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<4096xf32>
     %8 = "tt.scan"(%7) <{axis = 0 : i32}> ({
@@ -34,7 +34,7 @@ module {
       %12 = arith.addf %arg3, %arg4 : f32
       tt.scan.return %12 : f32
     }) : (tensor<4096xf32>) -> tensor<4096xf32>
-    %9 = tt.splat %arg1 : (!tt.ptr<i32, 1>) -> tensor<4096x!tt.ptr<i32, 1>>
+    %9 = tt.splat %arg1 : !tt.ptr<i32, 1> -> tensor<4096x!tt.ptr<i32, 1>>
     %10 = tt.addptr %9, %4 : tensor<4096x!tt.ptr<i32, 1>>, tensor<4096xi32>
     %11 = arith.fptosi %8 : tensor<4096xf32> to tensor<4096xi32>
     tt.store %10, %11 {cache = 1 : i32, evict = 1 : i32} : tensor<4096xi32>

--- a/test/Conversion/StructuredToMemref/dot.mlir
+++ b/test/Conversion/StructuredToMemref/dot.mlir
@@ -1,0 +1,85 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+module {
+  tt.func @kernel(
+    %arg0 : !tt.ptr<bf16>,
+    %arg1 : !tt.ptr<bf16>,
+    %arg2 : !tt.ptr<bf16>
+  )
+  {
+    %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %c64 = arith.constant 128 : i32
+    %1 = tt.splat %c64 : (i32) -> tensor<128xi32>
+    %2 = arith.muli %0, %1 : tensor<128xi32>
+    %3 = tt.expand_dims %2 {axis = 1 : i32} : (tensor<128xi32>) -> tensor<128x1xi32>
+    %4 = tt.broadcast %3 : (tensor<128x1xi32>) -> tensor<128x64xi32>
+    %5 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32>
+    %6 = tt.expand_dims %5 {axis = 0 : i32} : (tensor<64xi32>) -> tensor<1x64xi32>
+    %7 = tt.broadcast %6 : (tensor<1x64xi32>) -> tensor<128x64xi32>
+    %8 = arith.addi %4, %7 : tensor<128x64xi32>
+    %10 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
+    %11 = tt.expand_dims %10 {axis = 1 : i32} : (tensor<256xi32>) -> tensor<256x1xi32>
+    %12 = tt.broadcast %11 : (tensor<256x1xi32>) -> tensor<256x64xi32>
+    %13 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32>
+    %c256 = arith.constant 256 : i32
+    %14 = tt.splat %c256 : (i32) -> tensor<64xi32>
+    %15 = arith.muli %13, %14 : tensor<64xi32>
+    %16 = tt.expand_dims %15 {axis = 0 : i32} : (tensor<64xi32>) -> tensor<1x64xi32>
+    %17 = tt.broadcast %16 : (tensor<1x64xi32>) -> tensor<256x64xi32>
+    %18 = arith.addi %12, %17 : tensor<256x64xi32>
+    %20 = tt.splat %c256 : (i32) -> tensor<128xi32>
+    %21 = arith.muli %0, %20 : tensor<128xi32>
+    %22 = tt.expand_dims %21 {axis = 1 : i32} : (tensor<128xi32>) -> tensor<128x1xi32>
+    %23 = tt.broadcast %22 : (tensor<128x1xi32>) -> tensor<128x256xi32>
+    %24 = tt.expand_dims %10 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
+    %25 = tt.broadcast %24 {axis = 0 : i32} : (tensor<1x256xi32>) -> tensor<128x256xi32>
+    %26 = arith.addi %23, %25 : tensor<128x256xi32>
+    %30 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<128x64x!tt.ptr<bf16>>
+    %31 = tt.addptr %30, %8 : tensor<128x64x!tt.ptr<bf16>>, tensor<128x64xi32>
+    %32 = tt.load %31 {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<128x64xbf16>
+    %40 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<256x64x!tt.ptr<bf16>>
+    %41 = tt.addptr %40, %18 : tensor<256x64x!tt.ptr<bf16>>, tensor<256x64xi32>
+    %42 = tt.load %41 {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<256x64xbf16>
+    %43 = tt.trans %42 {order = array<i32: 1, 0>} : (tensor<256x64xbf16>) -> tensor<64x256xbf16>
+    %50 = tt.splat %arg2 : (!tt.ptr<bf16>) -> tensor<128x256x!tt.ptr<bf16>>
+    %51 = tt.addptr %50, %26 : tensor<128x256x!tt.ptr<bf16>>, tensor<128x256xi32>
+    %52 = tt.load %51 {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<128x256xbf16>
+    %60 = tt.dot %32, %43, %52 {allowTF32 = false, maxNumImpreciseAcc = 0 : i32} : tensor<128x64xbf16> * tensor<64x256xbf16> -> tensor<128x256xbf16>
+    tt.store %51, %60 : tensor<128x256xbf16>
+    tt.return
+  }
+}
+
+// mlir2FileCheck.py
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK-LABEL:  func.func @kernel
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: memref<*xbf16>, [[PARAM_2_:%.+]]: memref<*xbf16>, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : bf16
+// CHECK-DAG:       [[CST_256_:%.+]] = arith.constant 256 : index
+// CHECK-DAG:       [[CST_128_:%.+]] = arith.constant 128 : index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [128, 64], strides: {{.}}[[CST_128_]], 1] : memref<*xbf16> to memref<128x64xbf16, strided<[?, 1]>>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<128x64xbf16>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<128x64xbf16, strided<[?, 1]>> to memref<128x64xbf16>
+// CHECK-DAG:       [[VAR_0_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<128x64xbf16>
+// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: [0], sizes: [256, 64], strides: [1, [[CST_256_]]{{.}} : memref<*xbf16> to memref<256x64xbf16, strided<[1, ?]>>
+// CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc() : memref<256x64xbf16>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_0_]], [[RES_1_]] : memref<256x64xbf16, strided<[1, ?]>> to memref<256x64xbf16>
+// CHECK-DAG:       [[VAR_1_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<256x64xbf16>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tensor.empty() : tensor<64x256xbf16>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_transposed_:%.+]] = linalg.transpose ins([[VAR_1_]] : tensor<256x64xbf16>) outs([[VAR_2_]] : tensor<64x256xbf16>) permutation = [1, 0]
+// CHECK-DAG:       [[VAR_reinterpret_cast_2_:%.+]] = memref.reinterpret_cast [[PARAM_2_]] to offset: [0], sizes: [128, 256], strides: {{.}}[[CST_256_]], 1] : memref<*xbf16> to memref<128x256xbf16, strided<[?, 1]>>
+// CHECK-DAG:       [[RES_2_:%.+]] = memref.alloc() : memref<128x256xbf16>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_2_]], [[RES_2_]] : memref<128x256xbf16, strided<[?, 1]>> to memref<128x256xbf16>
+// CHECK-DAG:       [[VAR_3_:%.+]] = bufferization.to_tensor [[RES_2_]] restrict writable : memref<128x256xbf16>
+// CHECK-DAG:       [[VAR_4_:%.+]] = tensor.empty() : tensor<128x256xbf16>
+// CHECK:           [[VAR_5_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : bf16) outs([[VAR_4_]] : tensor<128x256xbf16>) -> tensor<128x256xbf16>
+// CHECK:           [[VAR_6_:%.+]] = linalg.matmul ins([[VAR_0_]], [[VAR_transposed_]] : tensor<128x64xbf16>, tensor<64x256xbf16>) outs([[VAR_5_]] : tensor<128x256xbf16>) -> tensor<128x256xbf16>
+// CHECK:           [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_6_]], [[VAR_3_]] : tensor<128x256xbf16>, tensor<128x256xbf16>) outs([[VAR_6_]] : tensor<128x256xbf16>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: bf16, [[IN_1_:%.+]]: bf16, [[IN_2_:%.+]]: bf16):
+// CHECK:             [[VAR_8_:%.+]] = arith.addf [[IN_0_]], [[IN_1_]] : bf16
+// CHECK:             linalg.yield [[VAR_8_]] : bf16
+// CHECK:           } -> tensor<128x256xbf16>
+// CHECK:           bufferization.materialize_in_destination [[VAR_7_]] in writable [[VAR_reinterpret_cast_2_]] : (tensor<128x256xbf16>, memref<128x256xbf16, strided<[?, 1]>>) -> ()
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/dot.mlir
+++ b/test/Conversion/StructuredToMemref/dot.mlir
@@ -8,39 +8,39 @@ module {
   {
     %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
     %c64 = arith.constant 128 : i32
-    %1 = tt.splat %c64 : (i32) -> tensor<128xi32>
+    %1 = tt.splat %c64 : i32 -> tensor<128xi32>
     %2 = arith.muli %0, %1 : tensor<128xi32>
-    %3 = tt.expand_dims %2 {axis = 1 : i32} : (tensor<128xi32>) -> tensor<128x1xi32>
-    %4 = tt.broadcast %3 : (tensor<128x1xi32>) -> tensor<128x64xi32>
+    %3 = tt.expand_dims %2 {axis = 1 : i32} : tensor<128xi32> -> tensor<128x1xi32>
+    %4 = tt.broadcast %3 : tensor<128x1xi32> -> tensor<128x64xi32>
     %5 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32>
-    %6 = tt.expand_dims %5 {axis = 0 : i32} : (tensor<64xi32>) -> tensor<1x64xi32>
-    %7 = tt.broadcast %6 : (tensor<1x64xi32>) -> tensor<128x64xi32>
+    %6 = tt.expand_dims %5 {axis = 0 : i32} : tensor<64xi32> -> tensor<1x64xi32>
+    %7 = tt.broadcast %6 : tensor<1x64xi32> -> tensor<128x64xi32>
     %8 = arith.addi %4, %7 : tensor<128x64xi32>
     %10 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
-    %11 = tt.expand_dims %10 {axis = 1 : i32} : (tensor<256xi32>) -> tensor<256x1xi32>
-    %12 = tt.broadcast %11 : (tensor<256x1xi32>) -> tensor<256x64xi32>
+    %11 = tt.expand_dims %10 {axis = 1 : i32} : tensor<256xi32> -> tensor<256x1xi32>
+    %12 = tt.broadcast %11 : tensor<256x1xi32> -> tensor<256x64xi32>
     %13 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32>
     %c256 = arith.constant 256 : i32
-    %14 = tt.splat %c256 : (i32) -> tensor<64xi32>
+    %14 = tt.splat %c256 : i32 -> tensor<64xi32>
     %15 = arith.muli %13, %14 : tensor<64xi32>
-    %16 = tt.expand_dims %15 {axis = 0 : i32} : (tensor<64xi32>) -> tensor<1x64xi32>
-    %17 = tt.broadcast %16 : (tensor<1x64xi32>) -> tensor<256x64xi32>
+    %16 = tt.expand_dims %15 {axis = 0 : i32} : tensor<64xi32> -> tensor<1x64xi32>
+    %17 = tt.broadcast %16 : tensor<1x64xi32> -> tensor<256x64xi32>
     %18 = arith.addi %12, %17 : tensor<256x64xi32>
-    %20 = tt.splat %c256 : (i32) -> tensor<128xi32>
+    %20 = tt.splat %c256 : i32 -> tensor<128xi32>
     %21 = arith.muli %0, %20 : tensor<128xi32>
-    %22 = tt.expand_dims %21 {axis = 1 : i32} : (tensor<128xi32>) -> tensor<128x1xi32>
-    %23 = tt.broadcast %22 : (tensor<128x1xi32>) -> tensor<128x256xi32>
-    %24 = tt.expand_dims %10 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
-    %25 = tt.broadcast %24 {axis = 0 : i32} : (tensor<1x256xi32>) -> tensor<128x256xi32>
+    %22 = tt.expand_dims %21 {axis = 1 : i32} : tensor<128xi32> -> tensor<128x1xi32>
+    %23 = tt.broadcast %22 : tensor<128x1xi32> -> tensor<128x256xi32>
+    %24 = tt.expand_dims %10 {axis = 0 : i32} : tensor<256xi32> -> tensor<1x256xi32>
+    %25 = tt.broadcast %24 {axis = 0 : i32} : tensor<1x256xi32> -> tensor<128x256xi32>
     %26 = arith.addi %23, %25 : tensor<128x256xi32>
-    %30 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<128x64x!tt.ptr<bf16>>
+    %30 = tt.splat %arg0 : !tt.ptr<bf16> -> tensor<128x64x!tt.ptr<bf16>>
     %31 = tt.addptr %30, %8 : tensor<128x64x!tt.ptr<bf16>>, tensor<128x64xi32>
     %32 = tt.load %31 {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<128x64xbf16>
-    %40 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<256x64x!tt.ptr<bf16>>
+    %40 = tt.splat %arg1 : !tt.ptr<bf16> -> tensor<256x64x!tt.ptr<bf16>>
     %41 = tt.addptr %40, %18 : tensor<256x64x!tt.ptr<bf16>>, tensor<256x64xi32>
     %42 = tt.load %41 {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<256x64xbf16>
-    %43 = tt.trans %42 {order = array<i32: 1, 0>} : (tensor<256x64xbf16>) -> tensor<64x256xbf16>
-    %50 = tt.splat %arg2 : (!tt.ptr<bf16>) -> tensor<128x256x!tt.ptr<bf16>>
+    %43 = tt.trans %42 {order = array<i32: 1, 0>} : tensor<256x64xbf16> -> tensor<64x256xbf16>
+    %50 = tt.splat %arg2 : !tt.ptr<bf16> -> tensor<128x256x!tt.ptr<bf16>>
     %51 = tt.addptr %50, %26 : tensor<128x256x!tt.ptr<bf16>>, tensor<128x256xi32>
     %52 = tt.load %51 {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<128x256xbf16>
     %60 = tt.dot %32, %43, %52 {allowTF32 = false, maxNumImpreciseAcc = 0 : i32} : tensor<128x64xbf16> * tensor<64x256xbf16> -> tensor<128x256xbf16>

--- a/test/Conversion/StructuredToMemref/get_num_programs.mlir
+++ b/test/Conversion/StructuredToMemref/get_num_programs.mlir
@@ -1,0 +1,41 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+
+module {
+  tt.func public @num_programs(%arg0: !tt.ptr<i32>) {
+    %0 = tt.get_num_programs {axis = 0 : i32} : i32
+    %1 = tt.get_num_programs {axis = 1 : i32} : i32
+    %2 = tt.get_num_programs {axis = 2 : i32} : i32
+    %3 = tt.make_range {end = 1 : i32, start = 0 : i32} : tensor<1xi32>
+    %4 = tt.make_range {end = 2 : i32, start = 1 : i32} : tensor<1xi32>
+    %5 = tt.make_range {end = 3 : i32, start = 2 : i32} : tensor<1xi32>
+    %6 = tt.splat %arg0 : (!tt.ptr<i32>) -> tensor<1x!tt.ptr<i32>>
+    %7 = tt.addptr %6, %3 : tensor<1x!tt.ptr<i32>>, tensor<1xi32>
+    %8 = tt.splat %0 : (i32) -> tensor<1xi32>
+    tt.store %7, %8 {cache = 1 : i32, evict = 1 : i32} : tensor<1xi32>
+    %9 = tt.addptr %6, %4 : tensor<1x!tt.ptr<i32>>, tensor<1xi32>
+    %10 = tt.splat %1 : (i32) -> tensor<1xi32>
+    tt.store %9, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<1xi32>
+    %11 = tt.addptr %6, %5 : tensor<1x!tt.ptr<i32>>, tensor<1xi32>
+    %12 = tt.splat %2 : (i32) -> tensor<1xi32>
+    tt.store %11, %12 {cache = 1 : i32, evict = 1 : i32} : tensor<1xi32>
+    tt.return
+  }
+}
+
+// mlir2FileCheck.py
+// CHECK-LABEL:  func.func @num_programs
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xi32>, [[PARAM_1_:%.+]]: i32, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32) {
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [1], strides: [1] : memref<*xi32> to memref<1xi32, strided<[1]>>
+// CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<1xi32>
+// CHECK:           [[VAR_1_:%.+]] = linalg.fill ins([[PARAM_1_]] : i32) outs([[VAR_0_]] : tensor<1xi32>) -> tensor<1xi32>
+// CHECK:           bufferization.materialize_in_destination [[VAR_1_]] in writable [[VAR_reinterpret_cast_]] : (tensor<1xi32>, memref<1xi32, strided<[1]>>) -> ()
+// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [1], sizes: [1], strides: [1] : memref<*xi32> to memref<1xi32, strided<[1], offset: 1>>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tensor.empty() : tensor<1xi32>
+// CHECK:           [[VAR_3_:%.+]] = linalg.fill ins([[PARAM_2_]] : i32) outs([[VAR_2_]] : tensor<1xi32>) -> tensor<1xi32>
+// CHECK:           bufferization.materialize_in_destination [[VAR_3_]] in writable [[VAR_reinterpret_cast_0_]] : (tensor<1xi32>, memref<1xi32, strided<[1], offset: 1>>) -> ()
+// CHECK-DAG:       [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [2], sizes: [1], strides: [1] : memref<*xi32> to memref<1xi32, strided<[1], offset: 2>>
+// CHECK-DAG:       [[VAR_4_:%.+]] = tensor.empty() : tensor<1xi32>
+// CHECK:           [[VAR_5_:%.+]] = linalg.fill ins([[PARAM_3_]] : i32) outs([[VAR_4_]] : tensor<1xi32>) -> tensor<1xi32>
+// CHECK:           bufferization.materialize_in_destination [[VAR_5_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<1xi32>, memref<1xi32, strided<[1], offset: 2>>) -> ()
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/get_num_programs.mlir
+++ b/test/Conversion/StructuredToMemref/get_num_programs.mlir
@@ -8,15 +8,15 @@ module {
     %3 = tt.make_range {end = 1 : i32, start = 0 : i32} : tensor<1xi32>
     %4 = tt.make_range {end = 2 : i32, start = 1 : i32} : tensor<1xi32>
     %5 = tt.make_range {end = 3 : i32, start = 2 : i32} : tensor<1xi32>
-    %6 = tt.splat %arg0 : (!tt.ptr<i32>) -> tensor<1x!tt.ptr<i32>>
+    %6 = tt.splat %arg0 : !tt.ptr<i32> -> tensor<1x!tt.ptr<i32>>
     %7 = tt.addptr %6, %3 : tensor<1x!tt.ptr<i32>>, tensor<1xi32>
-    %8 = tt.splat %0 : (i32) -> tensor<1xi32>
+    %8 = tt.splat %0 : i32 -> tensor<1xi32>
     tt.store %7, %8 {cache = 1 : i32, evict = 1 : i32} : tensor<1xi32>
     %9 = tt.addptr %6, %4 : tensor<1x!tt.ptr<i32>>, tensor<1xi32>
-    %10 = tt.splat %1 : (i32) -> tensor<1xi32>
+    %10 = tt.splat %1 : i32 -> tensor<1xi32>
     tt.store %9, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<1xi32>
     %11 = tt.addptr %6, %5 : tensor<1x!tt.ptr<i32>>, tensor<1xi32>
-    %12 = tt.splat %2 : (i32) -> tensor<1xi32>
+    %12 = tt.splat %2 : i32 -> tensor<1xi32>
     tt.store %11, %12 {cache = 1 : i32, evict = 1 : i32} : tensor<1xi32>
     tt.return
   }

--- a/test/Conversion/StructuredToMemref/kernel-01-vector-add.mlir
+++ b/test/Conversion/StructuredToMemref/kernel-01-vector-add.mlir
@@ -6,18 +6,18 @@ module {
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %c1024_i32 : i32
     %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
-    %3 = tt.splat %1 : (i32) -> tensor<1024xi32>
+    %3 = tt.splat %1 : i32 -> tensor<1024xi32>
     %4 = arith.addi %3, %2 : tensor<1024xi32>
-    %5 = tt.splat %arg3 : (i32) -> tensor<1024xi32>
+    %5 = tt.splat %arg3 : i32 -> tensor<1024xi32>
     %6 = arith.cmpi slt, %4, %5 : tensor<1024xi32>
-    %7 = tt.splat %arg0 : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+    %7 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
     %8 = tt.addptr %7, %4 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
     %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xf32>
-    %10 = tt.splat %arg1 : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+    %10 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
     %11 = tt.addptr %10, %4 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
     %12 = tt.load %11, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xf32>
     %13 = arith.addf %9, %12 : tensor<1024xf32>
-    %14 = tt.splat %arg2 : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+    %14 = tt.splat %arg2 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
     %15 = tt.addptr %14, %4 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
     tt.store %15, %13, %6 {cache = 1 : i32, evict = 1 : i32} : tensor<1024xf32>
     tt.return

--- a/test/Conversion/StructuredToMemref/kernel-01-vector-add.mlir
+++ b/test/Conversion/StructuredToMemref/kernel-01-vector-add.mlir
@@ -1,0 +1,80 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+
+module {
+  tt.func public @add_kernel_01234(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: !tt.ptr<f32>, %arg3: i32) {
+    %c1024_i32 = arith.constant 1024 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c1024_i32 : i32
+    %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+    %3 = tt.splat %1 : (i32) -> tensor<1024xi32>
+    %4 = arith.addi %3, %2 : tensor<1024xi32>
+    %5 = tt.splat %arg3 : (i32) -> tensor<1024xi32>
+    %6 = arith.cmpi slt, %4, %5 : tensor<1024xi32>
+    %7 = tt.splat %arg0 : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+    %8 = tt.addptr %7, %4 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+    %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xf32>
+    %10 = tt.splat %arg1 : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+    %11 = tt.addptr %10, %4 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+    %12 = tt.load %11, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xf32>
+    %13 = arith.addf %9, %12 : tensor<1024xf32>
+    %14 = tt.splat %arg2 : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+    %15 = tt.addptr %14, %4 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+    tt.store %15, %13, %6 {cache = 1 : i32, evict = 1 : i32} : tensor<1024xf32>
+    tt.return
+  }
+}
+
+// mlir2FileCheck.py
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func @add_kernel_01234
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: memref<*xf32>, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_1024_:%.+]] = arith.constant 1024 : i32
+// CHECK-DAG:       [[CST_1024_1_:%.+]] = arith.constant 1024 : index
+// CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_7_]], [[CST_1024_]] : i32
+// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_3_]]{{.}}, sizes: [1024], strides: [1] : memref<*xf32> to memref<1024xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_4_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.addi [[VAR_4_]], [[CST_1024_1_]] : index
+// CHECK-DAG:       [[VAR_6_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
+// CHECK:           [[VAR_7_:%.+]] = arith.minsi [[VAR_5_]], [[VAR_6_]] : index
+// CHECK-DAG:       [[VAR_8_:%.+]] = arith.subi [[VAR_7_]], [[VAR_4_]] : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<1024xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_8_]]{{.}} [1] : memref<1024xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_8_]]{{.}} [1] : memref<1024xf32> to memref<?xf32, strided<[1]>>
+// CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:       [[VAR_9_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<1024xf32>
+// CHECK-DAG:       [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [1024], strides: [1] : memref<*xf32> to memref<1024xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_10_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_11_:%.+]] = arith.addi [[VAR_10_]], [[CST_1024_1_]] : index
+// CHECK-DAG:       [[VAR_12_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
+// CHECK:           [[VAR_13_:%.+]] = arith.minsi [[VAR_11_]], [[VAR_12_]] : index
+// CHECK-DAG:       [[VAR_14_:%.+]] = arith.subi [[VAR_13_]], [[VAR_10_]] : index
+// CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc() : memref<1024xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_subview_3_:%.+]] = memref.subview [[VAR_reinterpret_cast_1_]][0] {{.}}[[VAR_14_]]{{.}} [1] : memref<1024xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_4_:%.+]] = memref.subview [[RES_1_]][0] {{.}}[[VAR_14_]]{{.}} [1] : memref<1024xf32> to memref<?xf32, strided<[1]>>
+// CHECK:           memref.copy [[VAR_subview_3_]], [[VAR_subview_4_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK:           [[VAR_15_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<1024xf32>
+// CHECK:           [[VAR_16_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_9_]], [[VAR_15_]] : tensor<1024xf32>, tensor<1024xf32>) outs([[VAR_9_]] : tensor<1024xf32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32, [[IN_2_:%.+]]: f32):
+// CHECK:             [[VAR_22_:%.+]] = arith.addf [[IN_0_]], [[IN_1_]] : f32
+// CHECK:             linalg.yield [[VAR_22_]] : f32
+// CHECK:           } -> tensor<1024xf32>
+// CHECK-DAG:       [[VAR_reinterpret_cast_5_:%.+]] = memref.reinterpret_cast [[PARAM_2_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [1024], strides: [1] : memref<*xf32> to memref<1024xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_17_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_18_:%.+]] = arith.addi [[VAR_17_]], [[CST_1024_1_]] : index
+// CHECK-DAG:       [[VAR_19_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
+// CHECK:           [[VAR_20_:%.+]] = arith.minsi [[VAR_18_]], [[VAR_19_]] : index
+// CHECK:           [[VAR_21_:%.+]] = arith.subi [[VAR_20_]], [[VAR_17_]] : index
+// CHECK-DAG:       [[VAR_extracted_slice_:%.+]] = tensor.extract_slice [[VAR_16_]][0] {{.}}[[VAR_21_]]{{.}} [1] : tensor<1024xf32> to tensor<?xf32>
+// CHECK-DAG:       [[VAR_subview_6_:%.+]] = memref.subview [[VAR_reinterpret_cast_5_]][0] {{.}}[[VAR_21_]]{{.}} [1] : memref<1024xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_extracted_slice_]] in writable [[VAR_subview_6_]] : (tensor<?xf32>, memref<?xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/kernel-02-fused-softmax.mlir
+++ b/test/Conversion/StructuredToMemref/kernel-02-fused-softmax.mlir
@@ -1,0 +1,107 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+
+module {
+  tt.func public @softmax_kernel_012345(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: i32, %arg3: i32, %arg4: i32) {
+    %cst = arith.constant 0xFF800000 : f32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %arg2 : i32
+    %2 = tt.addptr %arg1, %1 : !tt.ptr<f32>, i32
+    %3 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %4 = tt.splat %2 : (!tt.ptr<f32>) -> tensor<128x!tt.ptr<f32>>
+    %5 = tt.addptr %4, %3 : tensor<128x!tt.ptr<f32>>, tensor<128xi32>
+    %6 = tt.splat %arg4 : (i32) -> tensor<128xi32>
+    %7 = arith.cmpi slt, %3, %6 : tensor<128xi32>
+    %8 = tt.splat %cst : (f32) -> tensor<128xf32>
+    %9 = tt.load %5, %7, %8 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128xf32>
+    %10 = "tt.reduce"(%9) ({
+    ^bb0(%arg5: f32, %arg6: f32):
+      %21 = arith.cmpf ogt, %arg5, %arg6 : f32
+      %22 = arith.select %21, %arg5, %arg6 : f32
+      tt.reduce.return %22 : f32
+    }) {axis = 0 : i32} : (tensor<128xf32>) -> f32
+    %11 = tt.splat %10 : (f32) -> tensor<128xf32>
+    %12 = arith.subf %9, %11 : tensor<128xf32>
+    %13 = math.exp %12 : tensor<128xf32>
+    %14 = "tt.reduce"(%13) ({
+    ^bb0(%arg5: f32, %arg6: f32):
+      %21 = arith.addf %arg5, %arg6 : f32
+      tt.reduce.return %21 : f32
+    }) {axis = 0 : i32} : (tensor<128xf32>) -> f32
+    %15 = tt.splat %14 : (f32) -> tensor<128xf32>
+    %16 = arith.divf %13, %15 : tensor<128xf32>
+    %17 = arith.muli %0, %arg3 : i32
+    %18 = tt.addptr %arg0, %17 : !tt.ptr<f32>, i32
+    %19 = tt.splat %18 : (!tt.ptr<f32>) -> tensor<128x!tt.ptr<f32>>
+    %20 = tt.addptr %19, %3 : tensor<128x!tt.ptr<f32>>, tensor<128xi32>
+    tt.store %20, %16, %7 {cache = 1 : i32, evict = 1 : i32} : tensor<128xf32>
+    tt.return
+  }
+}
+
+// mlir2FileCheck.py
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func @softmax_kernel_012345
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32, [[PARAM_10_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0xFF800000 : f32
+// CHECK-DAG:       [[CST_128_:%.+]] = arith.constant 128 : index
+// CHECK-DAG:       [[VAR_0_:%.+]] = arith.muli [[PARAM_8_]], [[PARAM_2_]] : i32
+// CHECK:           [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [128], strides: [1] : memref<*xf32> to memref<128xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[PARAM_4_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.minsi [[VAR_2_]], [[CST_128_]] : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<128xf32>
+// CHECK:           [[VAR_4_:%.+]] = arith.cmpi slt, [[VAR_3_]], [[CST_128_]] : index
+// CHECK:           scf.if [[VAR_4_]] {
+// CHECK:             linalg.fill ins([[CST_0_]] : f32) outs([[RES_]] : memref<128xf32>)
+// CHECK:           }
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_3_]]{{.}} [1] : memref<128xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_1_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_3_]]{{.}} [1] : memref<128xf32> to memref<?xf32, strided<[1]>>
+// CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_1_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:       [[VAR_5_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<128xf32>
+// CHECK-DAG:       [[VAR_6_:%.+]] = bufferization.alloc_tensor() : tensor<f32>
+// CHECK:           [[VAR_inserted_:%.+]] = tensor.insert [[CST_0_]] into [[VAR_6_]][] : tensor<f32>
+// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_5_]] : tensor<128xf32>) outs([[VAR_inserted_]] : tensor<f32>) dimensions = [0]
+// CHECK:             ([[in_:%.+]]: f32, [[init_:%.+]]: f32) {
+// CHECK:               [[VAR_19_:%.+]] = arith.maximumf [[in_]], [[init_]] : f32
+// CHECK:               linalg.yield [[VAR_19_]] : f32
+// CHECK:             }
+// CHECK-DAG:       [[VAR_extracted_:%.+]] = tensor.extract [[VAR_reduced_]][] : tensor<f32>
+// CHECK-DAG:       [[VAR_7_:%.+]] = tensor.empty() : tensor<128xf32>
+// CHECK:           [[VAR_8_:%.+]] = linalg.fill ins([[VAR_extracted_]] : f32) outs([[VAR_7_]] : tensor<128xf32>) -> tensor<128xf32>
+// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_5_]], [[VAR_8_]] : tensor<128xf32>, tensor<128xf32>) outs([[VAR_5_]] : tensor<128xf32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32, [[IN_2_:%.+]]: f32):
+// CHECK:             [[VAR_19_1_:%.+]] = arith.subf [[IN_0_]], [[IN_1_]] : f32
+// CHECK:             linalg.yield [[VAR_19_1_]] : f32
+// CHECK:           } -> tensor<128xf32>
+// CHECK:           [[VAR_10_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_9_]] : tensor<128xf32>) outs([[VAR_9_]] : tensor<128xf32>) {
+// CHECK:           ^bb0([[IN_3_:%.+]]: f32, [[IN_4_:%.+]]: f32):
+// CHECK:             [[VAR_19_2_:%.+]] = math.exp [[IN_3_]] : f32
+// CHECK:             linalg.yield [[VAR_19_2_]] : f32
+// CHECK:           } -> tensor<128xf32>
+// CHECK:           [[VAR_11_:%.+]] = bufferization.alloc_tensor() : tensor<f32>
+// CHECK:           [[VAR_inserted_2_:%.+]] = tensor.insert [[CST_0_dot_000000_]] into [[VAR_11_]][] : tensor<f32>
+// CHECK:           [[VAR_reduced_3_:%.+]] = linalg.reduce ins([[VAR_10_]] : tensor<128xf32>) outs([[VAR_inserted_2_]] : tensor<f32>) dimensions = [0]
+// CHECK:             ([[IN_3_:%.+]]: f32, [[init_:%.+]]: f32) {
+// CHECK:               [[VAR_19_3_:%.+]] = arith.addf [[IN_3_]], [[init_]] : f32
+// CHECK:               linalg.yield [[VAR_19_3_]] : f32
+// CHECK:             }
+// CHECK-DAG:       [[VAR_extracted_4_:%.+]] = tensor.extract [[VAR_reduced_3_]][] : tensor<f32>
+// CHECK-DAG:       [[VAR_12_:%.+]] = tensor.empty() : tensor<128xf32>
+// CHECK:           [[VAR_13_:%.+]] = linalg.fill ins([[VAR_extracted_4_]] : f32) outs([[VAR_12_]] : tensor<128xf32>) -> tensor<128xf32>
+// CHECK:           [[VAR_14_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_10_]], [[VAR_13_]] : tensor<128xf32>, tensor<128xf32>) outs([[VAR_10_]] : tensor<128xf32>) {
+// CHECK:           ^bb0([[IN_5_:%.+]]: f32, [[IN_6_:%.+]]: f32, [[IN_7_:%.+]]: f32):
+// CHECK:             [[VAR_19_4_:%.+]] = arith.divf [[IN_5_]], [[IN_6_]] : f32
+// CHECK:             linalg.yield [[VAR_19_4_]] : f32
+// CHECK:           } -> tensor<128xf32>
+// CHECK:           [[VAR_15_:%.+]] = arith.muli [[PARAM_8_]], [[PARAM_3_]] : i32
+// CHECK:           [[VAR_16_:%.+]] = arith.index_cast [[VAR_15_]] : i32 to index
+// CHECK-DAG:       [[VAR_reinterpret_cast_5_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_16_]]{{.}}, sizes: [128], strides: [1] : memref<*xf32> to memref<128xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_17_:%.+]] = arith.index_cast [[PARAM_4_]] : i32 to index
+// CHECK:           [[VAR_18_:%.+]] = arith.minsi [[VAR_17_]], [[CST_128_]] : index
+// CHECK-DAG:       [[VAR_extracted_slice_:%.+]] = tensor.extract_slice [[VAR_14_]][0] {{.}}[[VAR_18_]]{{.}} [1] : tensor<128xf32> to tensor<?xf32>
+// CHECK-DAG:       [[VAR_subview_6_:%.+]] = memref.subview [[VAR_reinterpret_cast_5_]][0] {{.}}[[VAR_18_]]{{.}} [1] : memref<128xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_extracted_slice_]] in writable [[VAR_subview_6_]] : (tensor<?xf32>, memref<?xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/kernel-02-fused-softmax.mlir
+++ b/test/Conversion/StructuredToMemref/kernel-02-fused-softmax.mlir
@@ -7,11 +7,11 @@ module {
     %1 = arith.muli %0, %arg2 : i32
     %2 = tt.addptr %arg1, %1 : !tt.ptr<f32>, i32
     %3 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
-    %4 = tt.splat %2 : (!tt.ptr<f32>) -> tensor<128x!tt.ptr<f32>>
+    %4 = tt.splat %2 : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
     %5 = tt.addptr %4, %3 : tensor<128x!tt.ptr<f32>>, tensor<128xi32>
-    %6 = tt.splat %arg4 : (i32) -> tensor<128xi32>
+    %6 = tt.splat %arg4 : i32 -> tensor<128xi32>
     %7 = arith.cmpi slt, %3, %6 : tensor<128xi32>
-    %8 = tt.splat %cst : (f32) -> tensor<128xf32>
+    %8 = tt.splat %cst : f32 -> tensor<128xf32>
     %9 = tt.load %5, %7, %8 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128xf32>
     %10 = "tt.reduce"(%9) ({
     ^bb0(%arg5: f32, %arg6: f32):
@@ -19,7 +19,7 @@ module {
       %22 = arith.select %21, %arg5, %arg6 : f32
       tt.reduce.return %22 : f32
     }) {axis = 0 : i32} : (tensor<128xf32>) -> f32
-    %11 = tt.splat %10 : (f32) -> tensor<128xf32>
+    %11 = tt.splat %10 : f32 -> tensor<128xf32>
     %12 = arith.subf %9, %11 : tensor<128xf32>
     %13 = math.exp %12 : tensor<128xf32>
     %14 = "tt.reduce"(%13) ({
@@ -27,11 +27,11 @@ module {
       %21 = arith.addf %arg5, %arg6 : f32
       tt.reduce.return %21 : f32
     }) {axis = 0 : i32} : (tensor<128xf32>) -> f32
-    %15 = tt.splat %14 : (f32) -> tensor<128xf32>
+    %15 = tt.splat %14 : f32 -> tensor<128xf32>
     %16 = arith.divf %13, %15 : tensor<128xf32>
     %17 = arith.muli %0, %arg3 : i32
     %18 = tt.addptr %arg0, %17 : !tt.ptr<f32>, i32
-    %19 = tt.splat %18 : (!tt.ptr<f32>) -> tensor<128x!tt.ptr<f32>>
+    %19 = tt.splat %18 : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
     %20 = tt.addptr %19, %3 : tensor<128x!tt.ptr<f32>>, tensor<128xi32>
     tt.store %20, %16, %7 {cache = 1 : i32, evict = 1 : i32} : tensor<128xf32>
     tt.return

--- a/test/Conversion/StructuredToMemref/kernel-03-matrix-multiplication.mlir
+++ b/test/Conversion/StructuredToMemref/kernel-03-matrix-multiplication.mlir
@@ -1,0 +1,213 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+
+module {
+  tt.func public @matmul_kernel_0123456789101112131415(%arg0: !tt.ptr<bf16>, %arg1: !tt.ptr<bf16>, %arg2: !tt.ptr<bf16>, %arg3: i32, %arg4: i32, %arg5: i32, %arg6: i32, %arg7: i32, %arg8: i32, %arg9: i32, %arg10: i32, %arg11: i32) {
+    %c63_i32 = arith.constant 63 : i32
+    %c255_i32 = arith.constant 255 : i32
+    %c127_i32 = arith.constant 127 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %cst = arith.constant 0.000000e+00 : f32
+    %c256_i32 = arith.constant 256 : i32
+    %c128_i32 = arith.constant 128 : i32
+    %c8_i32 = arith.constant 8 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.addi %arg3, %c127_i32 : i32
+    %2 = arith.divsi %1, %c128_i32 : i32
+    %3 = arith.addi %arg4, %c255_i32 : i32
+    %4 = arith.divsi %3, %c256_i32 : i32
+    %5 = arith.addi %arg5, %c63_i32 : i32
+    %6 = arith.divsi %5, %c64_i32 : i32
+    %7 = arith.muli %4, %c8_i32 : i32
+    %8 = arith.divsi %0, %7 : i32
+    %9 = arith.muli %8, %c8_i32 : i32
+    %10 = arith.subi %2, %9 : i32
+    %11 = arith.cmpi slt, %10, %c8_i32 : i32
+    %12 = arith.select %11, %10, %c8_i32 : i32
+    %13 = arith.remsi %0, %12 : i32
+    %14 = arith.addi %9, %13 : i32
+    %15 = arith.remsi %0, %7 : i32
+    %16 = arith.divsi %15, %12 : i32
+    %17 = arith.muli %14, %c128_i32 : i32
+    %18 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %19 = tt.splat %17 : (i32) -> tensor<128xi32>
+    %20 = arith.addi %19, %18 : tensor<128xi32>
+    %21 = arith.muli %16, %c256_i32 : i32
+    %22 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
+    %23 = tt.splat %21 : (i32) -> tensor<256xi32>
+    %24 = arith.addi %23, %22 : tensor<256xi32>
+    %25 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32>
+    %26 = tt.expand_dims %20 {axis = 1 : i32} : (tensor<128xi32>) -> tensor<128x1xi32>
+    %27 = tt.splat %arg6 : (i32) -> tensor<128x1xi32>
+    %28 = arith.muli %26, %27 : tensor<128x1xi32>
+    %29 = tt.expand_dims %25 {axis = 0 : i32} : (tensor<64xi32>) -> tensor<1x64xi32>
+    %30 = tt.splat %arg7 : (i32) -> tensor<1x64xi32>
+    %31 = arith.muli %29, %30 : tensor<1x64xi32>
+    %32 = tt.broadcast %28 : (tensor<128x1xi32>) -> tensor<128x64xi32>
+    %33 = tt.broadcast %31 : (tensor<1x64xi32>) -> tensor<128x64xi32>
+    %34 = arith.addi %32, %33 : tensor<128x64xi32>
+    %35 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<128x64x!tt.ptr<bf16>>
+    %36 = tt.addptr %35, %34 : tensor<128x64x!tt.ptr<bf16>>, tensor<128x64xi32>
+    %37 = tt.expand_dims %25 {axis = 1 : i32} : (tensor<64xi32>) -> tensor<64x1xi32>
+    %38 = tt.splat %arg8 : (i32) -> tensor<64x1xi32>
+    %39 = arith.muli %37, %38 : tensor<64x1xi32>
+    %40 = tt.expand_dims %24 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
+    %41 = tt.splat %arg9 : (i32) -> tensor<1x256xi32>
+    %42 = arith.muli %40, %41 : tensor<1x256xi32>
+    %43 = tt.broadcast %39 : (tensor<64x1xi32>) -> tensor<64x256xi32>
+    %44 = tt.broadcast %42 : (tensor<1x256xi32>) -> tensor<64x256xi32>
+    %45 = arith.addi %43, %44 : tensor<64x256xi32>
+    %46 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<64x256x!tt.ptr<bf16>>
+    %47 = tt.addptr %46, %45 : tensor<64x256x!tt.ptr<bf16>>, tensor<64x256xi32>
+    %48 = tt.splat %cst : (f32) -> tensor<128x256xf32>
+    %49 = arith.muli %arg7, %c64_i32 : i32
+    %50 = tt.splat %49 : (i32) -> tensor<128x64xi32>
+    %51 = arith.muli %arg8, %c64_i32 : i32
+    %52 = tt.splat %51 : (i32) -> tensor<64x256xi32>
+    %53:3 = scf.for %arg12 = %c0_i32 to %6 step %c1_i32 iter_args(%arg13 = %48, %arg14 = %36, %arg15 = %47) -> (tensor<128x256xf32>, tensor<128x64x!tt.ptr<bf16>>, tensor<64x256x!tt.ptr<bf16>>)  : i32 {
+      %71 = tt.load %arg14 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128x64xbf16>
+      %72 = tt.load %arg15 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<64x256xbf16>
+      %73 = tt.dot %71, %72, %48 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<128x64xbf16> * tensor<64x256xbf16> -> tensor<128x256xf32>
+      %74 = arith.addf %arg13, %73 : tensor<128x256xf32>
+      %75 = tt.addptr %arg14, %50 : tensor<128x64x!tt.ptr<bf16>>, tensor<128x64xi32>
+      %76 = tt.addptr %arg15, %52 : tensor<64x256x!tt.ptr<bf16>>, tensor<64x256xi32>
+      scf.yield %74, %75, %76 : tensor<128x256xf32>, tensor<128x64x!tt.ptr<bf16>>, tensor<64x256x!tt.ptr<bf16>>
+    }
+    %54 = arith.truncf %53#0 : tensor<128x256xf32> to tensor<128x256xbf16>
+    %55 = tt.splat %arg10 : (i32) -> tensor<128x1xi32>
+    %56 = arith.muli %55, %26 : tensor<128x1xi32>
+    %57 = tt.splat %arg2 : (!tt.ptr<bf16>) -> tensor<128x1x!tt.ptr<bf16>>
+    %58 = tt.addptr %57, %56 : tensor<128x1x!tt.ptr<bf16>>, tensor<128x1xi32>
+    %59 = tt.splat %arg11 : (i32) -> tensor<1x256xi32>
+    %60 = arith.muli %59, %40 : tensor<1x256xi32>
+    %61 = tt.broadcast %58 : (tensor<128x1x!tt.ptr<bf16>>) -> tensor<128x256x!tt.ptr<bf16>>
+    %62 = tt.broadcast %60 : (tensor<1x256xi32>) -> tensor<128x256xi32>
+    %63 = tt.addptr %61, %62 : tensor<128x256x!tt.ptr<bf16>>, tensor<128x256xi32>
+    %64 = tt.splat %arg3 : (i32) -> tensor<128x1xi32>
+    %65 = arith.cmpi slt, %26, %64 : tensor<128x1xi32>
+    %66 = tt.splat %arg4 : (i32) -> tensor<1x256xi32>
+    %67 = arith.cmpi slt, %40, %66 : tensor<1x256xi32>
+    %68 = tt.broadcast %65 : (tensor<128x1xi1>) -> tensor<128x256xi1>
+    %69 = tt.broadcast %67 : (tensor<1x256xi1>) -> tensor<128x256xi1>
+    %70 = arith.andi %68, %69 : tensor<128x256xi1>
+    tt.store %63, %54, %70 {cache = 1 : i32, evict = 1 : i32} : tensor<128x256xbf16>
+    tt.return
+  }
+}
+
+// mlir2FileCheck.py
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK-LABEL:  func.func @matmul_kernel_0123456789101112131415
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: memref<*xbf16>, [[PARAM_2_:%.+]]: memref<*xbf16>, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32, [[PARAM_10_:%.+]]: i32, [[PARAM_11_:%.+]]: i32, [[PARAM_12_:%.+]]: i32, [[PARAM_13_:%.+]]: i32, [[PARAM_14_:%.+]]: i32, [[PARAM_15_:%.+]]: i32, [[PARAM_16_:%.+]]: i32, [[PARAM_17_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_8_:%.+]] = arith.constant 8 : i32
+// CHECK-DAG:       [[CST_128_:%.+]] = arith.constant 128 : i32
+// CHECK-DAG:       [[CST_256_:%.+]] = arith.constant 256 : i32
+// CHECK-DAG:       [[CST_64_:%.+]] = arith.constant 64 : i32
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : i32
+// CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : i32
+// CHECK-DAG:       [[CST_127_:%.+]] = arith.constant 127 : i32
+// CHECK-DAG:       [[CST_255_:%.+]] = arith.constant 255 : i32
+// CHECK-DAG:       [[CST_63_:%.+]] = arith.constant 63 : i32
+// CHECK-DAG:       [[CST_0_1_:%.+]] = arith.constant 0 : index
+// CHECK-DAG:       [[CST_128_1_:%.+]] = arith.constant 128 : index
+// CHECK-DAG:       [[CST_256_1_:%.+]] = arith.constant 256 : index
+// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<128x256xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_1_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[VAR_0_]] : tensor<128x256xf32>) -> tensor<128x256xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.addi [[PARAM_3_]], [[CST_127_]] : i32
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.divsi [[VAR_2_]], [[CST_128_]] : i32
+// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[PARAM_4_]], [[CST_255_]] : i32
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.divsi [[VAR_4_]], [[CST_256_]] : i32
+// CHECK-DAG:       [[VAR_6_:%.+]] = arith.addi [[PARAM_5_]], [[CST_63_]] : i32
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_7_:%.+]] = arith.divsi [[VAR_6_]], [[CST_64_]] : i32
+// CHECK-DAG:       [[VAR_8_:%.+]] = arith.muli [[VAR_5_]], [[CST_8_]] : i32
+// CHECK:           [[VAR_9_:%.+]] = arith.divsi [[PARAM_15_]], [[VAR_8_]] : i32
+// CHECK:           [[VAR_10_:%.+]] = arith.muli [[VAR_9_]], [[CST_8_]] : i32
+// CHECK:           [[VAR_11_:%.+]] = arith.subi [[VAR_3_]], [[VAR_10_]] : i32
+// CHECK:           [[VAR_12_:%.+]] = arith.minsi [[VAR_11_]], [[CST_8_]] : i32
+// CHECK:           [[VAR_13_:%.+]] = arith.remsi [[PARAM_15_]], [[VAR_12_]] : i32
+// CHECK-DAG:       [[VAR_14_:%.+]] = arith.addi [[VAR_10_]], [[VAR_13_]] : i32
+// CHECK-DAG:       [[VAR_15_:%.+]] = arith.remsi [[PARAM_15_]], [[VAR_8_]] : i32
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_16_:%.+]] = arith.divsi [[VAR_15_]], [[VAR_12_]] : i32
+// CHECK-DAG:       [[VAR_17_:%.+]] = arith.muli [[VAR_14_]], [[CST_128_]] : i32
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_18_:%.+]] = arith.index_cast [[VAR_17_]] : i32 to index
+// CHECK-DAG:       [[VAR_19_:%.+]] = arith.index_cast [[VAR_17_]] : i32 to index
+// CHECK-DAG:       [[VAR_20_:%.+]] = arith.muli [[VAR_16_]], [[CST_256_]] : i32
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_21_:%.+]] = arith.index_cast [[VAR_20_]] : i32 to index
+// CHECK-DAG:       [[VAR_22_:%.+]] = arith.index_cast [[VAR_20_]] : i32 to index
+// CHECK-DAG:       [[VAR_23_:%.+]] = arith.index_cast [[PARAM_6_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_24_:%.+]] = arith.muli [[VAR_19_]], [[VAR_23_]] : index
+// CHECK-DAG:       [[VAR_25_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
+// CHECK-DAG:       [[VAR_26_:%.+]] = arith.index_cast [[PARAM_8_]] : i32 to index
+// CHECK-DAG:       [[VAR_27_:%.+]] = arith.index_cast [[PARAM_9_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_28_:%.+]] = arith.muli [[VAR_22_]], [[VAR_27_]] : index
+// CHECK-DAG:       [[VAR_29_:%.+]] = arith.muli [[PARAM_7_]], [[CST_64_]] : i32
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_30_:%.+]] = arith.index_cast [[VAR_29_]] : i32 to index
+// CHECK-DAG:       [[VAR_31_:%.+]] = arith.muli [[PARAM_8_]], [[CST_64_]] : i32
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_32_:%.+]] = arith.index_cast [[VAR_31_]] : i32 to index
+// CHECK-DAG:       [[VAR_33_:%.+]]:3 = scf.for [[VAR_arg18_:%.+]] = [[CST_0_]] to [[VAR_7_]] step [[CST_1_]] iter_args([[VAR_arg19_:%.+]] = [[VAR_1_]], [[VAR_arg20_:%.+]] = [[VAR_24_]], [[VAR_arg21_:%.+]] = [[CST_0_1_]]) -> (tensor<128x256xf32>, index, index)  : i32 {
+// CHECK-DAG:         [[VAR_53_:%.+]] = arith.addi [[VAR_arg21_]], [[VAR_28_]] : index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_53_]]{{.}}, sizes: [64, 256], strides: {{.}}[[VAR_26_]], [[VAR_27_]]{{.}} : memref<*xbf16> to memref<64x256xbf16, strided<[?, ?], offset: ?>>
+// CHECK-DAG:         [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_arg20_]]{{.}}, sizes: [128, 64], strides: {{.}}[[VAR_23_]], [[VAR_25_]]{{.}} : memref<*xbf16> to memref<128x64xbf16, strided<[?, ?], offset: ?>>
+// CHECK-DAG:         [[RES_:%.+]] = memref.alloc() : memref<128x64xbf16>
+// CHECK:             memref.copy [[VAR_reinterpret_cast_1_]], [[RES_]] : memref<128x64xbf16, strided<[?, ?], offset: ?>> to memref<128x64xbf16>
+// CHECK-DAG:         [[VAR_54_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<128x64xbf16>
+// CHECK-DAG:         [[RES_1_:%.+]] = memref.alloc() : memref<64x256xbf16>
+// CHECK:             memref.copy [[VAR_reinterpret_cast_0_]], [[RES_1_]] : memref<64x256xbf16, strided<[?, ?], offset: ?>> to memref<64x256xbf16>
+// CHECK-DAG:         [[VAR_55_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<64x256xbf16>
+// CHECK-DAG:         [[VAR_56_:%.+]] = tensor.empty() : tensor<128x256xf32>
+// CHECK:             [[VAR_57_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[VAR_56_]] : tensor<128x256xf32>) -> tensor<128x256xf32>
+// CHECK:             [[VAR_58_:%.+]] = linalg.matmul ins([[VAR_54_]], [[VAR_55_]] : tensor<128x64xbf16>, tensor<64x256xbf16>) outs([[VAR_57_]] : tensor<128x256xf32>) -> tensor<128x256xf32>
+// CHECK:             [[VAR_59_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_arg19_]], [[VAR_58_]] : tensor<128x256xf32>, tensor<128x256xf32>) outs([[VAR_arg19_]] : tensor<128x256xf32>) {
+// CHECK:             ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32, [[IN_2_:%.+]]: f32):
+// CHECK:               [[VAR_62_:%.+]] = arith.addf [[IN_0_]], [[IN_1_]] : f32
+// CHECK:               linalg.yield [[VAR_62_]] : f32
+// CHECK:             } -> tensor<128x256xf32>
+// CHECK-DAG:         [[VAR_60_:%.+]] = arith.addi [[VAR_arg20_]], [[VAR_30_]] : index
+// CHECK-DAG:         [[VAR_61_:%.+]] = arith.addi [[VAR_arg21_]], [[VAR_32_]] : index
+// CHECK:             scf.yield [[VAR_59_]], [[VAR_60_]], [[VAR_61_]] : tensor<128x256xf32>, index, index
+// CHECK:           }
+// CHECK:           [[VAR_34_:%.+]] = tensor.empty() : tensor<128x256xbf16>
+// CHECK:           [[VAR_35_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_33_]]#0 : tensor<128x256xf32>) outs([[VAR_34_]] : tensor<128x256xbf16>) {
+// CHECK:           ^bb0([[IN_3_:%.+]]: f32, [[IN_4_:%.+]]: bf16):
+// CHECK:             [[VAR_53_1_:%.+]] = arith.truncf [[IN_3_]] : f32 to bf16
+// CHECK:             linalg.yield [[VAR_53_1_]] : bf16
+// CHECK:           } -> tensor<128x256xbf16>
+// CHECK:           [[VAR_36_:%.+]] = arith.index_cast [[PARAM_10_]] : i32 to index
+// CHECK-DAG:       [[VAR_37_:%.+]] = arith.muli [[VAR_18_]], [[VAR_36_]] : index
+// CHECK-DAG:       [[VAR_38_:%.+]] = arith.index_cast [[PARAM_11_]] : i32 to index
+// CHECK:           [[VAR_39_:%.+]] = arith.muli [[VAR_21_]], [[VAR_38_]] : index
+// CHECK:           [[VAR_40_:%.+]] = arith.addi [[VAR_37_]], [[VAR_39_]] : index
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_2_]] to offset: {{.}}[[VAR_40_]]{{.}}, sizes: [128, 256], strides: {{.}}[[VAR_36_]], [[VAR_38_]]{{.}} : memref<*xbf16> to memref<128x256xbf16, strided<[?, ?], offset: ?>>
+// CHECK-DAG:       [[VAR_41_:%.+]] = arith.index_cast [[VAR_17_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_42_:%.+]] = arith.addi [[VAR_41_]], [[CST_128_1_]] : index
+// CHECK-DAG:       [[VAR_43_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
+// CHECK:           [[VAR_44_:%.+]] = arith.minsi [[VAR_42_]], [[VAR_43_]] : index
+// CHECK-DAG:       [[VAR_45_:%.+]] = arith.subi [[VAR_44_]], [[VAR_41_]] : index
+// CHECK-DAG:       [[VAR_46_:%.+]] = arith.index_cast [[VAR_20_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_47_:%.+]] = arith.addi [[VAR_46_]], [[CST_256_1_]] : index
+// CHECK-DAG:       [[VAR_48_:%.+]] = arith.index_cast [[PARAM_4_]] : i32 to index
+// CHECK:           [[VAR_49_:%.+]] = arith.minsi [[VAR_47_]], [[VAR_48_]] : index
+// CHECK-DAG:       [[VAR_50_:%.+]] = arith.subi [[VAR_49_]], [[VAR_46_]] : index
+// CHECK-DAG:       [[VAR_51_:%.+]] = arith.minsi [[VAR_45_]], [[CST_128_1_]] : index
+// CHECK:           [[VAR_52_:%.+]] = arith.minsi [[VAR_50_]], [[CST_256_1_]] : index
+// CHECK-DAG:       [[VAR_extracted_slice_:%.+]] = tensor.extract_slice [[VAR_35_]][0, 0] {{.}}[[VAR_51_]], [[VAR_52_]]{{.}} [1, 1] : tensor<128x256xbf16> to tensor<?x?xbf16>
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0, 0] {{.}}[[VAR_51_]], [[VAR_52_]]{{.}} [1, 1] : memref<128x256xbf16, strided<[?, ?], offset: ?>> to memref<?x?xbf16, strided<[?, ?], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_extracted_slice_]] in writable [[VAR_subview_]] : (tensor<?x?xbf16>, memref<?x?xbf16, strided<[?, ?], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/kernel-03-matrix-multiplication.mlir
+++ b/test/Conversion/StructuredToMemref/kernel-03-matrix-multiplication.mlir
@@ -31,40 +31,40 @@ module {
     %16 = arith.divsi %15, %12 : i32
     %17 = arith.muli %14, %c128_i32 : i32
     %18 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
-    %19 = tt.splat %17 : (i32) -> tensor<128xi32>
+    %19 = tt.splat %17 : i32 -> tensor<128xi32>
     %20 = arith.addi %19, %18 : tensor<128xi32>
     %21 = arith.muli %16, %c256_i32 : i32
     %22 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
-    %23 = tt.splat %21 : (i32) -> tensor<256xi32>
+    %23 = tt.splat %21 : i32 -> tensor<256xi32>
     %24 = arith.addi %23, %22 : tensor<256xi32>
     %25 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32>
-    %26 = tt.expand_dims %20 {axis = 1 : i32} : (tensor<128xi32>) -> tensor<128x1xi32>
-    %27 = tt.splat %arg6 : (i32) -> tensor<128x1xi32>
+    %26 = tt.expand_dims %20 {axis = 1 : i32} : tensor<128xi32> -> tensor<128x1xi32>
+    %27 = tt.splat %arg6 : i32 -> tensor<128x1xi32>
     %28 = arith.muli %26, %27 : tensor<128x1xi32>
-    %29 = tt.expand_dims %25 {axis = 0 : i32} : (tensor<64xi32>) -> tensor<1x64xi32>
-    %30 = tt.splat %arg7 : (i32) -> tensor<1x64xi32>
+    %29 = tt.expand_dims %25 {axis = 0 : i32} : tensor<64xi32> -> tensor<1x64xi32>
+    %30 = tt.splat %arg7 : i32 -> tensor<1x64xi32>
     %31 = arith.muli %29, %30 : tensor<1x64xi32>
-    %32 = tt.broadcast %28 : (tensor<128x1xi32>) -> tensor<128x64xi32>
-    %33 = tt.broadcast %31 : (tensor<1x64xi32>) -> tensor<128x64xi32>
+    %32 = tt.broadcast %28 : tensor<128x1xi32> -> tensor<128x64xi32>
+    %33 = tt.broadcast %31 : tensor<1x64xi32> -> tensor<128x64xi32>
     %34 = arith.addi %32, %33 : tensor<128x64xi32>
-    %35 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<128x64x!tt.ptr<bf16>>
+    %35 = tt.splat %arg0 : !tt.ptr<bf16> -> tensor<128x64x!tt.ptr<bf16>>
     %36 = tt.addptr %35, %34 : tensor<128x64x!tt.ptr<bf16>>, tensor<128x64xi32>
-    %37 = tt.expand_dims %25 {axis = 1 : i32} : (tensor<64xi32>) -> tensor<64x1xi32>
-    %38 = tt.splat %arg8 : (i32) -> tensor<64x1xi32>
+    %37 = tt.expand_dims %25 {axis = 1 : i32} : tensor<64xi32> -> tensor<64x1xi32>
+    %38 = tt.splat %arg8 : i32 -> tensor<64x1xi32>
     %39 = arith.muli %37, %38 : tensor<64x1xi32>
-    %40 = tt.expand_dims %24 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
-    %41 = tt.splat %arg9 : (i32) -> tensor<1x256xi32>
+    %40 = tt.expand_dims %24 {axis = 0 : i32} : tensor<256xi32> -> tensor<1x256xi32>
+    %41 = tt.splat %arg9 : i32 -> tensor<1x256xi32>
     %42 = arith.muli %40, %41 : tensor<1x256xi32>
-    %43 = tt.broadcast %39 : (tensor<64x1xi32>) -> tensor<64x256xi32>
-    %44 = tt.broadcast %42 : (tensor<1x256xi32>) -> tensor<64x256xi32>
+    %43 = tt.broadcast %39 : tensor<64x1xi32> -> tensor<64x256xi32>
+    %44 = tt.broadcast %42 : tensor<1x256xi32> -> tensor<64x256xi32>
     %45 = arith.addi %43, %44 : tensor<64x256xi32>
-    %46 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<64x256x!tt.ptr<bf16>>
+    %46 = tt.splat %arg1 : !tt.ptr<bf16> -> tensor<64x256x!tt.ptr<bf16>>
     %47 = tt.addptr %46, %45 : tensor<64x256x!tt.ptr<bf16>>, tensor<64x256xi32>
-    %48 = tt.splat %cst : (f32) -> tensor<128x256xf32>
+    %48 = tt.splat %cst : f32 -> tensor<128x256xf32>
     %49 = arith.muli %arg7, %c64_i32 : i32
-    %50 = tt.splat %49 : (i32) -> tensor<128x64xi32>
+    %50 = tt.splat %49 : i32 -> tensor<128x64xi32>
     %51 = arith.muli %arg8, %c64_i32 : i32
-    %52 = tt.splat %51 : (i32) -> tensor<64x256xi32>
+    %52 = tt.splat %51 : i32 -> tensor<64x256xi32>
     %53:3 = scf.for %arg12 = %c0_i32 to %6 step %c1_i32 iter_args(%arg13 = %48, %arg14 = %36, %arg15 = %47) -> (tensor<128x256xf32>, tensor<128x64x!tt.ptr<bf16>>, tensor<64x256x!tt.ptr<bf16>>)  : i32 {
       %71 = tt.load %arg14 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128x64xbf16>
       %72 = tt.load %arg15 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<64x256xbf16>
@@ -75,21 +75,21 @@ module {
       scf.yield %74, %75, %76 : tensor<128x256xf32>, tensor<128x64x!tt.ptr<bf16>>, tensor<64x256x!tt.ptr<bf16>>
     }
     %54 = arith.truncf %53#0 : tensor<128x256xf32> to tensor<128x256xbf16>
-    %55 = tt.splat %arg10 : (i32) -> tensor<128x1xi32>
+    %55 = tt.splat %arg10 : i32 -> tensor<128x1xi32>
     %56 = arith.muli %55, %26 : tensor<128x1xi32>
-    %57 = tt.splat %arg2 : (!tt.ptr<bf16>) -> tensor<128x1x!tt.ptr<bf16>>
+    %57 = tt.splat %arg2 : !tt.ptr<bf16> -> tensor<128x1x!tt.ptr<bf16>>
     %58 = tt.addptr %57, %56 : tensor<128x1x!tt.ptr<bf16>>, tensor<128x1xi32>
-    %59 = tt.splat %arg11 : (i32) -> tensor<1x256xi32>
+    %59 = tt.splat %arg11 : i32 -> tensor<1x256xi32>
     %60 = arith.muli %59, %40 : tensor<1x256xi32>
-    %61 = tt.broadcast %58 : (tensor<128x1x!tt.ptr<bf16>>) -> tensor<128x256x!tt.ptr<bf16>>
-    %62 = tt.broadcast %60 : (tensor<1x256xi32>) -> tensor<128x256xi32>
+    %61 = tt.broadcast %58 : tensor<128x1x!tt.ptr<bf16>> -> tensor<128x256x!tt.ptr<bf16>>
+    %62 = tt.broadcast %60 : tensor<1x256xi32> -> tensor<128x256xi32>
     %63 = tt.addptr %61, %62 : tensor<128x256x!tt.ptr<bf16>>, tensor<128x256xi32>
-    %64 = tt.splat %arg3 : (i32) -> tensor<128x1xi32>
+    %64 = tt.splat %arg3 : i32 -> tensor<128x1xi32>
     %65 = arith.cmpi slt, %26, %64 : tensor<128x1xi32>
-    %66 = tt.splat %arg4 : (i32) -> tensor<1x256xi32>
+    %66 = tt.splat %arg4 : i32 -> tensor<1x256xi32>
     %67 = arith.cmpi slt, %40, %66 : tensor<1x256xi32>
-    %68 = tt.broadcast %65 : (tensor<128x1xi1>) -> tensor<128x256xi1>
-    %69 = tt.broadcast %67 : (tensor<1x256xi1>) -> tensor<128x256xi1>
+    %68 = tt.broadcast %65 : tensor<128x1xi1> -> tensor<128x256xi1>
+    %69 = tt.broadcast %67 : tensor<1x256xi1> -> tensor<128x256xi1>
     %70 = arith.andi %68, %69 : tensor<128x256xi1>
     tt.store %63, %54, %70 {cache = 1 : i32, evict = 1 : i32} : tensor<128x256xbf16>
     tt.return

--- a/test/Conversion/StructuredToMemref/kernel-05-layer-norm-dwdb.mlir
+++ b/test/Conversion/StructuredToMemref/kernel-05-layer-norm-dwdb.mlir
@@ -8,27 +8,27 @@ module {
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %c256_i32 : i32
     %2 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
-    %3 = tt.splat %1 : (i32) -> tensor<256xi32>
+    %3 = tt.splat %1 : i32 -> tensor<256xi32>
     %4 = arith.addi %3, %2 : tensor<256xi32>
-    %5 = tt.splat %cst : (f32) -> tensor<256x256xf32>
-    %6 = tt.splat %arg4 : (i32) -> tensor<256x1xi32>
-    %7 = tt.expand_dims %4 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
-    %8 = tt.splat %arg5 : (i32) -> tensor<1x256xi32>
+    %5 = tt.splat %cst : f32 -> tensor<256x256xf32>
+    %6 = tt.splat %arg4 : i32 -> tensor<256x1xi32>
+    %7 = tt.expand_dims %4 {axis = 0 : i32} : tensor<256xi32> -> tensor<1x256xi32>
+    %8 = tt.splat %arg5 : i32 -> tensor<1x256xi32>
     %9 = arith.cmpi slt, %7, %8 : tensor<1x256xi32>
-    %10 = tt.broadcast %9 : (tensor<1x256xi1>) -> tensor<256x256xi1>
-    %11 = tt.splat %arg5 : (i32) -> tensor<256x1xi32>
-    %12 = tt.broadcast %7 : (tensor<1x256xi32>) -> tensor<256x256xi32>
-    %13 = tt.splat %arg0 : (!tt.ptr<f32>) -> tensor<256x256x!tt.ptr<f32>>
-    %14 = tt.splat %arg1 : (!tt.ptr<f32>) -> tensor<256x256x!tt.ptr<f32>>
+    %10 = tt.broadcast %9 : tensor<1x256xi1> -> tensor<256x256xi1>
+    %11 = tt.splat %arg5 : i32 -> tensor<256x1xi32>
+    %12 = tt.broadcast %7 : tensor<1x256xi32> -> tensor<256x256xi32>
+    %13 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<256x256x!tt.ptr<f32>>
+    %14 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<256x256x!tt.ptr<f32>>
     %15:2 = scf.for %arg6 = %c0_i32 to %arg4 step %c256_i32 iter_args(%arg7 = %5, %arg8 = %5) -> (tensor<256x256xf32>, tensor<256x256xf32>)  : i32 {
-      %24 = tt.splat %arg6 : (i32) -> tensor<256xi32>
+      %24 = tt.splat %arg6 : i32 -> tensor<256xi32>
       %25 = arith.addi %24, %2 : tensor<256xi32>
-      %26 = tt.expand_dims %25 {axis = 1 : i32} : (tensor<256xi32>) -> tensor<256x1xi32>
+      %26 = tt.expand_dims %25 {axis = 1 : i32} : tensor<256xi32> -> tensor<256x1xi32>
       %27 = arith.cmpi slt, %26, %6 : tensor<256x1xi32>
-      %28 = tt.broadcast %27 : (tensor<256x1xi1>) -> tensor<256x256xi1>
+      %28 = tt.broadcast %27 : tensor<256x1xi1> -> tensor<256x256xi1>
       %29 = arith.andi %28, %10 : tensor<256x256xi1>
       %30 = arith.muli %26, %11 : tensor<256x1xi32>
-      %31 = tt.broadcast %30 : (tensor<256x1xi32>) -> tensor<256x256xi32>
+      %31 = tt.broadcast %30 : tensor<256x1xi32> -> tensor<256x256xi32>
       %32 = arith.addi %31, %12 : tensor<256x256xi32>
       %33 = tt.addptr %13, %32 : tensor<256x256x!tt.ptr<f32>>, tensor<256x256xi32>
       %34 = tt.load %33, %29, %5 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<256x256xf32>
@@ -48,12 +48,12 @@ module {
       %24 = arith.addf %arg6, %arg7 : f32
       tt.reduce.return %24 : f32
     }) {axis = 0 : i32} : (tensor<256x256xf32>) -> tensor<256xf32>
-    %18 = tt.splat %arg5 : (i32) -> tensor<256xi32>
+    %18 = tt.splat %arg5 : i32 -> tensor<256xi32>
     %19 = arith.cmpi slt, %4, %18 : tensor<256xi32>
-    %20 = tt.splat %arg2 : (!tt.ptr<f32>) -> tensor<256x!tt.ptr<f32>>
+    %20 = tt.splat %arg2 : !tt.ptr<f32> -> tensor<256x!tt.ptr<f32>>
     %21 = tt.addptr %20, %4 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
     tt.store %21, %16, %19 {cache = 1 : i32, evict = 1 : i32} : tensor<256xf32>
-    %22 = tt.splat %arg3 : (!tt.ptr<f32>) -> tensor<256x!tt.ptr<f32>>
+    %22 = tt.splat %arg3 : !tt.ptr<f32> -> tensor<256x!tt.ptr<f32>>
     %23 = tt.addptr %22, %4 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
     tt.store %23, %17, %19 {cache = 1 : i32, evict = 1 : i32} : tensor<256xf32>
     tt.return

--- a/test/Conversion/StructuredToMemref/kernel-05-layer-norm-dwdb.mlir
+++ b/test/Conversion/StructuredToMemref/kernel-05-layer-norm-dwdb.mlir
@@ -1,0 +1,190 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+
+module {
+  tt.func public @_layer_norm_bwd_dwdb_0123456(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: !tt.ptr<f32>, %arg3: !tt.ptr<f32>, %arg4: i32, %arg5: i32) {
+    %c0_i32 = arith.constant 0 : i32
+    %c256_i32 = arith.constant 256 : i32
+    %cst = arith.constant 0.000000e+00 : f32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c256_i32 : i32
+    %2 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
+    %3 = tt.splat %1 : (i32) -> tensor<256xi32>
+    %4 = arith.addi %3, %2 : tensor<256xi32>
+    %5 = tt.splat %cst : (f32) -> tensor<256x256xf32>
+    %6 = tt.splat %arg4 : (i32) -> tensor<256x1xi32>
+    %7 = tt.expand_dims %4 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
+    %8 = tt.splat %arg5 : (i32) -> tensor<1x256xi32>
+    %9 = arith.cmpi slt, %7, %8 : tensor<1x256xi32>
+    %10 = tt.broadcast %9 : (tensor<1x256xi1>) -> tensor<256x256xi1>
+    %11 = tt.splat %arg5 : (i32) -> tensor<256x1xi32>
+    %12 = tt.broadcast %7 : (tensor<1x256xi32>) -> tensor<256x256xi32>
+    %13 = tt.splat %arg0 : (!tt.ptr<f32>) -> tensor<256x256x!tt.ptr<f32>>
+    %14 = tt.splat %arg1 : (!tt.ptr<f32>) -> tensor<256x256x!tt.ptr<f32>>
+    %15:2 = scf.for %arg6 = %c0_i32 to %arg4 step %c256_i32 iter_args(%arg7 = %5, %arg8 = %5) -> (tensor<256x256xf32>, tensor<256x256xf32>)  : i32 {
+      %24 = tt.splat %arg6 : (i32) -> tensor<256xi32>
+      %25 = arith.addi %24, %2 : tensor<256xi32>
+      %26 = tt.expand_dims %25 {axis = 1 : i32} : (tensor<256xi32>) -> tensor<256x1xi32>
+      %27 = arith.cmpi slt, %26, %6 : tensor<256x1xi32>
+      %28 = tt.broadcast %27 : (tensor<256x1xi1>) -> tensor<256x256xi1>
+      %29 = arith.andi %28, %10 : tensor<256x256xi1>
+      %30 = arith.muli %26, %11 : tensor<256x1xi32>
+      %31 = tt.broadcast %30 : (tensor<256x1xi32>) -> tensor<256x256xi32>
+      %32 = arith.addi %31, %12 : tensor<256x256xi32>
+      %33 = tt.addptr %13, %32 : tensor<256x256x!tt.ptr<f32>>, tensor<256x256xi32>
+      %34 = tt.load %33, %29, %5 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<256x256xf32>
+      %35 = arith.addf %arg7, %34 : tensor<256x256xf32>
+      %36 = tt.addptr %14, %32 : tensor<256x256x!tt.ptr<f32>>, tensor<256x256xi32>
+      %37 = tt.load %36, %29, %5 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<256x256xf32>
+      %38 = arith.addf %arg8, %37 : tensor<256x256xf32>
+      scf.yield %35, %38 : tensor<256x256xf32>, tensor<256x256xf32>
+    }
+    %16 = "tt.reduce"(%15#0) ({
+    ^bb0(%arg6: f32, %arg7: f32):
+      %24 = arith.addf %arg6, %arg7 : f32
+      tt.reduce.return %24 : f32
+    }) {axis = 0 : i32} : (tensor<256x256xf32>) -> tensor<256xf32>
+    %17 = "tt.reduce"(%15#1) ({
+    ^bb0(%arg6: f32, %arg7: f32):
+      %24 = arith.addf %arg6, %arg7 : f32
+      tt.reduce.return %24 : f32
+    }) {axis = 0 : i32} : (tensor<256x256xf32>) -> tensor<256xf32>
+    %18 = tt.splat %arg5 : (i32) -> tensor<256xi32>
+    %19 = arith.cmpi slt, %4, %18 : tensor<256xi32>
+    %20 = tt.splat %arg2 : (!tt.ptr<f32>) -> tensor<256x!tt.ptr<f32>>
+    %21 = tt.addptr %20, %4 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
+    tt.store %21, %16, %19 {cache = 1 : i32, evict = 1 : i32} : tensor<256xf32>
+    %22 = tt.splat %arg3 : (!tt.ptr<f32>) -> tensor<256x!tt.ptr<f32>>
+    %23 = tt.addptr %22, %4 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
+    tt.store %23, %17, %19 {cache = 1 : i32, evict = 1 : i32} : tensor<256xf32>
+    tt.return
+  }
+}
+
+// mlir2FileCheck.py
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK-LABEL:  func.func @_layer_norm_bwd_dwdb_0123456
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: memref<*xf32>, [[PARAM_3_:%.+]]: memref<*xf32>, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32, [[PARAM_10_:%.+]]: i32, [[PARAM_11_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_256_:%.+]] = arith.constant 256 : i32
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : i32
+// CHECK-DAG:       [[CST_256_1_:%.+]] = arith.constant 256 : index
+// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<256x256xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_1_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[VAR_0_]] : tensor<256x256xf32>) -> tensor<256x256xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.muli [[PARAM_9_]], [[CST_256_]] : i32
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
+// CHECK-DAG:       [[VAR_4_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
+// CHECK-DAG:       [[VAR_6_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
+// CHECK-DAG:       [[VAR_7_:%.+]]:2 = scf.for [[VAR_arg12_:%.+]] = [[CST_0_]] to [[PARAM_4_]] step [[CST_256_]] iter_args([[VAR_arg13_:%.+]] = [[VAR_1_]], [[VAR_arg14_:%.+]] = [[VAR_1_]]) -> (tensor<256x256xf32>, tensor<256x256xf32>)  : i32 {
+// CHECK-DAG:         [[VAR_22_:%.+]] = arith.index_cast [[VAR_arg12_]] : i32 to index
+// CHECK-DAG:         [[VAR_23_:%.+]] = arith.index_cast [[PARAM_5_]] : i32 to index
+// CHECK:             [[VAR_24_:%.+]] = arith.muli [[VAR_22_]], [[VAR_23_]] : index
+// CHECK:             [[VAR_25_:%.+]] = arith.addi [[VAR_24_]], [[VAR_6_]] : index
+// CHECK-DAG:         [[VAR_reinterpret_cast_4_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_25_]]{{.}}, sizes: [256, 256], strides: {{.}}[[VAR_23_]], 1] : memref<*xf32> to memref<256x256xf32, strided<[?, 1], offset: ?>>
+// CHECK-DAG:         [[VAR_26_:%.+]] = arith.index_cast [[VAR_arg12_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_27_:%.+]] = arith.addi [[VAR_26_]], [[CST_256_1_]] : index
+// CHECK-DAG:         [[VAR_28_:%.+]] = arith.index_cast [[PARAM_4_]] : i32 to index
+// CHECK:             [[VAR_29_:%.+]] = arith.minsi [[VAR_27_]], [[VAR_28_]] : index
+// CHECK-DAG:         [[VAR_30_:%.+]] = arith.subi [[VAR_29_]], [[VAR_26_]] : index
+// CHECK-DAG:         [[VAR_31_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_32_:%.+]] = arith.addi [[VAR_31_]], [[CST_256_1_]] : index
+// CHECK-DAG:         [[VAR_33_:%.+]] = arith.index_cast [[PARAM_5_]] : i32 to index
+// CHECK:             [[VAR_34_:%.+]] = arith.minsi [[VAR_32_]], [[VAR_33_]] : index
+// CHECK-DAG:         [[VAR_35_:%.+]] = arith.subi [[VAR_34_]], [[VAR_31_]] : index
+// CHECK-DAG:         [[VAR_36_:%.+]] = arith.minsi [[VAR_30_]], [[CST_256_1_]] : index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_37_:%.+]] = arith.minsi [[VAR_35_]], [[CST_256_1_]] : index
+// CHECK-DAG:         [[RES_:%.+]] = memref.alloc() : memref<256x256xf32>
+// CHECK-DAG:         [[VAR_38_:%.+]] = arith.cmpi slt, [[VAR_36_]], [[CST_256_1_]] : index
+// CHECK:             [[VAR_39_:%.+]] = arith.cmpi slt, [[VAR_37_]], [[CST_256_1_]] : index
+// CHECK:             [[VAR_40_:%.+]] = arith.ori [[VAR_38_]], [[VAR_39_]] : i1
+// CHECK:             scf.if [[VAR_40_]] {
+// CHECK:               linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[RES_]] : memref<256x256xf32>)
+// CHECK:             }
+// CHECK-DAG:         [[VAR_subview_5_:%.+]] = memref.subview [[VAR_reinterpret_cast_4_]][0, 0] {{.}}[[VAR_36_]], [[VAR_37_]]{{.}} [1, 1] : memref<256x256xf32, strided<[?, 1], offset: ?>> to memref<?x?xf32, strided<[?, 1], offset: ?>>
+// CHECK-DAG:         [[VAR_subview_6_:%.+]] = memref.subview [[RES_]][0, 0] {{.}}[[VAR_36_]], [[VAR_37_]]{{.}} [1, 1] : memref<256x256xf32> to memref<?x?xf32, strided<[256, 1]>>
+// CHECK:             memref.copy [[VAR_subview_5_]], [[VAR_subview_6_]] : memref<?x?xf32, strided<[?, 1], offset: ?>> to memref<?x?xf32, strided<[256, 1]>>
+// CHECK:             [[VAR_41_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<256x256xf32>
+// CHECK:             [[VAR_42_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_arg13_]], [[VAR_41_]] : tensor<256x256xf32>, tensor<256x256xf32>) outs([[VAR_arg13_]] : tensor<256x256xf32>) {
+// CHECK:             ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32, [[IN_2_:%.+]]: f32):
+// CHECK:               [[VAR_64_:%.+]] = arith.addf [[IN_0_]], [[IN_1_]] : f32
+// CHECK:               linalg.yield [[VAR_64_]] : f32
+// CHECK:             } -> tensor<256x256xf32>
+// CHECK-DAG:         [[VAR_43_:%.+]] = arith.index_cast [[VAR_arg12_]] : i32 to index
+// CHECK-DAG:         [[VAR_44_:%.+]] = arith.index_cast [[PARAM_5_]] : i32 to index
+// CHECK:             [[VAR_45_:%.+]] = arith.muli [[VAR_43_]], [[VAR_44_]] : index
+// CHECK:             [[VAR_46_:%.+]] = arith.addi [[VAR_45_]], [[VAR_5_]] : index
+// CHECK-DAG:         [[VAR_reinterpret_cast_7_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_46_]]{{.}}, sizes: [256, 256], strides: {{.}}[[VAR_44_]], 1] : memref<*xf32> to memref<256x256xf32, strided<[?, 1], offset: ?>>
+// CHECK-DAG:         [[VAR_47_:%.+]] = arith.index_cast [[VAR_arg12_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_48_:%.+]] = arith.addi [[VAR_47_]], [[CST_256_1_]] : index
+// CHECK-DAG:         [[VAR_49_:%.+]] = arith.index_cast [[PARAM_4_]] : i32 to index
+// CHECK:             [[VAR_50_:%.+]] = arith.minsi [[VAR_48_]], [[VAR_49_]] : index
+// CHECK-DAG:         [[VAR_51_:%.+]] = arith.subi [[VAR_50_]], [[VAR_47_]] : index
+// CHECK-DAG:         [[VAR_52_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_53_:%.+]] = arith.addi [[VAR_52_]], [[CST_256_1_]] : index
+// CHECK-DAG:         [[VAR_54_:%.+]] = arith.index_cast [[PARAM_5_]] : i32 to index
+// CHECK:             [[VAR_55_:%.+]] = arith.minsi [[VAR_53_]], [[VAR_54_]] : index
+// CHECK-DAG:         [[VAR_56_:%.+]] = arith.subi [[VAR_55_]], [[VAR_52_]] : index
+// CHECK-DAG:         [[VAR_57_:%.+]] = arith.minsi [[VAR_51_]], [[CST_256_1_]] : index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_58_:%.+]] = arith.minsi [[VAR_56_]], [[CST_256_1_]] : index
+// CHECK-DAG:         [[RES_1_:%.+]] = memref.alloc() : memref<256x256xf32>
+// CHECK-DAG:         [[VAR_59_:%.+]] = arith.cmpi slt, [[VAR_57_]], [[CST_256_1_]] : index
+// CHECK:             [[VAR_60_:%.+]] = arith.cmpi slt, [[VAR_58_]], [[CST_256_1_]] : index
+// CHECK:             [[VAR_61_:%.+]] = arith.ori [[VAR_59_]], [[VAR_60_]] : i1
+// CHECK:             scf.if [[VAR_61_]] {
+// CHECK:               linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[RES_1_]] : memref<256x256xf32>)
+// CHECK:             }
+// CHECK-DAG:         [[VAR_subview_9_:%.+]] = memref.subview [[VAR_reinterpret_cast_7_]][0, 0] {{.}}[[VAR_57_]], [[VAR_58_]]{{.}} [1, 1] : memref<256x256xf32, strided<[?, 1], offset: ?>> to memref<?x?xf32, strided<[?, 1], offset: ?>>
+// CHECK-DAG:         [[VAR_subview_10_:%.+]] = memref.subview [[RES_1_]][0, 0] {{.}}[[VAR_57_]], [[VAR_58_]]{{.}} [1, 1] : memref<256x256xf32> to memref<?x?xf32, strided<[256, 1]>>
+// CHECK:             memref.copy [[VAR_subview_9_]], [[VAR_subview_10_]] : memref<?x?xf32, strided<[?, 1], offset: ?>> to memref<?x?xf32, strided<[256, 1]>>
+// CHECK:             [[VAR_62_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<256x256xf32>
+// CHECK:             [[VAR_63_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_arg14_]], [[VAR_62_]] : tensor<256x256xf32>, tensor<256x256xf32>) outs([[VAR_arg14_]] : tensor<256x256xf32>) {
+// CHECK:             ^bb0([[IN_3_:%.+]]: f32, [[IN_4_:%.+]]: f32, [[IN_5_:%.+]]: f32):
+// CHECK:               [[VAR_64_1_:%.+]] = arith.addf [[IN_3_]], [[IN_4_]] : f32
+// CHECK:               linalg.yield [[VAR_64_1_]] : f32
+// CHECK:             } -> tensor<256x256xf32>
+// CHECK:             scf.yield [[VAR_42_]], [[VAR_63_]] : tensor<256x256xf32>, tensor<256x256xf32>
+// CHECK:           }
+// CHECK:           [[VAR_8_:%.+]] = tensor.empty() : tensor<256xf32>
+// CHECK:           [[VAR_9_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[VAR_8_]] : tensor<256xf32>) -> tensor<256xf32>
+// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_7_]]#0 : tensor<256x256xf32>) outs([[VAR_9_]] : tensor<256xf32>) dimensions = [0]
+// CHECK:             ([[IN_3_:%.+]]: f32, [[init_:%.+]]: f32) {
+// CHECK:               [[VAR_22_1_:%.+]] = arith.addf [[IN_3_]], [[init_]] : f32
+// CHECK:               linalg.yield [[VAR_22_1_]] : f32
+// CHECK:             }
+// CHECK:           [[VAR_10_:%.+]] = tensor.empty() : tensor<256xf32>
+// CHECK:           [[VAR_11_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[VAR_10_]] : tensor<256xf32>) -> tensor<256xf32>
+// CHECK:           [[VAR_reduced_0_:%.+]] = linalg.reduce ins([[VAR_7_]]#1 : tensor<256x256xf32>) outs([[VAR_11_]] : tensor<256xf32>) dimensions = [0]
+// CHECK:             ([[IN_3_:%.+]]: f32, [[init_:%.+]]: f32) {
+// CHECK:               [[VAR_22_2_:%.+]] = arith.addf [[IN_3_]], [[init_]] : f32
+// CHECK:               linalg.yield [[VAR_22_2_]] : f32
+// CHECK:             }
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_2_]] to offset: {{.}}[[VAR_4_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_12_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_13_:%.+]] = arith.addi [[VAR_12_]], [[CST_256_1_]] : index
+// CHECK-DAG:       [[VAR_14_:%.+]] = arith.index_cast [[PARAM_5_]] : i32 to index
+// CHECK:           [[VAR_15_:%.+]] = arith.minsi [[VAR_13_]], [[VAR_14_]] : index
+// CHECK:           [[VAR_16_:%.+]] = arith.subi [[VAR_15_]], [[VAR_12_]] : index
+// CHECK-DAG:       [[VAR_extracted_slice_:%.+]] = tensor.extract_slice [[VAR_reduced_]][0] {{.}}[[VAR_16_]]{{.}} [1] : tensor<256xf32> to tensor<?xf32>
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_16_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_extracted_slice_]] in writable [[VAR_subview_]] : (tensor<?xf32>, memref<?xf32, strided<[1], offset: ?>>) -> ()
+// CHECK-DAG:       [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_3_]] to offset: {{.}}[[VAR_3_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_17_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_18_:%.+]] = arith.addi [[VAR_17_]], [[CST_256_1_]] : index
+// CHECK-DAG:       [[VAR_19_:%.+]] = arith.index_cast [[PARAM_5_]] : i32 to index
+// CHECK:           [[VAR_20_:%.+]] = arith.minsi [[VAR_18_]], [[VAR_19_]] : index
+// CHECK:           [[VAR_21_:%.+]] = arith.subi [[VAR_20_]], [[VAR_17_]] : index
+// CHECK-DAG:       [[VAR_extracted_slice_2_:%.+]] = tensor.extract_slice [[VAR_reduced_0_]][0] {{.}}[[VAR_21_]]{{.}} [1] : tensor<256xf32> to tensor<?xf32>
+// CHECK-DAG:       [[VAR_subview_3_:%.+]] = memref.subview [[VAR_reinterpret_cast_1_]][0] {{.}}[[VAR_21_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_extracted_slice_2_]] in writable [[VAR_subview_3_]] : (tensor<?xf32>, memref<?xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/kernel-05-layer-norm-fwd.mlir
+++ b/test/Conversion/StructuredToMemref/kernel-05-layer-norm-fwd.mlir
@@ -1,0 +1,319 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+
+module {
+  tt.func public @_layer_norm_fwd_fused_0123456789(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: !tt.ptr<f32>, %arg3: !tt.ptr<f32>, %arg4: !tt.ptr<f32>, %arg5: !tt.ptr<f32>, %arg6: i32, %arg7: i32, %arg8: f32) {
+    %c256_i32 = arith.constant 256 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %cst = arith.constant 1.000000e+00 : f32
+    %cst_0 = arith.constant 0.000000e+00 : f32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %arg6 : i32
+    %2 = tt.addptr %arg1, %1 : !tt.ptr<f32>, i32
+    %3 = tt.addptr %arg0, %1 : !tt.ptr<f32>, i32
+    %4 = tt.splat %cst_0 : (f32) -> tensor<256xf32>
+    %5 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
+    %6 = tt.splat %arg7 : (i32) -> tensor<256xi32>
+    %7 = tt.splat %3 : (!tt.ptr<f32>) -> tensor<256x!tt.ptr<f32>>
+    %8 = scf.for %arg9 = %c0_i32 to %arg7 step %c256_i32 iter_args(%arg10 = %4) -> (tensor<256xf32>)  : i32 {
+      %32 = tt.splat %arg9 : (i32) -> tensor<256xi32>
+      %33 = arith.addi %32, %5 : tensor<256xi32>
+      %34 = arith.cmpi slt, %33, %6 : tensor<256xi32>
+      %35 = tt.addptr %7, %33 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
+      %36 = tt.load %35, %34, %4 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<256xf32>
+      %37 = arith.addf %arg10, %36 : tensor<256xf32>
+      scf.yield %37 : tensor<256xf32>
+    }
+    %9 = "tt.reduce"(%8) ({
+    ^bb0(%arg9: f32, %arg10: f32):
+      %32 = arith.addf %arg9, %arg10 : f32
+      tt.reduce.return %32 : f32
+    }) {axis = 0 : i32} : (tensor<256xf32>) -> f32
+    %10 = arith.sitofp %arg7 : i32 to f32
+    %11 = arith.divf %9, %10 : f32
+    %12 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
+    %13 = tt.splat %arg7 : (i32) -> tensor<256xi32>
+    %14 = tt.splat %3 : (!tt.ptr<f32>) -> tensor<256x!tt.ptr<f32>>
+    %15 = tt.splat %11 : (f32) -> tensor<256xf32>
+    %16 = scf.for %arg9 = %c0_i32 to %arg7 step %c256_i32 iter_args(%arg10 = %4) -> (tensor<256xf32>)  : i32 {
+      %32 = tt.splat %arg9 : (i32) -> tensor<256xi32>
+      %33 = arith.addi %32, %12 : tensor<256xi32>
+      %34 = arith.cmpi slt, %33, %13 : tensor<256xi32>
+      %35 = tt.addptr %14, %33 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
+      %36 = tt.load %35, %34, %4 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<256xf32>
+      %37 = arith.subf %36, %15 : tensor<256xf32>
+      %38 = arith.select %34, %37, %4 : tensor<256xi1>, tensor<256xf32>
+      %39 = arith.mulf %38, %38 : tensor<256xf32>
+      %40 = arith.addf %arg10, %39 : tensor<256xf32>
+      scf.yield %40 : tensor<256xf32>
+    }
+    %17 = "tt.reduce"(%16) ({
+    ^bb0(%arg9: f32, %arg10: f32):
+      %32 = arith.addf %arg9, %arg10 : f32
+      tt.reduce.return %32 : f32
+    }) {axis = 0 : i32} : (tensor<256xf32>) -> f32
+    %18 = arith.divf %17, %10 : f32
+    %19 = arith.addf %18, %arg8 : f32
+    %20 = math.sqrt %19 : f32
+    %21 = arith.divf %cst, %20 : f32
+    %22 = tt.addptr %arg4, %0 : !tt.ptr<f32>, i32
+    tt.store %22, %11 {cache = 1 : i32, evict = 1 : i32} : f32
+    %23 = tt.addptr %arg5, %0 : !tt.ptr<f32>, i32
+    tt.store %23, %21 {cache = 1 : i32, evict = 1 : i32} : f32
+    %24 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
+    %25 = tt.splat %arg7 : (i32) -> tensor<256xi32>
+    %26 = tt.splat %arg2 : (!tt.ptr<f32>) -> tensor<256x!tt.ptr<f32>>
+    %27 = tt.splat %arg3 : (!tt.ptr<f32>) -> tensor<256x!tt.ptr<f32>>
+    %28 = tt.splat %3 : (!tt.ptr<f32>) -> tensor<256x!tt.ptr<f32>>
+    %29 = tt.splat %11 : (f32) -> tensor<256xf32>
+    %30 = tt.splat %21 : (f32) -> tensor<256xf32>
+    %31 = tt.splat %2 : (!tt.ptr<f32>) -> tensor<256x!tt.ptr<f32>>
+    scf.for %arg9 = %c0_i32 to %arg7 step %c256_i32  : i32 {
+      %32 = tt.splat %arg9 : (i32) -> tensor<256xi32>
+      %33 = arith.addi %32, %24 : tensor<256xi32>
+      %34 = arith.cmpi slt, %33, %25 : tensor<256xi32>
+      %35 = tt.addptr %26, %33 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
+      %36 = tt.load %35, %34 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<256xf32>
+      %37 = tt.addptr %27, %33 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
+      %38 = tt.load %37, %34 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<256xf32>
+      %39 = tt.addptr %28, %33 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
+      %40 = tt.load %39, %34, %4 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<256xf32>
+      %41 = arith.subf %40, %29 : tensor<256xf32>
+      %42 = arith.mulf %41, %30 : tensor<256xf32>
+      %43 = arith.mulf %42, %36 : tensor<256xf32>
+      %44 = arith.addf %43, %38 : tensor<256xf32>
+      %45 = tt.addptr %31, %33 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
+      tt.store %45, %44, %34 {cache = 1 : i32, evict = 1 : i32} : tensor<256xf32>
+    }
+    tt.return
+  }
+}
+
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func @_layer_norm_fwd_fused_0123456789
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: memref<*xf32>, [[PARAM_3_:%.+]]: memref<*xf32>, [[PARAM_4_:%.+]]: memref<*xf32>, [[PARAM_5_:%.+]]: memref<*xf32>, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: f32, [[PARAM_9_:%.+]]: i32, [[PARAM_10_:%.+]]: i32, [[PARAM_11_:%.+]]: i32, [[PARAM_12_:%.+]]: i32, [[PARAM_13_:%.+]]: i32, [[PARAM_14_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_1_dot_000000_:%.+]] = arith.constant 1.000000e+00 : f32
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : i32
+// CHECK-DAG:       [[CST_256_:%.+]] = arith.constant 256 : i32
+// CHECK-DAG:       [[CST_256_1_:%.+]] = arith.constant 256 : index
+// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_5_]] to offset: [0], sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_4_]] to offset: [0], sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<256xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_1_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[VAR_0_]] : tensor<256xf32>) -> tensor<256xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.muli [[PARAM_12_]], [[PARAM_6_]] : i32
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
+// CHECK-DAG:       [[VAR_4_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
+// CHECK-DAG:       [[VAR_5_:%.+]] = scf.for [[VAR_arg15_:%.+]] = [[CST_0_]] to [[PARAM_7_]] step [[CST_256_]] iter_args([[VAR_arg16_:%.+]] = [[VAR_1_]]) -> (tensor<256xf32>)  : i32 {
+// CHECK-DAG:         [[VAR_29_:%.+]] = arith.index_cast [[VAR_arg15_]] : i32 to index
+// CHECK:             [[VAR_30_:%.+]] = arith.addi [[VAR_3_]], [[VAR_29_]] : index
+// CHECK-DAG:         [[VAR_reinterpret_cast_11_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_30_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_31_:%.+]] = arith.index_cast [[VAR_arg15_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_32_:%.+]] = arith.addi [[VAR_31_]], [[CST_256_1_]] : index
+// CHECK-DAG:         [[VAR_33_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
+// CHECK:             [[VAR_34_:%.+]] = arith.minsi [[VAR_32_]], [[VAR_33_]] : index
+// CHECK-DAG:         [[VAR_35_:%.+]] = arith.subi [[VAR_34_]], [[VAR_31_]] : index
+// CHECK-DAG:         [[RES_:%.+]] = memref.alloc() : memref<256xf32>
+// CHECK:             [[VAR_36_:%.+]] = arith.cmpi slt, [[VAR_35_]], [[CST_256_1_]] : index
+// CHECK:             scf.if [[VAR_36_]] {
+// CHECK:               linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[RES_]] : memref<256xf32>)
+// CHECK:             }
+// CHECK-DAG:         [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_11_]][0] {{.}}[[VAR_35_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_subview_12_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_35_]]{{.}} [1] : memref<256xf32> to memref<?xf32, strided<[1]>>
+// CHECK:             memref.copy [[VAR_subview_]], [[VAR_subview_12_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK:             [[VAR_37_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<256xf32>
+// CHECK:             [[VAR_38_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_arg16_]], [[VAR_37_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_arg16_]] : tensor<256xf32>) {
+// CHECK:             ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32, [[IN_2_:%.+]]: f32):
+// CHECK:               [[VAR_39_:%.+]] = arith.addf [[IN_0_]], [[IN_1_]] : f32
+// CHECK:               linalg.yield [[VAR_39_]] : f32
+// CHECK:             } -> tensor<256xf32>
+// CHECK:             scf.yield [[VAR_38_]] : tensor<256xf32>
+// CHECK:           }
+// CHECK:           [[VAR_6_:%.+]] = bufferization.alloc_tensor() : tensor<f32>
+// CHECK:           [[VAR_inserted_:%.+]] = tensor.insert [[CST_0_dot_000000_]] into [[VAR_6_]][] : tensor<f32>
+// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_5_]] : tensor<256xf32>) outs([[VAR_inserted_]] : tensor<f32>) dimensions = [0]
+// CHECK:             ([[IN_0_:%.+]]: f32, [[init_:%.+]]: f32) {
+// CHECK:               [[VAR_29_1_:%.+]] = arith.addf [[IN_0_]], [[init_]] : f32
+// CHECK:               linalg.yield [[VAR_29_1_]] : f32
+// CHECK:             }
+// CHECK-DAG:       [[VAR_extracted_:%.+]] = tensor.extract [[VAR_reduced_]][] : tensor<f32>
+// CHECK-DAG:       [[VAR_7_:%.+]] = arith.sitofp [[PARAM_7_]] : i32 to f32
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_8_:%.+]] = arith.divf [[VAR_extracted_]], [[VAR_7_]] : f32
+// CHECK-DAG:       [[VAR_9_:%.+]] = tensor.empty() : tensor<256xi32>
+// CHECK:           [[VAR_10_:%.+]] = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel"]} outs([[VAR_9_]] : tensor<256xi32>) {
+// CHECK:           ^bb0([[IN_3_:%.+]]: i32):
+// CHECK:             [[VAR_29_2_:%.+]] = linalg.index 0 : index
+// CHECK:             [[VAR_30_1_:%.+]] = arith.index_cast [[VAR_29_2_]] : index to i32
+// CHECK:             linalg.yield [[VAR_30_1_]] : i32
+// CHECK:           } -> tensor<256xi32>
+// CHECK:           [[VAR_11_:%.+]] = tensor.empty() : tensor<256xi32>
+// CHECK-DAG:       [[VAR_12_:%.+]] = linalg.fill ins([[PARAM_7_]] : i32) outs([[VAR_11_]] : tensor<256xi32>) -> tensor<256xi32>
+// CHECK-DAG:       [[VAR_13_:%.+]] = tensor.empty() : tensor<256xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_14_:%.+]] = linalg.fill ins([[VAR_8_]] : f32) outs([[VAR_13_]] : tensor<256xf32>) -> tensor<256xf32>
+// CHECK-DAG:       [[VAR_15_:%.+]] = scf.for [[VAR_arg15_1_:%.+]] = [[CST_0_]] to [[PARAM_7_]] step [[CST_256_]] iter_args([[VAR_arg16_1_:%.+]] = [[VAR_1_]]) -> (tensor<256xf32>)  : i32 {
+// CHECK-DAG:         [[VAR_29_3_:%.+]] = tensor.empty() : tensor<256xi32>
+// CHECK:             [[VAR_30_2_:%.+]] = linalg.fill ins([[VAR_arg15_1_]] : i32) outs([[VAR_29_3_]] : tensor<256xi32>) -> tensor<256xi32>
+// CHECK:             [[VAR_31_1_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_30_2_]], [[VAR_10_]] : tensor<256xi32>, tensor<256xi32>) outs([[VAR_30_2_]] : tensor<256xi32>) {
+// CHECK:             ^bb0([[IN_4_:%.+]]: i32, [[IN_5_:%.+]]: i32, [[IN_6_:%.+]]: i32):
+// CHECK:               [[VAR_47_:%.+]] = arith.addi [[IN_4_]], [[IN_5_]] : i32
+// CHECK:               linalg.yield [[VAR_47_]] : i32
+// CHECK:             } -> tensor<256xi32>
+// CHECK:             [[VAR_32_1_:%.+]] = tensor.empty() : tensor<256xi1>
+// CHECK:             [[VAR_33_1_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_31_1_]], [[VAR_12_]] : tensor<256xi32>, tensor<256xi32>) outs([[VAR_32_1_]] : tensor<256xi1>) {
+// CHECK:             ^bb0([[IN_7_:%.+]]: i32, [[IN_8_:%.+]]: i32, [[IN_9_:%.+]]: i1):
+// CHECK:               [[VAR_47_1_:%.+]] = arith.cmpi slt, [[IN_7_]], [[IN_8_]] : i32
+// CHECK:               linalg.yield [[VAR_47_1_]] : i1
+// CHECK:             } -> tensor<256xi1>
+// CHECK:             [[VAR_34_1_:%.+]] = arith.index_cast [[VAR_arg15_1_]] : i32 to index
+// CHECK:             [[VAR_35_1_:%.+]] = arith.addi [[VAR_3_]], [[VAR_34_1_]] : index
+// CHECK-DAG:         [[VAR_reinterpret_cast_11_1_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_35_1_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_36_1_:%.+]] = arith.index_cast [[VAR_arg15_1_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_37_1_:%.+]] = arith.addi [[VAR_36_1_]], [[CST_256_1_]] : index
+// CHECK-DAG:         [[VAR_38_1_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
+// CHECK:             [[VAR_39_1_:%.+]] = arith.minsi [[VAR_37_1_]], [[VAR_38_1_]] : index
+// CHECK-DAG:         [[VAR_40_:%.+]] = arith.subi [[VAR_39_1_]], [[VAR_36_1_]] : index
+// CHECK-DAG:         [[RES_1_:%.+]] = memref.alloc() : memref<256xf32>
+// CHECK:             [[VAR_41_:%.+]] = arith.cmpi slt, [[VAR_40_]], [[CST_256_1_]] : index
+// CHECK:             scf.if [[VAR_41_]] {
+// CHECK:               linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[RES_1_]] : memref<256xf32>)
+// CHECK:             }
+// CHECK-DAG:         [[VAR_subview_1_:%.+]] = memref.subview [[VAR_reinterpret_cast_11_1_]][0] {{.}}[[VAR_40_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_subview_12_1_:%.+]] = memref.subview [[RES_1_]][0] {{.}}[[VAR_40_]]{{.}} [1] : memref<256xf32> to memref<?xf32, strided<[1]>>
+// CHECK:             memref.copy [[VAR_subview_1_]], [[VAR_subview_12_1_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK:             [[VAR_42_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<256xf32>
+// CHECK:             [[VAR_43_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_42_]], [[VAR_14_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_42_]] : tensor<256xf32>) {
+// CHECK:             ^bb0([[IN_10_:%.+]]: f32, [[IN_11_:%.+]]: f32, [[IN_12_:%.+]]: f32):
+// CHECK:               [[VAR_47_2_:%.+]] = arith.subf [[IN_10_]], [[IN_11_]] : f32
+// CHECK:               linalg.yield [[VAR_47_2_]] : f32
+// CHECK:             } -> tensor<256xf32>
+// CHECK:             [[VAR_44_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_33_1_]], [[VAR_43_]], [[VAR_1_]] : tensor<256xi1>, tensor<256xf32>, tensor<256xf32>) outs([[VAR_43_]] : tensor<256xf32>) {
+// CHECK:             ^bb0([[IN_13_:%.+]]: i1, [[IN_14_:%.+]]: f32, [[IN_15_:%.+]]: f32, [[IN_16_:%.+]]: f32):
+// CHECK:               [[VAR_47_3_:%.+]] = arith.select [[IN_13_]], [[IN_14_]], [[IN_15_]] : f32
+// CHECK:               linalg.yield [[VAR_47_3_]] : f32
+// CHECK:             } -> tensor<256xf32>
+// CHECK:             [[VAR_45_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_44_]], [[VAR_44_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_44_]] : tensor<256xf32>) {
+// CHECK:             ^bb0([[IN_17_:%.+]]: f32, [[IN_18_:%.+]]: f32, [[IN_19_:%.+]]: f32):
+// CHECK:               [[VAR_47_4_:%.+]] = arith.mulf [[IN_17_]], [[IN_18_]] : f32
+// CHECK:               linalg.yield [[VAR_47_4_]] : f32
+// CHECK:             } -> tensor<256xf32>
+// CHECK:             [[VAR_46_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_arg16_1_]], [[VAR_45_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_arg16_1_]] : tensor<256xf32>) {
+// CHECK:             ^bb0([[IN_20_:%.+]]: f32, [[IN_21_:%.+]]: f32, [[IN_22_:%.+]]: f32):
+// CHECK:               [[VAR_47_5_:%.+]] = arith.addf [[IN_20_]], [[IN_21_]] : f32
+// CHECK:               linalg.yield [[VAR_47_5_]] : f32
+// CHECK:             } -> tensor<256xf32>
+// CHECK:             scf.yield [[VAR_46_]] : tensor<256xf32>
+// CHECK:           }
+// CHECK:           [[VAR_16_:%.+]] = bufferization.alloc_tensor() : tensor<f32>
+// CHECK:           [[VAR_inserted_2_:%.+]] = tensor.insert [[CST_0_dot_000000_]] into [[VAR_16_]][] : tensor<f32>
+// CHECK:           [[VAR_reduced_3_:%.+]] = linalg.reduce ins([[VAR_15_]] : tensor<256xf32>) outs([[VAR_inserted_2_]] : tensor<f32>) dimensions = [0]
+// CHECK:             ([[IN_20_:%.+]]: f32, [[init_:%.+]]: f32) {
+// CHECK:               [[VAR_29_4_:%.+]] = arith.addf [[IN_20_]], [[init_]] : f32
+// CHECK:               linalg.yield [[VAR_29_4_]] : f32
+// CHECK:             }
+// CHECK:           [[VAR_extracted_4_:%.+]] = tensor.extract [[VAR_reduced_3_]][] : tensor<f32>
+// CHECK:           [[VAR_17_:%.+]] = arith.divf [[VAR_extracted_4_]], [[VAR_7_]] : f32
+// CHECK:           [[VAR_18_:%.+]] = arith.addf [[VAR_17_]], [[PARAM_8_]] : f32
+// CHECK:           [[VAR_19_:%.+]] = math.sqrt [[VAR_18_]] : f32
+// CHECK-DAG:       [[VAR_20_:%.+]] = arith.divf [[CST_1_dot_000000_]], [[VAR_19_]] : f32
+// CHECK-DAG:       [[VAR_21_:%.+]] = arith.index_cast [[PARAM_12_]] : i32 to index
+// CHECK:           [[base_buffer_:%.+]], [[offset_:%.+]], [[sizes_:%.+]], [[VAR_strides_:%.+]] = memref.extract_strided_metadata [[VAR_reinterpret_cast_1_]] : memref<1xf32, strided<[1], offset: ?>> -> memref<f32>, index, index, index
+// CHECK:           [[VAR_22_:%.+]] = arith.addi [[offset_]], [[VAR_21_]] : index
+// CHECK:           [[VAR_reinterpret_cast_5_:%.+]] = memref.reinterpret_cast [[base_buffer_]] to offset: {{.}}[[VAR_22_]]{{.}}, sizes: [1], strides: [1] : memref<f32> to memref<1xf32, strided<[1], offset: ?>>
+// CHECK:           affine.store [[VAR_8_]], [[VAR_reinterpret_cast_5_]][0] : memref<1xf32, strided<[1], offset: ?>>
+// CHECK:           [[VAR_23_:%.+]] = arith.index_cast [[PARAM_12_]] : i32 to index
+// CHECK:           [[base_buffer_6_:%.+]], [[offset_7_:%.+]], [[sizes_8_:%.+]], [[VAR_strides_9_:%.+]] = memref.extract_strided_metadata [[VAR_reinterpret_cast_]] : memref<1xf32, strided<[1], offset: ?>> -> memref<f32>, index, index, index
+// CHECK:           [[VAR_24_:%.+]] = arith.addi [[offset_7_]], [[VAR_23_]] : index
+// CHECK:           [[VAR_reinterpret_cast_10_:%.+]] = memref.reinterpret_cast [[base_buffer_6_]] to offset: {{.}}[[VAR_24_]]{{.}}, sizes: [1], strides: [1] : memref<f32> to memref<1xf32, strided<[1], offset: ?>>
+// CHECK:           affine.store [[VAR_20_]], [[VAR_reinterpret_cast_10_]][0] : memref<1xf32, strided<[1], offset: ?>>
+// CHECK:           [[VAR_25_:%.+]] = tensor.empty() : tensor<256xf32>
+// CHECK-DAG:       [[VAR_26_:%.+]] = linalg.fill ins([[VAR_8_]] : f32) outs([[VAR_25_]] : tensor<256xf32>) -> tensor<256xf32>
+// CHECK-DAG:       [[VAR_27_:%.+]] = tensor.empty() : tensor<256xf32>
+// CHECK:           [[VAR_28_:%.+]] = linalg.fill ins([[VAR_20_]] : f32) outs([[VAR_27_]] : tensor<256xf32>) -> tensor<256xf32>
+// CHECK:           scf.for [[VAR_arg15_1_:%.+]] = [[CST_0_]] to [[PARAM_7_]] step [[CST_256_]]  : i32 {
+// CHECK:             [[VAR_29_5_:%.+]] = arith.index_cast [[VAR_arg15_1_]] : i32 to index
+// CHECK-DAG:         [[VAR_reinterpret_cast_11_2_:%.+]] = memref.reinterpret_cast [[PARAM_2_]] to offset: {{.}}[[VAR_29_5_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_30_3_:%.+]] = arith.index_cast [[VAR_arg15_1_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_31_2_:%.+]] = arith.addi [[VAR_30_3_]], [[CST_256_1_]] : index
+// CHECK-DAG:         [[VAR_32_2_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
+// CHECK:             [[VAR_33_2_:%.+]] = arith.minsi [[VAR_31_2_]], [[VAR_32_2_]] : index
+// CHECK-DAG:         [[VAR_34_2_:%.+]] = arith.subi [[VAR_33_2_]], [[VAR_30_3_]] : index
+// CHECK-DAG:         [[RES_2_:%.+]] = memref.alloc() : memref<256xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_subview_2_:%.+]] = memref.subview [[VAR_reinterpret_cast_11_2_]][0] {{.}}[[VAR_34_2_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_subview_12_2_:%.+]] = memref.subview [[RES_2_]][0] {{.}}[[VAR_34_2_]]{{.}} [1] : memref<256xf32> to memref<?xf32, strided<[1]>>
+// CHECK:             memref.copy [[VAR_subview_2_]], [[VAR_subview_12_2_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:         [[VAR_35_2_:%.+]] = bufferization.to_tensor [[RES_2_]] restrict writable : memref<256xf32>
+// CHECK-DAG:         [[VAR_36_2_:%.+]] = arith.index_cast [[VAR_arg15_1_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_reinterpret_cast_13_:%.+]] = memref.reinterpret_cast [[PARAM_3_]] to offset: {{.}}[[VAR_36_2_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_37_2_:%.+]] = arith.index_cast [[VAR_arg15_1_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_38_2_:%.+]] = arith.addi [[VAR_37_2_]], [[CST_256_1_]] : index
+// CHECK-DAG:         [[VAR_39_2_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
+// CHECK:             [[VAR_40_1_:%.+]] = arith.minsi [[VAR_38_2_]], [[VAR_39_2_]] : index
+// CHECK-DAG:         [[VAR_41_1_:%.+]] = arith.subi [[VAR_40_1_]], [[VAR_37_2_]] : index
+// CHECK-DAG:         [[RES_3_:%.+]] = memref.alloc() : memref<256xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_subview_15_:%.+]] = memref.subview [[VAR_reinterpret_cast_13_]][0] {{.}}[[VAR_41_1_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_subview_16_:%.+]] = memref.subview [[RES_3_]][0] {{.}}[[VAR_41_1_]]{{.}} [1] : memref<256xf32> to memref<?xf32, strided<[1]>>
+// CHECK:             memref.copy [[VAR_subview_15_]], [[VAR_subview_16_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:         [[VAR_42_1_:%.+]] = bufferization.to_tensor [[RES_3_]] restrict writable : memref<256xf32>
+// CHECK-DAG:         [[VAR_43_1_:%.+]] = arith.index_cast [[VAR_arg15_1_]] : i32 to index
+// CHECK:             [[VAR_44_1_:%.+]] = arith.addi [[VAR_3_]], [[VAR_43_1_]] : index
+// CHECK-DAG:         [[VAR_reinterpret_cast_17_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_44_1_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_45_1_:%.+]] = arith.index_cast [[VAR_arg15_1_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_46_1_:%.+]] = arith.addi [[VAR_45_1_]], [[CST_256_1_]] : index
+// CHECK-DAG:         [[VAR_47_6_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
+// CHECK:             [[VAR_48_:%.+]] = arith.minsi [[VAR_46_1_]], [[VAR_47_6_]] : index
+// CHECK-DAG:         [[VAR_49_:%.+]] = arith.subi [[VAR_48_]], [[VAR_45_1_]] : index
+// CHECK-DAG:         [[RES_4_:%.+]] = memref.alloc() : memref<256xf32>
+// CHECK:             [[VAR_50_:%.+]] = arith.cmpi slt, [[VAR_49_]], [[CST_256_1_]] : index
+// CHECK:             scf.if [[VAR_50_]] {
+// CHECK:               linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[RES_4_]] : memref<256xf32>)
+// CHECK:             }
+// CHECK-DAG:         [[VAR_subview_19_:%.+]] = memref.subview [[VAR_reinterpret_cast_17_]][0] {{.}}[[VAR_49_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_subview_20_:%.+]] = memref.subview [[RES_4_]][0] {{.}}[[VAR_49_]]{{.}} [1] : memref<256xf32> to memref<?xf32, strided<[1]>>
+// CHECK:             memref.copy [[VAR_subview_19_]], [[VAR_subview_20_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK:             [[VAR_51_:%.+]] = bufferization.to_tensor [[RES_4_]] restrict writable : memref<256xf32>
+// CHECK:             [[VAR_52_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_51_]], [[VAR_26_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_51_]] : tensor<256xf32>) {
+// CHECK:             ^bb0([[IN_23_:%.+]]: f32, [[IN_24_:%.+]]: f32, [[IN_25_:%.+]]: f32):
+// CHECK:               [[VAR_63_:%.+]] = arith.subf [[IN_23_]], [[IN_24_]] : f32
+// CHECK:               linalg.yield [[VAR_63_]] : f32
+// CHECK:             } -> tensor<256xf32>
+// CHECK:             [[VAR_53_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_52_]], [[VAR_28_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_52_]] : tensor<256xf32>) {
+// CHECK:             ^bb0([[IN_26_:%.+]]: f32, [[IN_27_:%.+]]: f32, [[IN_28_:%.+]]: f32):
+// CHECK:               [[VAR_63_1_:%.+]] = arith.mulf [[IN_26_]], [[IN_27_]] : f32
+// CHECK:               linalg.yield [[VAR_63_1_]] : f32
+// CHECK:             } -> tensor<256xf32>
+// CHECK:             [[VAR_54_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_53_]], [[VAR_35_2_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_53_]] : tensor<256xf32>) {
+// CHECK:             ^bb0([[IN_29_:%.+]]: f32, [[IN_30_:%.+]]: f32, [[IN_31_:%.+]]: f32):
+// CHECK:               [[VAR_63_2_:%.+]] = arith.mulf [[IN_29_]], [[IN_30_]] : f32
+// CHECK:               linalg.yield [[VAR_63_2_]] : f32
+// CHECK:             } -> tensor<256xf32>
+// CHECK:             [[VAR_55_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_54_]], [[VAR_42_1_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_54_]] : tensor<256xf32>) {
+// CHECK:             ^bb0([[IN_32_:%.+]]: f32, [[IN_33_:%.+]]: f32, [[IN_34_:%.+]]: f32):
+// CHECK:               [[VAR_63_3_:%.+]] = arith.addf [[IN_32_]], [[IN_33_]] : f32
+// CHECK:               linalg.yield [[VAR_63_3_]] : f32
+// CHECK:             } -> tensor<256xf32>
+// CHECK:             [[VAR_56_:%.+]] = arith.index_cast [[VAR_arg15_1_]] : i32 to index
+// CHECK:             [[VAR_57_:%.+]] = arith.addi [[VAR_4_]], [[VAR_56_]] : index
+// CHECK-DAG:         [[VAR_reinterpret_cast_21_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_57_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_58_:%.+]] = arith.index_cast [[VAR_arg15_1_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_59_:%.+]] = arith.addi [[VAR_58_]], [[CST_256_1_]] : index
+// CHECK-DAG:         [[VAR_60_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
+// CHECK:             [[VAR_61_:%.+]] = arith.minsi [[VAR_59_]], [[VAR_60_]] : index
+// CHECK:             [[VAR_62_:%.+]] = arith.subi [[VAR_61_]], [[VAR_58_]] : index
+// CHECK-DAG:         [[VAR_extracted_slice_:%.+]] = tensor.extract_slice [[VAR_55_]][0] {{.}}[[VAR_62_]]{{.}} [1] : tensor<256xf32> to tensor<?xf32>
+// CHECK-DAG:         [[VAR_subview_22_:%.+]] = memref.subview [[VAR_reinterpret_cast_21_]][0] {{.}}[[VAR_62_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK:             bufferization.materialize_in_destination [[VAR_extracted_slice_]] in writable [[VAR_subview_22_]] : (tensor<?xf32>, memref<?xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/kernel-05-layer-norm-fwd.mlir
+++ b/test/Conversion/StructuredToMemref/kernel-05-layer-norm-fwd.mlir
@@ -10,12 +10,12 @@ module {
     %1 = arith.muli %0, %arg6 : i32
     %2 = tt.addptr %arg1, %1 : !tt.ptr<f32>, i32
     %3 = tt.addptr %arg0, %1 : !tt.ptr<f32>, i32
-    %4 = tt.splat %cst_0 : (f32) -> tensor<256xf32>
+    %4 = tt.splat %cst_0 : f32 -> tensor<256xf32>
     %5 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
-    %6 = tt.splat %arg7 : (i32) -> tensor<256xi32>
-    %7 = tt.splat %3 : (!tt.ptr<f32>) -> tensor<256x!tt.ptr<f32>>
+    %6 = tt.splat %arg7 : i32 -> tensor<256xi32>
+    %7 = tt.splat %3 : !tt.ptr<f32> -> tensor<256x!tt.ptr<f32>>
     %8 = scf.for %arg9 = %c0_i32 to %arg7 step %c256_i32 iter_args(%arg10 = %4) -> (tensor<256xf32>)  : i32 {
-      %32 = tt.splat %arg9 : (i32) -> tensor<256xi32>
+      %32 = tt.splat %arg9 : i32 -> tensor<256xi32>
       %33 = arith.addi %32, %5 : tensor<256xi32>
       %34 = arith.cmpi slt, %33, %6 : tensor<256xi32>
       %35 = tt.addptr %7, %33 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
@@ -31,11 +31,11 @@ module {
     %10 = arith.sitofp %arg7 : i32 to f32
     %11 = arith.divf %9, %10 : f32
     %12 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
-    %13 = tt.splat %arg7 : (i32) -> tensor<256xi32>
-    %14 = tt.splat %3 : (!tt.ptr<f32>) -> tensor<256x!tt.ptr<f32>>
-    %15 = tt.splat %11 : (f32) -> tensor<256xf32>
+    %13 = tt.splat %arg7 : i32 -> tensor<256xi32>
+    %14 = tt.splat %3 : !tt.ptr<f32> -> tensor<256x!tt.ptr<f32>>
+    %15 = tt.splat %11 : f32 -> tensor<256xf32>
     %16 = scf.for %arg9 = %c0_i32 to %arg7 step %c256_i32 iter_args(%arg10 = %4) -> (tensor<256xf32>)  : i32 {
-      %32 = tt.splat %arg9 : (i32) -> tensor<256xi32>
+      %32 = tt.splat %arg9 : i32 -> tensor<256xi32>
       %33 = arith.addi %32, %12 : tensor<256xi32>
       %34 = arith.cmpi slt, %33, %13 : tensor<256xi32>
       %35 = tt.addptr %14, %33 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
@@ -60,15 +60,15 @@ module {
     %23 = tt.addptr %arg5, %0 : !tt.ptr<f32>, i32
     tt.store %23, %21 {cache = 1 : i32, evict = 1 : i32} : f32
     %24 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
-    %25 = tt.splat %arg7 : (i32) -> tensor<256xi32>
-    %26 = tt.splat %arg2 : (!tt.ptr<f32>) -> tensor<256x!tt.ptr<f32>>
-    %27 = tt.splat %arg3 : (!tt.ptr<f32>) -> tensor<256x!tt.ptr<f32>>
-    %28 = tt.splat %3 : (!tt.ptr<f32>) -> tensor<256x!tt.ptr<f32>>
-    %29 = tt.splat %11 : (f32) -> tensor<256xf32>
-    %30 = tt.splat %21 : (f32) -> tensor<256xf32>
-    %31 = tt.splat %2 : (!tt.ptr<f32>) -> tensor<256x!tt.ptr<f32>>
+    %25 = tt.splat %arg7 : i32 -> tensor<256xi32>
+    %26 = tt.splat %arg2 : !tt.ptr<f32> -> tensor<256x!tt.ptr<f32>>
+    %27 = tt.splat %arg3 : !tt.ptr<f32> -> tensor<256x!tt.ptr<f32>>
+    %28 = tt.splat %3 : !tt.ptr<f32> -> tensor<256x!tt.ptr<f32>>
+    %29 = tt.splat %11 : f32 -> tensor<256xf32>
+    %30 = tt.splat %21 : f32 -> tensor<256xf32>
+    %31 = tt.splat %2 : !tt.ptr<f32> -> tensor<256x!tt.ptr<f32>>
     scf.for %arg9 = %c0_i32 to %arg7 step %c256_i32  : i32 {
-      %32 = tt.splat %arg9 : (i32) -> tensor<256xi32>
+      %32 = tt.splat %arg9 : i32 -> tensor<256xi32>
       %33 = arith.addi %32, %24 : tensor<256xi32>
       %34 = arith.cmpi slt, %33, %25 : tensor<256xi32>
       %35 = tt.addptr %26, %33 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>

--- a/test/Conversion/StructuredToMemref/masked_ldst_1d.mlir
+++ b/test/Conversion/StructuredToMemref/masked_ldst_1d.mlir
@@ -1,0 +1,47 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+module {
+  tt.func @kernel(
+  %arg0 : !tt.ptr<bf16>,
+  %arg1 : !tt.ptr<bf16>,
+  %arg2 : i32
+  )
+  {
+    %0 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<128x!tt.ptr<bf16>>
+    %1 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<128x!tt.ptr<bf16>>
+    %2 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %ldptr = tt.addptr %0, %2 : tensor<128x!tt.ptr<bf16>>, tensor<128xi32>
+    %stptr = tt.addptr %1, %2 : tensor<128x!tt.ptr<bf16>>, tensor<128xi32>
+    %nans = arith.constant dense<0xFF80> : tensor<128xbf16>
+    %5 = tt.splat %arg2 : (i32) -> tensor<128xi32>
+    %mask = arith.cmpi slt, %2, %5 : tensor<128xi32>
+    %buff = tt.load %ldptr, %mask, %nans {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128xbf16>
+    tt.store %stptr, %buff, %mask : tensor<128xbf16>
+    tt.return
+  }
+}
+// mlir2FileCheck.py
+// CHECK-LABEL:  func.func @kernel
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: memref<*xbf16>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_128_:%.+]] = arith.constant 128 : index
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0xFF80 : bf16
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [128], strides: [1] : memref<*xbf16> to memref<128xbf16, strided<[1]>>
+// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: [0], sizes: [128], strides: [1] : memref<*xbf16> to memref<128xbf16, strided<[1]>>
+// CHECK-DAG:       [[VAR_0_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_1_:%.+]] = arith.minsi [[VAR_0_]], [[CST_128_]] : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<128xbf16>
+// CHECK:           [[VAR_2_:%.+]] = arith.cmpi slt, [[VAR_1_]], [[CST_128_]] : index
+// CHECK:           scf.if [[VAR_2_]] {
+// CHECK:             linalg.fill ins([[CST_0_]] : bf16) outs([[RES_]] : memref<128xbf16>)
+// CHECK:           }
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_1_]]{{.}} [1] : memref<128xbf16, strided<[1]>> to memref<?xbf16, strided<[1]>>
+// CHECK-DAG:       [[VAR_subview_1_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_1_]]{{.}} [1] : memref<128xbf16> to memref<?xbf16, strided<[1]>>
+// CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_1_]] : memref<?xbf16, strided<[1]>> to memref<?xbf16, strided<[1]>>
+// CHECK-DAG:       [[VAR_3_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<128xbf16>
+// CHECK-DAG:       [[VAR_4_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_5_:%.+]] = arith.minsi [[VAR_4_]], [[CST_128_]] : index
+// CHECK-DAG:       [[VAR_extracted_slice_:%.+]] = tensor.extract_slice [[VAR_3_]][0] {{.}}[[VAR_5_]]{{.}} [1] : tensor<128xbf16> to tensor<?xbf16>
+// CHECK-DAG:       [[VAR_subview_2_:%.+]] = memref.subview [[VAR_reinterpret_cast_0_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<128xbf16, strided<[1]>> to memref<?xbf16, strided<[1]>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_extracted_slice_]] in writable [[VAR_subview_2_]] : (tensor<?xbf16>, memref<?xbf16, strided<[1]>>) -> ()
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/masked_ldst_1d.mlir
+++ b/test/Conversion/StructuredToMemref/masked_ldst_1d.mlir
@@ -6,13 +6,13 @@ module {
   %arg2 : i32
   )
   {
-    %0 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<128x!tt.ptr<bf16>>
-    %1 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<128x!tt.ptr<bf16>>
+    %0 = tt.splat %arg0 : !tt.ptr<bf16> -> tensor<128x!tt.ptr<bf16>>
+    %1 = tt.splat %arg1 : !tt.ptr<bf16> -> tensor<128x!tt.ptr<bf16>>
     %2 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
     %ldptr = tt.addptr %0, %2 : tensor<128x!tt.ptr<bf16>>, tensor<128xi32>
     %stptr = tt.addptr %1, %2 : tensor<128x!tt.ptr<bf16>>, tensor<128xi32>
     %nans = arith.constant dense<0xFF80> : tensor<128xbf16>
-    %5 = tt.splat %arg2 : (i32) -> tensor<128xi32>
+    %5 = tt.splat %arg2 : i32 -> tensor<128xi32>
     %mask = arith.cmpi slt, %2, %5 : tensor<128xi32>
     %buff = tt.load %ldptr, %mask, %nans {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128xbf16>
     tt.store %stptr, %buff, %mask : tensor<128xbf16>

--- a/test/Conversion/StructuredToMemref/masked_ldst_2d.mlir
+++ b/test/Conversion/StructuredToMemref/masked_ldst_2d.mlir
@@ -16,42 +16,42 @@ module {
     //  size[0] = 256
     //  stride[0] = 1024
     //  stride[1] = 1
-    %0 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<128x256x!tt.ptr<bf16>>
-    %1 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<128x256x!tt.ptr<bf16>>
+    %0 = tt.splat %arg0 : !tt.ptr<bf16> -> tensor<128x256x!tt.ptr<bf16>>
+    %1 = tt.splat %arg1 : !tt.ptr<bf16> -> tensor<128x256x!tt.ptr<bf16>>
     // horizontal index
     %2 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
     %c2 = arith.constant 2 : i32
-    %c2tensor = tt.splat %c2 : (i32) -> tensor<128xi32>
+    %c2tensor = tt.splat %c2 : i32 -> tensor<128xi32>
     %offset2 = arith.addi %2, %c2tensor : tensor<128xi32>
-    %3 = tt.expand_dims %offset2 {axis = 1 : i32} : (tensor<128xi32>) -> tensor<128x1xi32>
-    %4 = tt.broadcast %3 : (tensor<128x1xi32>) -> tensor<128x256xi32>
+    %3 = tt.expand_dims %offset2 {axis = 1 : i32} : tensor<128xi32> -> tensor<128x1xi32>
+    %4 = tt.broadcast %3 : tensor<128x1xi32> -> tensor<128x256xi32>
     // vertical index
     %5 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
     %c3 = arith.constant 3 : i32
-    %c3tensor = tt.splat %c3 : (i32) -> tensor<256xi32>
+    %c3tensor = tt.splat %c3 : i32 -> tensor<256xi32>
     %offset5 = arith.addi %5, %c3tensor : tensor<256xi32>
     %c1024 = arith.constant 1024 : i32
-    %c1024tensor = tt.splat %c1024 : (i32) -> tensor<256xi32>
+    %c1024tensor = tt.splat %c1024 : i32 -> tensor<256xi32>
     %scale5 = arith.muli %offset5, %c1024tensor : tensor<256xi32>
-    %6 = tt.expand_dims %scale5 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
-    %7 = tt.broadcast %6 : (tensor<1x256xi32>) -> tensor<128x256xi32>
+    %6 = tt.expand_dims %scale5 {axis = 0 : i32} : tensor<256xi32> -> tensor<1x256xi32>
+    %7 = tt.broadcast %6 : tensor<1x256xi32> -> tensor<128x256xi32>
     // combined index
     %index = arith.addi %4, %7 : tensor<128x256xi32>
     %ldptr = tt.addptr %0, %index : tensor<128x256x!tt.ptr<bf16>>, tensor<128x256xi32>
     %stptr = tt.addptr %1, %index : tensor<128x256x!tt.ptr<bf16>>, tensor<128x256xi32>
     // other value for masked load
     %cnan = arith.constant 0xFF80 : bf16
-    %nans = tt.splat %cnan : (bf16) -> tensor<128x256xbf16>
+    %nans = tt.splat %cnan : bf16 -> tensor<128x256xbf16>
     // horizontal mask
-    %8 = tt.splat %arg2 : (i32) -> tensor<128xi32>
+    %8 = tt.splat %arg2 : i32 -> tensor<128xi32>
     %9 = arith.cmpi slt, %offset2, %8 : tensor<128xi32>
-    %10 = tt.expand_dims %9 {axis = 1 : i32} : (tensor<128xi1>) -> tensor<128x1xi1>
-    %11 = tt.broadcast %10 : (tensor<128x1xi1>) -> tensor<128x256xi1>
+    %10 = tt.expand_dims %9 {axis = 1 : i32} : tensor<128xi1> -> tensor<128x1xi1>
+    %11 = tt.broadcast %10 : tensor<128x1xi1> -> tensor<128x256xi1>
     // vertical mask
-    %12 = tt.splat %arg3 : (i32) -> tensor<256xi32>
+    %12 = tt.splat %arg3 : i32 -> tensor<256xi32>
     %13 = arith.cmpi slt, %offset5, %12 : tensor<256xi32>
-    %14 = tt.expand_dims %13 {axis = 0 : i32} : (tensor<256xi1>) -> tensor<1x256xi1>
-    %15 = tt.broadcast %14 : (tensor<1x256xi1>) -> tensor<128x256xi1>
+    %14 = tt.expand_dims %13 {axis = 0 : i32} : tensor<256xi1> -> tensor<1x256xi1>
+    %15 = tt.broadcast %14 : tensor<1x256xi1> -> tensor<128x256xi1>
     // combined mask
     %mask = arith.andi %11, %15 : tensor<128x256xi1>
     // dim0 = min(%arg2, 128), dim1 = min(%arg3, 256)

--- a/test/Conversion/StructuredToMemref/masked_ldst_2d.mlir
+++ b/test/Conversion/StructuredToMemref/masked_ldst_2d.mlir
@@ -1,0 +1,111 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+module {
+  tt.func @kernel(
+  %arg0 : !tt.ptr<bf16>,
+  %arg1 : !tt.ptr<bf16>,
+  %arg2 : i32,
+  %arg3 : i32
+  )
+  {
+    // Mimic a scenario where the raw pointer points to a buffer with dimension (1024, 1024)
+    // in row-major, but the actual tensor size is (arg2, arg3).
+    // We are trying to load a 128x256 sub-buffer starting at (2, 3).
+    // The resulting memref:
+    //  offset = 3074
+    //  size[1] = 128
+    //  size[0] = 256
+    //  stride[0] = 1024
+    //  stride[1] = 1
+    %0 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<128x256x!tt.ptr<bf16>>
+    %1 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<128x256x!tt.ptr<bf16>>
+    // horizontal index
+    %2 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %c2 = arith.constant 2 : i32
+    %c2tensor = tt.splat %c2 : (i32) -> tensor<128xi32>
+    %offset2 = arith.addi %2, %c2tensor : tensor<128xi32>
+    %3 = tt.expand_dims %offset2 {axis = 1 : i32} : (tensor<128xi32>) -> tensor<128x1xi32>
+    %4 = tt.broadcast %3 : (tensor<128x1xi32>) -> tensor<128x256xi32>
+    // vertical index
+    %5 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
+    %c3 = arith.constant 3 : i32
+    %c3tensor = tt.splat %c3 : (i32) -> tensor<256xi32>
+    %offset5 = arith.addi %5, %c3tensor : tensor<256xi32>
+    %c1024 = arith.constant 1024 : i32
+    %c1024tensor = tt.splat %c1024 : (i32) -> tensor<256xi32>
+    %scale5 = arith.muli %offset5, %c1024tensor : tensor<256xi32>
+    %6 = tt.expand_dims %scale5 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
+    %7 = tt.broadcast %6 : (tensor<1x256xi32>) -> tensor<128x256xi32>
+    // combined index
+    %index = arith.addi %4, %7 : tensor<128x256xi32>
+    %ldptr = tt.addptr %0, %index : tensor<128x256x!tt.ptr<bf16>>, tensor<128x256xi32>
+    %stptr = tt.addptr %1, %index : tensor<128x256x!tt.ptr<bf16>>, tensor<128x256xi32>
+    // other value for masked load
+    %cnan = arith.constant 0xFF80 : bf16
+    %nans = tt.splat %cnan : (bf16) -> tensor<128x256xbf16>
+    // horizontal mask
+    %8 = tt.splat %arg2 : (i32) -> tensor<128xi32>
+    %9 = arith.cmpi slt, %offset2, %8 : tensor<128xi32>
+    %10 = tt.expand_dims %9 {axis = 1 : i32} : (tensor<128xi1>) -> tensor<128x1xi1>
+    %11 = tt.broadcast %10 : (tensor<128x1xi1>) -> tensor<128x256xi1>
+    // vertical mask
+    %12 = tt.splat %arg3 : (i32) -> tensor<256xi32>
+    %13 = arith.cmpi slt, %offset5, %12 : tensor<256xi32>
+    %14 = tt.expand_dims %13 {axis = 0 : i32} : (tensor<256xi1>) -> tensor<1x256xi1>
+    %15 = tt.broadcast %14 : (tensor<1x256xi1>) -> tensor<128x256xi1>
+    // combined mask
+    %mask = arith.andi %11, %15 : tensor<128x256xi1>
+    // dim0 = min(%arg2, 128), dim1 = min(%arg3, 256)
+    // TODO: need reinterpret cast
+    %buff = tt.load %ldptr, %mask, %nans {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128x256xbf16>
+    tt.store %stptr, %buff, %mask : tensor<128x256xbf16>
+    tt.return
+  }
+}
+// mlir2FileCheck.py
+// CHECK-LABEL:  func.func @kernel
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: memref<*xbf16>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_1024_:%.+]] = arith.constant 1024 : index
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0xFF80 : bf16
+// CHECK-DAG:       [[CST_130_:%.+]] = arith.constant 130 : index
+// CHECK-DAG:       [[CST_2_:%.+]] = arith.constant 2 : index
+// CHECK-DAG:       [[CST_259_:%.+]] = arith.constant 259 : index
+// CHECK-DAG:       [[CST_3_:%.+]] = arith.constant 3 : index
+// CHECK-DAG:       [[CST_128_:%.+]] = arith.constant 128 : index
+// CHECK-DAG:       [[CST_256_:%.+]] = arith.constant 256 : index
+// CHECK-DAG:       [[CST_3074_:%.+]] = arith.constant 3074 : index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[CST_3074_]]{{.}}, sizes: [128, 256], strides: [1, [[CST_1024_]]{{.}} : memref<*xbf16> to memref<128x256xbf16, strided<[1, ?], offset: ?>>
+// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[CST_3074_]]{{.}}, sizes: [128, 256], strides: [1, [[CST_1024_]]{{.}} : memref<*xbf16> to memref<128x256xbf16, strided<[1, ?], offset: ?>>
+// CHECK-DAG:       [[VAR_0_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_1_:%.+]] = arith.minsi [[VAR_0_]], [[CST_130_]] : index
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.subi [[VAR_1_]], [[CST_2_]] : index
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
+// CHECK:           [[VAR_4_:%.+]] = arith.minsi [[VAR_3_]], [[CST_259_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.subi [[VAR_4_]], [[CST_3_]] : index
+// CHECK-DAG:       [[VAR_6_:%.+]] = arith.minsi [[VAR_2_]], [[CST_128_]] : index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_7_:%.+]] = arith.minsi [[VAR_5_]], [[CST_256_]] : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<128x256xbf16>
+// CHECK-DAG:       [[VAR_8_:%.+]] = arith.cmpi slt, [[VAR_6_]], [[CST_128_]] : index
+// CHECK:           [[VAR_9_:%.+]] = arith.cmpi slt, [[VAR_7_]], [[CST_256_]] : index
+// CHECK:           [[VAR_10_:%.+]] = arith.ori [[VAR_8_]], [[VAR_9_]] : i1
+// CHECK:           scf.if [[VAR_10_]] {
+// CHECK:             linalg.fill ins([[CST_0_]] : bf16) outs([[RES_]] : memref<128x256xbf16>)
+// CHECK:           }
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0, 0] {{.}}[[VAR_6_]], [[VAR_7_]]{{.}} [1, 1] : memref<128x256xbf16, strided<[1, ?], offset: ?>> to memref<?x?xbf16, strided<[1, ?], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_1_:%.+]] = memref.subview [[RES_]][0, 0] {{.}}[[VAR_6_]], [[VAR_7_]]{{.}} [1, 1] : memref<128x256xbf16> to memref<?x?xbf16, strided<[256, 1]>>
+// CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_1_]] : memref<?x?xbf16, strided<[1, ?], offset: ?>> to memref<?x?xbf16, strided<[256, 1]>>
+// CHECK-DAG:       [[VAR_11_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<128x256xbf16>
+// CHECK-DAG:       [[VAR_12_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_13_:%.+]] = arith.minsi [[VAR_12_]], [[CST_130_]] : index
+// CHECK-DAG:       [[VAR_14_:%.+]] = arith.subi [[VAR_13_]], [[CST_2_]] : index
+// CHECK-DAG:       [[VAR_15_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
+// CHECK:           [[VAR_16_:%.+]] = arith.minsi [[VAR_15_]], [[CST_259_]] : index
+// CHECK-DAG:       [[VAR_17_:%.+]] = arith.subi [[VAR_16_]], [[CST_3_]] : index
+// CHECK-DAG:       [[VAR_18_:%.+]] = arith.minsi [[VAR_14_]], [[CST_128_]] : index
+// CHECK:           [[VAR_19_:%.+]] = arith.minsi [[VAR_17_]], [[CST_256_]] : index
+// CHECK-DAG:       [[VAR_extracted_slice_:%.+]] = tensor.extract_slice [[VAR_11_]][0, 0] {{.}}[[VAR_18_]], [[VAR_19_]]{{.}} [1, 1] : tensor<128x256xbf16> to tensor<?x?xbf16>
+// CHECK-DAG:       [[VAR_subview_2_:%.+]] = memref.subview [[VAR_reinterpret_cast_0_]][0, 0] {{.}}[[VAR_18_]], [[VAR_19_]]{{.}} [1, 1] : memref<128x256xbf16, strided<[1, ?], offset: ?>> to memref<?x?xbf16, strided<[1, ?], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_extracted_slice_]] in writable [[VAR_subview_2_]] : (tensor<?x?xbf16>, memref<?x?xbf16, strided<[1, ?], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/masked_ldst_sitofp_other.mlir
+++ b/test/Conversion/StructuredToMemref/masked_ldst_sitofp_other.mlir
@@ -6,15 +6,15 @@ module {
   %arg2 : i32
   )
   {
-    %0 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<128x!tt.ptr<bf16>>
-    %1 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<128x!tt.ptr<bf16>>
+    %0 = tt.splat %arg0 : !tt.ptr<bf16> -> tensor<128x!tt.ptr<bf16>>
+    %1 = tt.splat %arg1 : !tt.ptr<bf16> -> tensor<128x!tt.ptr<bf16>>
     %2 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
     %ldptr = tt.addptr %0, %2 : tensor<128x!tt.ptr<bf16>>, tensor<128xi32>
     %stptr = tt.addptr %1, %2 : tensor<128x!tt.ptr<bf16>>, tensor<128xi32>
     %c7_i32 = arith.constant 7 : i32
-    %splat_c7_i32 = tt.splat %c7_i32 : (i32) -> tensor<128xi32>
+    %splat_c7_i32 = tt.splat %c7_i32 : i32 -> tensor<128xi32>
     %splat_c7_bf16 = arith.sitofp %splat_c7_i32 : tensor<128xi32> to tensor<128xbf16>
-    %5 = tt.splat %arg2 : (i32) -> tensor<128xi32>
+    %5 = tt.splat %arg2 : i32 -> tensor<128xi32>
     %mask = arith.cmpi slt, %2, %5 : tensor<128xi32>
     %buff = tt.load %ldptr, %mask, %splat_c7_bf16 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128xbf16>
     tt.store %stptr, %buff, %mask : tensor<128xbf16>

--- a/test/Conversion/StructuredToMemref/masked_ldst_sitofp_other.mlir
+++ b/test/Conversion/StructuredToMemref/masked_ldst_sitofp_other.mlir
@@ -1,0 +1,49 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+module {
+  tt.func @kernel(
+  %arg0 : !tt.ptr<bf16>,
+  %arg1 : !tt.ptr<bf16>,
+  %arg2 : i32
+  )
+  {
+    %0 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<128x!tt.ptr<bf16>>
+    %1 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<128x!tt.ptr<bf16>>
+    %2 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %ldptr = tt.addptr %0, %2 : tensor<128x!tt.ptr<bf16>>, tensor<128xi32>
+    %stptr = tt.addptr %1, %2 : tensor<128x!tt.ptr<bf16>>, tensor<128xi32>
+    %c7_i32 = arith.constant 7 : i32
+    %splat_c7_i32 = tt.splat %c7_i32 : (i32) -> tensor<128xi32>
+    %splat_c7_bf16 = arith.sitofp %splat_c7_i32 : tensor<128xi32> to tensor<128xbf16>
+    %5 = tt.splat %arg2 : (i32) -> tensor<128xi32>
+    %mask = arith.cmpi slt, %2, %5 : tensor<128xi32>
+    %buff = tt.load %ldptr, %mask, %splat_c7_bf16 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128xbf16>
+    tt.store %stptr, %buff, %mask : tensor<128xbf16>
+    tt.return
+  }
+}
+// mlir2FileCheck.py
+// CHECK-LABEL:  func.func @kernel
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: memref<*xbf16>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_128_:%.+]] = arith.constant 128 : index
+// CHECK-DAG:       [[CST_7_dot_000000_:%.+]] = arith.constant 7.000000e+00 : bf16
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [128], strides: [1] : memref<*xbf16> to memref<128xbf16, strided<[1]>>
+// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: [0], sizes: [128], strides: [1] : memref<*xbf16> to memref<128xbf16, strided<[1]>>
+// CHECK-DAG:       [[VAR_0_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_1_:%.+]] = arith.minsi [[VAR_0_]], [[CST_128_]] : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<128xbf16>
+// CHECK:           [[VAR_2_:%.+]] = arith.cmpi slt, [[VAR_1_]], [[CST_128_]] : index
+// CHECK:           scf.if [[VAR_2_]] {
+// CHECK:             linalg.fill ins([[CST_7_dot_000000_]] : bf16) outs([[RES_]] : memref<128xbf16>)
+// CHECK:           }
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_1_]]{{.}} [1] : memref<128xbf16, strided<[1]>> to memref<?xbf16, strided<[1]>>
+// CHECK-DAG:       [[VAR_subview_1_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_1_]]{{.}} [1] : memref<128xbf16> to memref<?xbf16, strided<[1]>>
+// CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_1_]] : memref<?xbf16, strided<[1]>> to memref<?xbf16, strided<[1]>>
+// CHECK-DAG:       [[VAR_3_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<128xbf16>
+// CHECK-DAG:       [[VAR_4_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_5_:%.+]] = arith.minsi [[VAR_4_]], [[CST_128_]] : index
+// CHECK-DAG:       [[VAR_extracted_slice_:%.+]] = tensor.extract_slice [[VAR_3_]][0] {{.}}[[VAR_5_]]{{.}} [1] : tensor<128xbf16> to tensor<?xbf16>
+// CHECK-DAG:       [[VAR_subview_2_:%.+]] = memref.subview [[VAR_reinterpret_cast_0_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<128xbf16, strided<[1]>> to memref<?xbf16, strided<[1]>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_extracted_slice_]] in writable [[VAR_subview_2_]] : (tensor<?xbf16>, memref<?xbf16, strided<[1]>>) -> ()
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/reducemax_32_256_bf16.mlir
+++ b/test/Conversion/StructuredToMemref/reducemax_32_256_bf16.mlir
@@ -1,0 +1,60 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+module {
+    tt.func @kernel(%afloat : !tt.ptr<bf16>,
+        %res : tensor<256x16x!tt.ptr<bf16>>
+    ) -> () {
+    // offset calculations
+    %0 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %c256 = arith.constant 256 : i32
+    %ct256 = tt.splat %c256 : (i32) -> tensor<32xi32>
+    %ws = arith.muli %ct256, %0 : tensor<32xi32>
+    %1 = tt.expand_dims %ws {axis = 1 : i32} : (tensor<32xi32>) -> tensor<32x1xi32>
+    %m2 = tt.broadcast %1 : (tensor<32x1xi32>) -> tensor<32x256xi32>
+    %100 = tt.expand_dims %m2 {axis = 2 : i32} : (tensor<32x256xi32>) -> tensor<32x256x1xi32>
+    %moff = tt.broadcast %100 : (tensor<32x256x1xi32>) -> tensor<32x256x16xi32>
+    %33 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
+    %34 = tt.expand_dims %33 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
+    %k2 = tt.broadcast %34 : (tensor<1x256xi32>) -> tensor<32x256xi32>
+    %200 = tt.expand_dims %k2 {axis = 2 : i32} : (tensor<32x256xi32>) -> tensor<32x256x1xi32>
+    %koff = tt.broadcast %200 : (tensor<32x256x1xi32>) -> tensor<32x256x16xi32>
+    %23 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %24 = tt.expand_dims %23 {axis = 0 : i32} : (tensor<16xi32>) -> tensor<1x16xi32>
+    %n2 = tt.broadcast %24 : (tensor<1x16xi32>) -> tensor<256x16xi32>
+    %300 = tt.expand_dims %n2 {axis = 0 : i32} : (tensor<256x16xi32>) -> tensor<1x256x16xi32>
+    %noff = tt.broadcast %300 : (tensor<1x256x16xi32>) -> tensor<32x256x16xi32>
+    %mkoff = arith.addi %moff, %koff : tensor<32x256x16xi32>
+    %mknoff = arith.addi %mkoff, %noff : tensor<32x256x16xi32>
+    // afloat pointer
+    %8 = tt.splat %afloat : (!tt.ptr<bf16>) -> tensor<32x256x16x!tt.ptr<bf16>>
+    %9 = tt.addptr %8, %mknoff : tensor<32x256x16x!tt.ptr<bf16>>, tensor<32x256x16xi32>
+    %afm = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32x256x16xbf16>
+    %6 = "tt.reduce"(%afm) ({
+    ^bb0(%arg5: bf16, %arg6: bf16):
+      %21 = arith.cmpf ogt, %arg5, %arg6 : bf16
+      %22 = arith.select %21, %arg5, %arg6 : bf16
+      tt.reduce.return %22 : bf16
+    }) {axis = 0 : i32} : (tensor<32x256x16xbf16>) -> tensor<256x16xbf16>
+    tt.store %res, %6 {cache = 1 : i32, evict = 1 : i32} : tensor<256x16xbf16>
+    tt.return
+    }
+}
+// mlir2FileCheck.py
+// CHECK-LABEL:  func.func @kernel
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: tensor<256x16x!tt.ptr<bf16, 1>>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0xFF80 : bf16
+// CHECK-DAG:       [[CST_256_:%.+]] = arith.constant 256 : index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [32, 256, 16], strides: {{.}}[[CST_256_]], 1, 1] : memref<*xbf16> to memref<32x256x16xbf16, strided<[?, 1, 1]>>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32x256x16xbf16>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<32x256x16xbf16, strided<[?, 1, 1]>> to memref<32x256x16xbf16>
+// CHECK-DAG:       [[VAR_0_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32x256x16xbf16>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tensor.empty() : tensor<256x16xbf16>
+// CHECK:           [[VAR_2_:%.+]] = linalg.fill ins([[CST_0_]] : bf16) outs([[VAR_1_]] : tensor<256x16xbf16>) -> tensor<256x16xbf16>
+// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_0_]] : tensor<32x256x16xbf16>) outs([[VAR_2_]] : tensor<256x16xbf16>) dimensions = [0]
+// CHECK:             ([[in_:%.+]]: bf16, [[init_:%.+]]: bf16) {
+// CHECK:               [[VAR_3_:%.+]] = arith.maximumf [[in_]], [[init_]] : bf16
+// CHECK:               linalg.yield [[VAR_3_]] : bf16
+// CHECK:             }
+// CHECK:           tt.store [[PARAM_1_]], [[VAR_reduced_]] {cache = 1 : i32, evict = 1 : i32} : tensor<256x16xbf16>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/reducemax_32_256_bf16.mlir
+++ b/test/Conversion/StructuredToMemref/reducemax_32_256_bf16.mlir
@@ -6,26 +6,26 @@ module {
     // offset calculations
     %0 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
     %c256 = arith.constant 256 : i32
-    %ct256 = tt.splat %c256 : (i32) -> tensor<32xi32>
+    %ct256 = tt.splat %c256 : i32 -> tensor<32xi32>
     %ws = arith.muli %ct256, %0 : tensor<32xi32>
-    %1 = tt.expand_dims %ws {axis = 1 : i32} : (tensor<32xi32>) -> tensor<32x1xi32>
-    %m2 = tt.broadcast %1 : (tensor<32x1xi32>) -> tensor<32x256xi32>
-    %100 = tt.expand_dims %m2 {axis = 2 : i32} : (tensor<32x256xi32>) -> tensor<32x256x1xi32>
-    %moff = tt.broadcast %100 : (tensor<32x256x1xi32>) -> tensor<32x256x16xi32>
+    %1 = tt.expand_dims %ws {axis = 1 : i32} : tensor<32xi32> -> tensor<32x1xi32>
+    %m2 = tt.broadcast %1 : tensor<32x1xi32> -> tensor<32x256xi32>
+    %100 = tt.expand_dims %m2 {axis = 2 : i32} : tensor<32x256xi32> -> tensor<32x256x1xi32>
+    %moff = tt.broadcast %100 : tensor<32x256x1xi32> -> tensor<32x256x16xi32>
     %33 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
-    %34 = tt.expand_dims %33 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
-    %k2 = tt.broadcast %34 : (tensor<1x256xi32>) -> tensor<32x256xi32>
-    %200 = tt.expand_dims %k2 {axis = 2 : i32} : (tensor<32x256xi32>) -> tensor<32x256x1xi32>
-    %koff = tt.broadcast %200 : (tensor<32x256x1xi32>) -> tensor<32x256x16xi32>
+    %34 = tt.expand_dims %33 {axis = 0 : i32} : tensor<256xi32> -> tensor<1x256xi32>
+    %k2 = tt.broadcast %34 : tensor<1x256xi32> -> tensor<32x256xi32>
+    %200 = tt.expand_dims %k2 {axis = 2 : i32} : tensor<32x256xi32> -> tensor<32x256x1xi32>
+    %koff = tt.broadcast %200 : tensor<32x256x1xi32> -> tensor<32x256x16xi32>
     %23 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
-    %24 = tt.expand_dims %23 {axis = 0 : i32} : (tensor<16xi32>) -> tensor<1x16xi32>
-    %n2 = tt.broadcast %24 : (tensor<1x16xi32>) -> tensor<256x16xi32>
-    %300 = tt.expand_dims %n2 {axis = 0 : i32} : (tensor<256x16xi32>) -> tensor<1x256x16xi32>
-    %noff = tt.broadcast %300 : (tensor<1x256x16xi32>) -> tensor<32x256x16xi32>
+    %24 = tt.expand_dims %23 {axis = 0 : i32} : tensor<16xi32> -> tensor<1x16xi32>
+    %n2 = tt.broadcast %24 : tensor<1x16xi32> -> tensor<256x16xi32>
+    %300 = tt.expand_dims %n2 {axis = 0 : i32} : tensor<256x16xi32> -> tensor<1x256x16xi32>
+    %noff = tt.broadcast %300 : tensor<1x256x16xi32> -> tensor<32x256x16xi32>
     %mkoff = arith.addi %moff, %koff : tensor<32x256x16xi32>
     %mknoff = arith.addi %mkoff, %noff : tensor<32x256x16xi32>
     // afloat pointer
-    %8 = tt.splat %afloat : (!tt.ptr<bf16>) -> tensor<32x256x16x!tt.ptr<bf16>>
+    %8 = tt.splat %afloat : !tt.ptr<bf16> -> tensor<32x256x16x!tt.ptr<bf16>>
     %9 = tt.addptr %8, %mknoff : tensor<32x256x16x!tt.ptr<bf16>>, tensor<32x256x16xi32>
     %afm = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32x256x16xbf16>
     %6 = "tt.reduce"(%afm) ({

--- a/test/Conversion/StructuredToMemref/reducesum_512_256_bf16_axis0.mlir
+++ b/test/Conversion/StructuredToMemref/reducesum_512_256_bf16_axis0.mlir
@@ -6,19 +6,19 @@ module {
     // offset calculations
     %0 = tt.make_range {end = 512 : i32, start = 0 : i32} : tensor<512xi32>
     %c256 = arith.constant 256 : i32
-    %ct256 = tt.splat %c256 : (i32) -> tensor<512xi32>
+    %ct256 = tt.splat %c256 : i32 -> tensor<512xi32>
     %ws = arith.muli %ct256, %0 : tensor<512xi32>
-    %1 = tt.expand_dims %ws {axis = 1 : i32} : (tensor<512xi32>) -> tensor<512x1xi32>
-    %moff = tt.broadcast %1 : (tensor<512x1xi32>) -> tensor<512x256xi32>
+    %1 = tt.expand_dims %ws {axis = 1 : i32} : tensor<512xi32> -> tensor<512x1xi32>
+    %moff = tt.broadcast %1 : tensor<512x1xi32> -> tensor<512x256xi32>
     %3 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
-    %4 = tt.expand_dims %3 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
-    %koff = tt.broadcast %4 : (tensor<1x256xi32>) -> tensor<512x256xi32>
+    %4 = tt.expand_dims %3 {axis = 0 : i32} : tensor<256xi32> -> tensor<1x256xi32>
+    %koff = tt.broadcast %4 : tensor<1x256xi32> -> tensor<512x256xi32>
     %mkoff = arith.addi %moff, %koff : tensor<512x256xi32>
     // afloat pointer
-    %8 = tt.splat %afloat : (!tt.ptr<bf16>) -> tensor<512x256x!tt.ptr<bf16>>
+    %8 = tt.splat %afloat : !tt.ptr<bf16> -> tensor<512x256x!tt.ptr<bf16>>
     %9 = tt.addptr %8, %mkoff : tensor<512x256x!tt.ptr<bf16>>, tensor<512x256xi32>
     // res pointer
-    %18 = tt.splat %res : (!tt.ptr<bf16>) -> tensor<256x!tt.ptr<bf16>>
+    %18 = tt.splat %res : !tt.ptr<bf16> -> tensor<256x!tt.ptr<bf16>>
     %19 = tt.addptr %18, %3 : tensor<256x!tt.ptr<bf16>>, tensor<256xi32>
     %afm = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<512x256xbf16>
     %5 = "tt.reduce"(%afm) ({

--- a/test/Conversion/StructuredToMemref/reducesum_512_256_bf16_axis0.mlir
+++ b/test/Conversion/StructuredToMemref/reducesum_512_256_bf16_axis0.mlir
@@ -1,0 +1,53 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+module {
+    tt.func @kernel(%afloat : !tt.ptr<bf16>,
+        %res : !tt.ptr<bf16>
+    ) -> () {
+    // offset calculations
+    %0 = tt.make_range {end = 512 : i32, start = 0 : i32} : tensor<512xi32>
+    %c256 = arith.constant 256 : i32
+    %ct256 = tt.splat %c256 : (i32) -> tensor<512xi32>
+    %ws = arith.muli %ct256, %0 : tensor<512xi32>
+    %1 = tt.expand_dims %ws {axis = 1 : i32} : (tensor<512xi32>) -> tensor<512x1xi32>
+    %moff = tt.broadcast %1 : (tensor<512x1xi32>) -> tensor<512x256xi32>
+    %3 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
+    %4 = tt.expand_dims %3 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
+    %koff = tt.broadcast %4 : (tensor<1x256xi32>) -> tensor<512x256xi32>
+    %mkoff = arith.addi %moff, %koff : tensor<512x256xi32>
+    // afloat pointer
+    %8 = tt.splat %afloat : (!tt.ptr<bf16>) -> tensor<512x256x!tt.ptr<bf16>>
+    %9 = tt.addptr %8, %mkoff : tensor<512x256x!tt.ptr<bf16>>, tensor<512x256xi32>
+    // res pointer
+    %18 = tt.splat %res : (!tt.ptr<bf16>) -> tensor<256x!tt.ptr<bf16>>
+    %19 = tt.addptr %18, %3 : tensor<256x!tt.ptr<bf16>>, tensor<256xi32>
+    %afm = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<512x256xbf16>
+    %5 = "tt.reduce"(%afm) ({
+    ^bb0(%arg5: bf16, %arg6: bf16):
+      %21 = arith.addf %arg5, %arg6 : bf16
+      tt.reduce.return %21 : bf16
+    }) {axis = 0 : i32} : (tensor<512x256xbf16>) -> tensor<256xbf16>
+    tt.store %19, %5 : tensor<256xbf16>
+    tt.return
+    }
+}
+// mlir2FileCheck.py
+// CHECK-LABEL:  func.func @kernel
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: memref<*xbf16>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : bf16
+// CHECK-DAG:       [[CST_256_:%.+]] = arith.constant 256 : index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [512, 256], strides: {{.}}[[CST_256_]], 1] : memref<*xbf16> to memref<512x256xbf16, strided<[?, 1]>>
+// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: [0], sizes: [256], strides: [1] : memref<*xbf16> to memref<256xbf16, strided<[1]>>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<512x256xbf16>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<512x256xbf16, strided<[?, 1]>> to memref<512x256xbf16>
+// CHECK-DAG:       [[VAR_0_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<512x256xbf16>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tensor.empty() : tensor<256xbf16>
+// CHECK:           [[VAR_2_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : bf16) outs([[VAR_1_]] : tensor<256xbf16>) -> tensor<256xbf16>
+// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_0_]] : tensor<512x256xbf16>) outs([[VAR_2_]] : tensor<256xbf16>) dimensions = [0]
+// CHECK:             ([[in_:%.+]]: bf16, [[init_:%.+]]: bf16) {
+// CHECK:               [[VAR_3_:%.+]] = arith.addf [[in_]], [[init_]] : bf16
+// CHECK:               linalg.yield [[VAR_3_]] : bf16
+// CHECK:             }
+// CHECK:           bufferization.materialize_in_destination [[VAR_reduced_]] in writable [[VAR_reinterpret_cast_0_]] : (tensor<256xbf16>, memref<256xbf16, strided<[1]>>) -> ()
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/reducesum_512_256_bf16_axis1.mlir
+++ b/test/Conversion/StructuredToMemref/reducesum_512_256_bf16_axis1.mlir
@@ -1,0 +1,56 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+module {
+    tt.func @kernel(%afloat : !tt.ptr<bf16>,
+        %res : !tt.ptr<bf16>
+    ) -> () {
+    // offset calculations
+    %0 = tt.make_range {end = 512 : i32, start = 0 : i32} : tensor<512xi32>
+    %c256 = arith.constant 256 : i32
+    %ct256 = tt.splat %c256 : (i32) -> tensor<512xi32>
+    %ws = arith.muli %ct256, %0 : tensor<512xi32>
+    %1 = tt.expand_dims %ws {axis = 1 : i32} : (tensor<512xi32>) -> tensor<512x1xi32>
+    %moff = tt.broadcast %1 : (tensor<512x1xi32>) -> tensor<512x256xi32>
+    %3 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
+    %4 = tt.expand_dims %3 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
+    %koff = tt.broadcast %4 : (tensor<1x256xi32>) -> tensor<512x256xi32>
+    %mkoff = arith.addi %moff, %koff : tensor<512x256xi32>
+    // afloat pointer
+    %8 = tt.splat %afloat : (!tt.ptr<bf16>) -> tensor<512x256x!tt.ptr<bf16>>
+    %9 = tt.addptr %8, %mkoff : tensor<512x256x!tt.ptr<bf16>>, tensor<512x256xi32>
+    // res pointer
+    %18 = tt.splat %res : (!tt.ptr<bf16>) -> tensor<512x!tt.ptr<bf16>>
+    %19 = tt.addptr %18, %0 : tensor<512x!tt.ptr<bf16>>, tensor<512xi32>
+    %afm = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<512x256xbf16>
+    %5 = "tt.reduce"(%afm) ({
+    ^bb0(%arg5: bf16, %arg6: bf16):
+      %21 = arith.addf %arg5, %arg6 : bf16
+      tt.reduce.return %21 : bf16
+    }) {axis = 1 : i32} : (tensor<512x256xbf16>) -> tensor<512xbf16>
+    tt.store %19, %5 : tensor<512xbf16>
+    tt.return
+    }
+}
+// mlir2FileCheck.py
+// CHECK-LABEL:  func.func @kernel
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: memref<*xbf16>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : bf16
+// CHECK-DAG:       [[CST_256_:%.+]] = arith.constant 256 : index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [512, 256], strides: {{.}}[[CST_256_]], 1] : memref<*xbf16> to memref<512x256xbf16, strided<[?, 1]>>
+// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: [0], sizes: [512], strides: [1] : memref<*xbf16> to memref<512xbf16, strided<[1]>>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<512x256xbf16>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<512x256xbf16, strided<[?, 1]>> to memref<512x256xbf16>
+// CHECK-DAG:       [[VAR_0_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<512x256xbf16>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tensor.empty() : tensor<256x512xbf16>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_transposed_:%.+]] = linalg.transpose ins([[VAR_0_]] : tensor<512x256xbf16>) outs([[VAR_1_]] : tensor<256x512xbf16>) permutation = [1, 0]
+// CHECK-DAG:       [[VAR_2_:%.+]] = tensor.empty() : tensor<512xbf16>
+// CHECK:           [[VAR_3_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : bf16) outs([[VAR_2_]] : tensor<512xbf16>) -> tensor<512xbf16>
+// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_transposed_]] : tensor<256x512xbf16>) outs([[VAR_3_]] : tensor<512xbf16>) dimensions = [0]
+// CHECK:             ([[in_:%.+]]: bf16, [[init_:%.+]]: bf16) {
+// CHECK:               [[VAR_4_:%.+]] = arith.addf [[in_]], [[init_]] : bf16
+// CHECK:               linalg.yield [[VAR_4_]] : bf16
+// CHECK:             }
+// CHECK:           bufferization.materialize_in_destination [[VAR_reduced_]] in writable [[VAR_reinterpret_cast_0_]] : (tensor<512xbf16>, memref<512xbf16, strided<[1]>>) -> ()
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/reducesum_512_256_bf16_axis1.mlir
+++ b/test/Conversion/StructuredToMemref/reducesum_512_256_bf16_axis1.mlir
@@ -6,19 +6,19 @@ module {
     // offset calculations
     %0 = tt.make_range {end = 512 : i32, start = 0 : i32} : tensor<512xi32>
     %c256 = arith.constant 256 : i32
-    %ct256 = tt.splat %c256 : (i32) -> tensor<512xi32>
+    %ct256 = tt.splat %c256 : i32 -> tensor<512xi32>
     %ws = arith.muli %ct256, %0 : tensor<512xi32>
-    %1 = tt.expand_dims %ws {axis = 1 : i32} : (tensor<512xi32>) -> tensor<512x1xi32>
-    %moff = tt.broadcast %1 : (tensor<512x1xi32>) -> tensor<512x256xi32>
+    %1 = tt.expand_dims %ws {axis = 1 : i32} : tensor<512xi32> -> tensor<512x1xi32>
+    %moff = tt.broadcast %1 : tensor<512x1xi32> -> tensor<512x256xi32>
     %3 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
-    %4 = tt.expand_dims %3 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
-    %koff = tt.broadcast %4 : (tensor<1x256xi32>) -> tensor<512x256xi32>
+    %4 = tt.expand_dims %3 {axis = 0 : i32} : tensor<256xi32> -> tensor<1x256xi32>
+    %koff = tt.broadcast %4 : tensor<1x256xi32> -> tensor<512x256xi32>
     %mkoff = arith.addi %moff, %koff : tensor<512x256xi32>
     // afloat pointer
-    %8 = tt.splat %afloat : (!tt.ptr<bf16>) -> tensor<512x256x!tt.ptr<bf16>>
+    %8 = tt.splat %afloat : !tt.ptr<bf16> -> tensor<512x256x!tt.ptr<bf16>>
     %9 = tt.addptr %8, %mkoff : tensor<512x256x!tt.ptr<bf16>>, tensor<512x256xi32>
     // res pointer
-    %18 = tt.splat %res : (!tt.ptr<bf16>) -> tensor<512x!tt.ptr<bf16>>
+    %18 = tt.splat %res : !tt.ptr<bf16> -> tensor<512x!tt.ptr<bf16>>
     %19 = tt.addptr %18, %0 : tensor<512x!tt.ptr<bf16>>, tensor<512xi32>
     %afm = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<512x256xbf16>
     %5 = "tt.reduce"(%afm) ({

--- a/test/Conversion/StructuredToMemref/reducesum_512_256_f32_axis0.mlir
+++ b/test/Conversion/StructuredToMemref/reducesum_512_256_f32_axis0.mlir
@@ -1,0 +1,53 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+module {
+    tt.func @kernel(%afloat : !tt.ptr<f32>,
+        %res : !tt.ptr<f32>
+    ) -> () {
+    // offset calculations
+    %0 = tt.make_range {end = 512 : i32, start = 0 : i32} : tensor<512xi32>
+    %c256 = arith.constant 256 : i32
+    %ct256 = tt.splat %c256 : (i32) -> tensor<512xi32>
+    %ws = arith.muli %ct256, %0 : tensor<512xi32>
+    %1 = tt.expand_dims %ws {axis = 1 : i32} : (tensor<512xi32>) -> tensor<512x1xi32>
+    %moff = tt.broadcast %1 : (tensor<512x1xi32>) -> tensor<512x256xi32>
+    %3 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
+    %4 = tt.expand_dims %3 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
+    %koff = tt.broadcast %4 : (tensor<1x256xi32>) -> tensor<512x256xi32>
+    %mkoff = arith.addi %moff, %koff : tensor<512x256xi32>
+    // afloat pointer
+    %8 = tt.splat %afloat : (!tt.ptr<f32>) -> tensor<512x256x!tt.ptr<f32>>
+    %9 = tt.addptr %8, %mkoff : tensor<512x256x!tt.ptr<f32>>, tensor<512x256xi32>
+    // res pointer
+    %18 = tt.splat %res : (!tt.ptr<f32>) -> tensor<256x!tt.ptr<f32>>
+    %19 = tt.addptr %18, %3 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
+    %afm = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<512x256xf32>
+    %5 = "tt.reduce"(%afm) ({
+    ^bb0(%arg5: f32, %arg6: f32):
+      %21 = arith.addf %arg5, %arg6 : f32
+      tt.reduce.return %21 : f32
+    }) {axis = 0 : i32} : (tensor<512x256xf32>) -> tensor<256xf32>
+    tt.store %19, %5 : tensor<256xf32>
+    tt.return
+    }
+}
+// mlir2FileCheck.py
+// CHECK-LABEL:  func.func @kernel
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG:       [[CST_256_:%.+]] = arith.constant 256 : index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [512, 256], strides: {{.}}[[CST_256_]], 1] : memref<*xf32> to memref<512x256xf32, strided<[?, 1]>>
+// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: [0], sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1]>>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<512x256xf32>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<512x256xf32, strided<[?, 1]>> to memref<512x256xf32>
+// CHECK-DAG:       [[VAR_0_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<512x256xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tensor.empty() : tensor<256xf32>
+// CHECK:           [[VAR_2_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[VAR_1_]] : tensor<256xf32>) -> tensor<256xf32>
+// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_0_]] : tensor<512x256xf32>) outs([[VAR_2_]] : tensor<256xf32>) dimensions = [0]
+// CHECK:             ([[in_:%.+]]: f32, [[init_:%.+]]: f32) {
+// CHECK:               [[VAR_3_:%.+]] = arith.addf [[in_]], [[init_]] : f32
+// CHECK:               linalg.yield [[VAR_3_]] : f32
+// CHECK:             }
+// CHECK:           bufferization.materialize_in_destination [[VAR_reduced_]] in writable [[VAR_reinterpret_cast_0_]] : (tensor<256xf32>, memref<256xf32, strided<[1]>>) -> ()
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/reducesum_512_256_f32_axis0.mlir
+++ b/test/Conversion/StructuredToMemref/reducesum_512_256_f32_axis0.mlir
@@ -6,19 +6,19 @@ module {
     // offset calculations
     %0 = tt.make_range {end = 512 : i32, start = 0 : i32} : tensor<512xi32>
     %c256 = arith.constant 256 : i32
-    %ct256 = tt.splat %c256 : (i32) -> tensor<512xi32>
+    %ct256 = tt.splat %c256 : i32 -> tensor<512xi32>
     %ws = arith.muli %ct256, %0 : tensor<512xi32>
-    %1 = tt.expand_dims %ws {axis = 1 : i32} : (tensor<512xi32>) -> tensor<512x1xi32>
-    %moff = tt.broadcast %1 : (tensor<512x1xi32>) -> tensor<512x256xi32>
+    %1 = tt.expand_dims %ws {axis = 1 : i32} : tensor<512xi32> -> tensor<512x1xi32>
+    %moff = tt.broadcast %1 : tensor<512x1xi32> -> tensor<512x256xi32>
     %3 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
-    %4 = tt.expand_dims %3 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
-    %koff = tt.broadcast %4 : (tensor<1x256xi32>) -> tensor<512x256xi32>
+    %4 = tt.expand_dims %3 {axis = 0 : i32} : tensor<256xi32> -> tensor<1x256xi32>
+    %koff = tt.broadcast %4 : tensor<1x256xi32> -> tensor<512x256xi32>
     %mkoff = arith.addi %moff, %koff : tensor<512x256xi32>
     // afloat pointer
-    %8 = tt.splat %afloat : (!tt.ptr<f32>) -> tensor<512x256x!tt.ptr<f32>>
+    %8 = tt.splat %afloat : !tt.ptr<f32> -> tensor<512x256x!tt.ptr<f32>>
     %9 = tt.addptr %8, %mkoff : tensor<512x256x!tt.ptr<f32>>, tensor<512x256xi32>
     // res pointer
-    %18 = tt.splat %res : (!tt.ptr<f32>) -> tensor<256x!tt.ptr<f32>>
+    %18 = tt.splat %res : !tt.ptr<f32> -> tensor<256x!tt.ptr<f32>>
     %19 = tt.addptr %18, %3 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
     %afm = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<512x256xf32>
     %5 = "tt.reduce"(%afm) ({

--- a/test/Conversion/StructuredToMemref/reducesum_512_256_f32_axis1.mlir
+++ b/test/Conversion/StructuredToMemref/reducesum_512_256_f32_axis1.mlir
@@ -6,19 +6,19 @@ module {
     // offset calculations
     %0 = tt.make_range {end = 512 : i32, start = 0 : i32} : tensor<512xi32>
     %c256 = arith.constant 256 : i32
-    %ct256 = tt.splat %c256 : (i32) -> tensor<512xi32>
+    %ct256 = tt.splat %c256 : i32 -> tensor<512xi32>
     %ws = arith.muli %ct256, %0 : tensor<512xi32>
-    %1 = tt.expand_dims %ws {axis = 1 : i32} : (tensor<512xi32>) -> tensor<512x1xi32>
-    %moff = tt.broadcast %1 : (tensor<512x1xi32>) -> tensor<512x256xi32>
+    %1 = tt.expand_dims %ws {axis = 1 : i32} : tensor<512xi32> -> tensor<512x1xi32>
+    %moff = tt.broadcast %1 : tensor<512x1xi32> -> tensor<512x256xi32>
     %3 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
-    %4 = tt.expand_dims %3 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
-    %koff = tt.broadcast %4 : (tensor<1x256xi32>) -> tensor<512x256xi32>
+    %4 = tt.expand_dims %3 {axis = 0 : i32} : tensor<256xi32> -> tensor<1x256xi32>
+    %koff = tt.broadcast %4 : tensor<1x256xi32> -> tensor<512x256xi32>
     %mkoff = arith.addi %moff, %koff : tensor<512x256xi32>
     // afloat pointer
-    %8 = tt.splat %afloat : (!tt.ptr<f32>) -> tensor<512x256x!tt.ptr<f32>>
+    %8 = tt.splat %afloat : !tt.ptr<f32> -> tensor<512x256x!tt.ptr<f32>>
     %9 = tt.addptr %8, %mkoff : tensor<512x256x!tt.ptr<f32>>, tensor<512x256xi32>
     // res pointer
-    %18 = tt.splat %res : (!tt.ptr<f32>) -> tensor<512x!tt.ptr<f32>>
+    %18 = tt.splat %res : !tt.ptr<f32> -> tensor<512x!tt.ptr<f32>>
     %19 = tt.addptr %18, %0 : tensor<512x!tt.ptr<f32>>, tensor<512xi32>
     %afm = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<512x256xf32>
     %5 = "tt.reduce"(%afm) ({

--- a/test/Conversion/StructuredToMemref/reducesum_512_256_f32_axis1.mlir
+++ b/test/Conversion/StructuredToMemref/reducesum_512_256_f32_axis1.mlir
@@ -1,0 +1,56 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+module {
+    tt.func @kernel(%afloat : !tt.ptr<f32>,
+        %res : !tt.ptr<f32>
+    ) -> () {
+    // offset calculations
+    %0 = tt.make_range {end = 512 : i32, start = 0 : i32} : tensor<512xi32>
+    %c256 = arith.constant 256 : i32
+    %ct256 = tt.splat %c256 : (i32) -> tensor<512xi32>
+    %ws = arith.muli %ct256, %0 : tensor<512xi32>
+    %1 = tt.expand_dims %ws {axis = 1 : i32} : (tensor<512xi32>) -> tensor<512x1xi32>
+    %moff = tt.broadcast %1 : (tensor<512x1xi32>) -> tensor<512x256xi32>
+    %3 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
+    %4 = tt.expand_dims %3 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
+    %koff = tt.broadcast %4 : (tensor<1x256xi32>) -> tensor<512x256xi32>
+    %mkoff = arith.addi %moff, %koff : tensor<512x256xi32>
+    // afloat pointer
+    %8 = tt.splat %afloat : (!tt.ptr<f32>) -> tensor<512x256x!tt.ptr<f32>>
+    %9 = tt.addptr %8, %mkoff : tensor<512x256x!tt.ptr<f32>>, tensor<512x256xi32>
+    // res pointer
+    %18 = tt.splat %res : (!tt.ptr<f32>) -> tensor<512x!tt.ptr<f32>>
+    %19 = tt.addptr %18, %0 : tensor<512x!tt.ptr<f32>>, tensor<512xi32>
+    %afm = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<512x256xf32>
+    %5 = "tt.reduce"(%afm) ({
+    ^bb0(%arg5: f32, %arg6: f32):
+      %21 = arith.addf %arg5, %arg6 : f32
+      tt.reduce.return %21 : f32
+    }) {axis = 1 : i32} : (tensor<512x256xf32>) -> tensor<512xf32>
+    tt.store %19, %5 : tensor<512xf32>
+    tt.return
+    }
+}
+// mlir2FileCheck.py
+// CHECK-LABEL:  func.func @kernel
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG:       [[CST_256_:%.+]] = arith.constant 256 : index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [512, 256], strides: {{.}}[[CST_256_]], 1] : memref<*xf32> to memref<512x256xf32, strided<[?, 1]>>
+// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: [0], sizes: [512], strides: [1] : memref<*xf32> to memref<512xf32, strided<[1]>>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<512x256xf32>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<512x256xf32, strided<[?, 1]>> to memref<512x256xf32>
+// CHECK-DAG:       [[VAR_0_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<512x256xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tensor.empty() : tensor<256x512xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_transposed_:%.+]] = linalg.transpose ins([[VAR_0_]] : tensor<512x256xf32>) outs([[VAR_1_]] : tensor<256x512xf32>) permutation = [1, 0]
+// CHECK-DAG:       [[VAR_2_:%.+]] = tensor.empty() : tensor<512xf32>
+// CHECK:           [[VAR_3_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[VAR_2_]] : tensor<512xf32>) -> tensor<512xf32>
+// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_transposed_]] : tensor<256x512xf32>) outs([[VAR_3_]] : tensor<512xf32>) dimensions = [0]
+// CHECK:             ([[in_:%.+]]: f32, [[init_:%.+]]: f32) {
+// CHECK:               [[VAR_4_:%.+]] = arith.addf [[in_]], [[init_]] : f32
+// CHECK:               linalg.yield [[VAR_4_]] : f32
+// CHECK:             }
+// CHECK:           bufferization.materialize_in_destination [[VAR_reduced_]] in writable [[VAR_reinterpret_cast_0_]] : (tensor<512xf32>, memref<512xf32, strided<[1]>>) -> ()
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/reducesum_middle_dim.mlir
+++ b/test/Conversion/StructuredToMemref/reducesum_middle_dim.mlir
@@ -1,0 +1,60 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+module {
+    tt.func @kernel(%afloat : !tt.ptr<bf16>,
+        %res : !tt.ptr<bf16>,
+        %out: tensor<32x16x!tt.ptr<bf16>>
+    ) -> () {
+    // offset calculations
+    %0 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %c256 = arith.constant 256 : i32
+    %ct256 = tt.splat %c256 : (i32) -> tensor<32xi32>
+    %ws = arith.muli %ct256, %0 : tensor<32xi32>
+    %1 = tt.expand_dims %ws {axis = 1 : i32} : (tensor<32xi32>) -> tensor<32x1xi32>
+    %m2 = tt.broadcast %1 : (tensor<32x1xi32>) -> tensor<32x256xi32>
+    %100 = tt.expand_dims %m2 {axis = 2 : i32} : (tensor<32x256xi32>) -> tensor<32x256x1xi32>
+    %moff = tt.broadcast %100 : (tensor<32x256x1xi32>) -> tensor<32x256x16xi32>
+    %33 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
+    %34 = tt.expand_dims %33 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
+    %k2 = tt.broadcast %34 : (tensor<1x256xi32>) -> tensor<32x256xi32>
+    %200 = tt.expand_dims %k2 {axis = 2 : i32} : (tensor<32x256xi32>) -> tensor<32x256x1xi32>
+    %koff = tt.broadcast %200 : (tensor<32x256x1xi32>) -> tensor<32x256x16xi32>
+    %23 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %24 = tt.expand_dims %23 {axis = 0 : i32} : (tensor<16xi32>) -> tensor<1x16xi32>
+    %n2 = tt.broadcast %24 : (tensor<1x16xi32>) -> tensor<256x16xi32>
+    %300 = tt.expand_dims %n2 {axis = 0 : i32} : (tensor<256x16xi32>) -> tensor<1x256x16xi32>
+    %noff = tt.broadcast %300 : (tensor<1x256x16xi32>) -> tensor<32x256x16xi32>
+    %mkoff = arith.addi %moff, %koff : tensor<32x256x16xi32>
+    %mknoff = arith.addi %mkoff, %noff : tensor<32x256x16xi32>
+    // afloat pointer
+    %8 = tt.splat %afloat : (!tt.ptr<bf16>) -> tensor<32x256x16x!tt.ptr<bf16>>
+    %9 = tt.addptr %8, %mknoff : tensor<32x256x16x!tt.ptr<bf16>>, tensor<32x256x16xi32>
+    %afm = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32x256x16xbf16>
+    %5 = "tt.reduce"(%afm) ({
+    ^bb0(%arg5: bf16, %arg6: bf16):
+      %21 = arith.addf %arg5, %arg6 : bf16
+      tt.reduce.return %21 : bf16
+    }) {axis = 1 : i32} : (tensor<32x256x16xbf16>) -> tensor<32x16xbf16>
+    tt.store %out, %5 : tensor<32x16xbf16>
+    tt.return
+    }
+}
+// mlir2FileCheck.py
+// CHECK-LABEL:  func.func @kernel
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: memref<*xbf16>, [[PARAM_2_:%.+]]: tensor<32x16x!tt.ptr<bf16, 1>>, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : bf16
+// CHECK-DAG:       [[CST_256_:%.+]] = arith.constant 256 : index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [32, 256, 16], strides: {{.}}[[CST_256_]], 1, 1] : memref<*xbf16> to memref<32x256x16xbf16, strided<[?, 1, 1]>>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32x256x16xbf16>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<32x256x16xbf16, strided<[?, 1, 1]>> to memref<32x256x16xbf16>
+// CHECK-DAG:       [[VAR_0_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32x256x16xbf16>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tensor.empty() : tensor<32x16xbf16>
+// CHECK:           [[VAR_2_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : bf16) outs([[VAR_1_]] : tensor<32x16xbf16>) -> tensor<32x16xbf16>
+// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_0_]] : tensor<32x256x16xbf16>) outs([[VAR_2_]] : tensor<32x16xbf16>) dimensions = [1]
+// CHECK:             ([[in_:%.+]]: bf16, [[init_:%.+]]: bf16) {
+// CHECK:               [[VAR_3_:%.+]] = arith.addf [[in_]], [[init_]] : bf16
+// CHECK:               linalg.yield [[VAR_3_]] : bf16
+// CHECK:             }
+// CHECK:           tt.store [[PARAM_2_]], [[VAR_reduced_]] {cache = 1 : i32, evict = 1 : i32} : tensor<32x16xbf16>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/reducesum_middle_dim.mlir
+++ b/test/Conversion/StructuredToMemref/reducesum_middle_dim.mlir
@@ -7,26 +7,26 @@ module {
     // offset calculations
     %0 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
     %c256 = arith.constant 256 : i32
-    %ct256 = tt.splat %c256 : (i32) -> tensor<32xi32>
+    %ct256 = tt.splat %c256 : i32 -> tensor<32xi32>
     %ws = arith.muli %ct256, %0 : tensor<32xi32>
-    %1 = tt.expand_dims %ws {axis = 1 : i32} : (tensor<32xi32>) -> tensor<32x1xi32>
-    %m2 = tt.broadcast %1 : (tensor<32x1xi32>) -> tensor<32x256xi32>
-    %100 = tt.expand_dims %m2 {axis = 2 : i32} : (tensor<32x256xi32>) -> tensor<32x256x1xi32>
-    %moff = tt.broadcast %100 : (tensor<32x256x1xi32>) -> tensor<32x256x16xi32>
+    %1 = tt.expand_dims %ws {axis = 1 : i32} : tensor<32xi32> -> tensor<32x1xi32>
+    %m2 = tt.broadcast %1 : tensor<32x1xi32> -> tensor<32x256xi32>
+    %100 = tt.expand_dims %m2 {axis = 2 : i32} : tensor<32x256xi32> -> tensor<32x256x1xi32>
+    %moff = tt.broadcast %100 : tensor<32x256x1xi32> -> tensor<32x256x16xi32>
     %33 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
-    %34 = tt.expand_dims %33 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
-    %k2 = tt.broadcast %34 : (tensor<1x256xi32>) -> tensor<32x256xi32>
-    %200 = tt.expand_dims %k2 {axis = 2 : i32} : (tensor<32x256xi32>) -> tensor<32x256x1xi32>
-    %koff = tt.broadcast %200 : (tensor<32x256x1xi32>) -> tensor<32x256x16xi32>
+    %34 = tt.expand_dims %33 {axis = 0 : i32} : tensor<256xi32> -> tensor<1x256xi32>
+    %k2 = tt.broadcast %34 : tensor<1x256xi32> -> tensor<32x256xi32>
+    %200 = tt.expand_dims %k2 {axis = 2 : i32} : tensor<32x256xi32> -> tensor<32x256x1xi32>
+    %koff = tt.broadcast %200 : tensor<32x256x1xi32> -> tensor<32x256x16xi32>
     %23 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
-    %24 = tt.expand_dims %23 {axis = 0 : i32} : (tensor<16xi32>) -> tensor<1x16xi32>
-    %n2 = tt.broadcast %24 : (tensor<1x16xi32>) -> tensor<256x16xi32>
-    %300 = tt.expand_dims %n2 {axis = 0 : i32} : (tensor<256x16xi32>) -> tensor<1x256x16xi32>
-    %noff = tt.broadcast %300 : (tensor<1x256x16xi32>) -> tensor<32x256x16xi32>
+    %24 = tt.expand_dims %23 {axis = 0 : i32} : tensor<16xi32> -> tensor<1x16xi32>
+    %n2 = tt.broadcast %24 : tensor<1x16xi32> -> tensor<256x16xi32>
+    %300 = tt.expand_dims %n2 {axis = 0 : i32} : tensor<256x16xi32> -> tensor<1x256x16xi32>
+    %noff = tt.broadcast %300 : tensor<1x256x16xi32> -> tensor<32x256x16xi32>
     %mkoff = arith.addi %moff, %koff : tensor<32x256x16xi32>
     %mknoff = arith.addi %mkoff, %noff : tensor<32x256x16xi32>
     // afloat pointer
-    %8 = tt.splat %afloat : (!tt.ptr<bf16>) -> tensor<32x256x16x!tt.ptr<bf16>>
+    %8 = tt.splat %afloat : !tt.ptr<bf16> -> tensor<32x256x16x!tt.ptr<bf16>>
     %9 = tt.addptr %8, %mknoff : tensor<32x256x16x!tt.ptr<bf16>>, tensor<32x256x16xi32>
     %afm = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32x256x16xbf16>
     %5 = "tt.reduce"(%afm) ({

--- a/test/Conversion/StructuredToMemref/reducesum_scalar.mlir
+++ b/test/Conversion/StructuredToMemref/reducesum_scalar.mlir
@@ -3,7 +3,7 @@ module {
   tt.func @kernel(%afloat : !tt.ptr<bf16>, %res : !tt.ptr<bf16>)
   {
     %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
-    %1 = tt.splat %afloat : (!tt.ptr<bf16>) -> tensor<128x!tt.ptr<bf16>>
+    %1 = tt.splat %afloat : !tt.ptr<bf16> -> tensor<128x!tt.ptr<bf16>>
     %2 = tt.addptr %1, %0 : tensor<128x!tt.ptr<bf16>>, tensor<128xi32>
     %afm = tt.load %2 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128xbf16>
     %3 = "tt.reduce"(%afm) ({

--- a/test/Conversion/StructuredToMemref/reducesum_scalar.mlir
+++ b/test/Conversion/StructuredToMemref/reducesum_scalar.mlir
@@ -1,0 +1,39 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+module {
+  tt.func @kernel(%afloat : !tt.ptr<bf16>, %res : !tt.ptr<bf16>)
+  {
+    %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %1 = tt.splat %afloat : (!tt.ptr<bf16>) -> tensor<128x!tt.ptr<bf16>>
+    %2 = tt.addptr %1, %0 : tensor<128x!tt.ptr<bf16>>, tensor<128xi32>
+    %afm = tt.load %2 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128xbf16>
+    %3 = "tt.reduce"(%afm) ({
+    ^bb0(%arg5: bf16, %arg6: bf16):
+      %21 = arith.addf %arg5, %arg6 : bf16
+      tt.reduce.return %21 : bf16
+    }) {axis = 0 : i32} : (tensor<128xbf16>) -> bf16
+    tt.store %res, %3 : bf16
+    tt.return
+  }
+}
+
+// CHECK-LABEL:  func.func @kernel
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: memref<*xbf16>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: [0], sizes: [1], strides: [1] : memref<*xbf16> to memref<1xbf16, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [128], strides: [1] : memref<*xbf16> to memref<128xbf16, strided<[1]>>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<128xbf16>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_0_]], [[RES_]] : memref<128xbf16, strided<[1]>> to memref<128xbf16>
+// CHECK-DAG:       [[VAR_0_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<128xbf16>
+// CHECK-DAG:       [[VAR_1_:%.+]] = bufferization.alloc_tensor() : tensor<f32>
+// CHECK:           [[VAR_inserted_:%.+]] = tensor.insert [[CST_0_dot_000000_]] into [[VAR_1_]][] : tensor<f32>
+// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_0_]] : tensor<128xbf16>) outs([[VAR_inserted_]] : tensor<f32>) dimensions = [0]
+// CHECK:             ([[in_:%.+]]: bf16, [[init_:%.+]]: f32) {
+// CHECK:               [[VAR_3_:%.+]] = arith.extf [[in_]] : bf16 to f32
+// CHECK:               [[VAR_4_:%.+]] = arith.addf [[VAR_3_]], [[init_]] : f32
+// CHECK:               linalg.yield [[VAR_4_]] : f32
+// CHECK:             }
+// CHECK:           [[VAR_extracted_:%.+]] = tensor.extract [[VAR_reduced_]][] : tensor<f32>
+// CHECK:           [[VAR_2_:%.+]] = arith.truncf [[VAR_extracted_]] : f32 to bf16
+// CHECK:           affine.store [[VAR_2_]], [[VAR_reinterpret_cast_]][0] : memref<1xbf16, strided<[1], offset: ?>>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/scalar_store_loop.mlir
+++ b/test/Conversion/StructuredToMemref/scalar_store_loop.mlir
@@ -1,0 +1,35 @@
+// RUN: triton-shared-opt --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+
+module {
+  func.func @reduce_kernel_2d_0d(%arg0: !tt.ptr<f32, 1> {tt.divisibility = 16 : i32}, %arg1: i32, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32, %arg6: i32) {
+    %c8_i32 = arith.constant 8 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %0 = scf.for %arg7 = %c0_i32 to %c8_i32 step %c1_i32 iter_args(%arg8 = %arg0) -> (!tt.ptr<f32, 1>)  : i32 {
+      %1 = arith.sitofp %arg7 : i32 to f32
+      tt.store %arg8, %1 {cache = 1 : i32, evict = 1 : i32} : f32
+      %2 = tt.addptr %arg8, %c1_i32 : !tt.ptr<f32, 1>, i32
+      scf.yield %2 : !tt.ptr<f32, 1>
+    }
+    return
+  }
+}
+
+// CHECK-LABEL:  func.func @reduce_kernel_2d_0d
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32> {tt.divisibility = 16 : i32}, [[PARAM_1_:%.+]]: i32, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : index
+// CHECK-DAG:       [[CST_1_1_:%.+]] = arith.constant 1 : i32
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : i32
+// CHECK-DAG:       [[CST_8_:%.+]] = arith.constant 8 : i32
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_0_:%.+]] = scf.for [[VAR_arg7_:%.+]] = [[CST_0_]] to [[CST_8_]] step [[CST_1_1_]] iter_args([[VAR_arg8_:%.+]] = [[VAR_reinterpret_cast_]]) -> (memref<1xf32, strided<[1], offset: ?>>)  : i32 {
+// CHECK-DAG:         [[VAR_1_:%.+]] = arith.sitofp [[VAR_arg7_]] : i32 to f32
+// CHECK:             affine.store [[VAR_1_]], [[VAR_arg8_]][0] : memref<1xf32, strided<[1], offset: ?>>
+// CHECK:             [[base_buffer_:%.+]], [[offset_:%.+]], [[sizes_:%.+]], [[VAR_strides_:%.+]] = memref.extract_strided_metadata [[VAR_arg8_]] : memref<1xf32, strided<[1], offset: ?>> -> memref<f32>, index, index, index
+// CHECK:             [[VAR_2_:%.+]] = arith.addi [[offset_]], [[CST_1_]] : index
+// CHECK:             [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[base_buffer_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [1], strides: [1] : memref<f32> to memref<1xf32, strided<[1], offset: ?>>
+// CHECK:             scf.yield [[VAR_reinterpret_cast_0_]] : memref<1xf32, strided<[1], offset: ?>>
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/scalar_store_loop_iterargs.mlir
+++ b/test/Conversion/StructuredToMemref/scalar_store_loop_iterargs.mlir
@@ -1,0 +1,49 @@
+// RUN: triton-shared-opt --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+
+module {
+  func.func @reduce_kernel_2d_0d1d2de3de(%arg0: !tt.ptr<f32, 1> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32, 1> {tt.divisibility = 16 : i32}, %arg2: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 16 : i32}, %arg3: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 16 : i32}, %arg4: i32, %arg5: i32, %arg6: i32, %arg7: i32, %arg8: i32, %arg9: i32) {
+    %c1_i32 = arith.constant 1 : i32
+    %c5_i32 = arith.constant 5 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %0 = arith.index_cast %arg7 : i32 to index
+    %1 = tt.addptr %arg1, %arg7 : !tt.ptr<f32, 1>, i32
+    %2 = arith.sitofp %arg7 : i32 to f32
+    %3:2 = scf.for %arg10 = %c0_i32 to %c5_i32 step %c1_i32 iter_args(%arg11 = %1, %arg12 = %0) -> (!tt.ptr<f32, 1>, index)  : i32 {
+      tt.store %arg11, %2 {cache = 1 : i32, evict = 1 : i32} : f32
+      %4 = tt.addptr %arg11, %arg10 : !tt.ptr<f32, 1>, i32
+      %5 = arith.index_cast %arg10 : i32 to index
+      %6 = arith.addi %arg12, %5 : index
+      scf.yield %4, %6 : !tt.ptr<f32, 1>, index
+    }
+    return
+  }
+}
+
+// CHECK-LABEL:  func.func @reduce_kernel_2d_0d1d2de3de
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32> {tt.divisibility = 16 : i32}, [[PARAM_1_:%.+]]: memref<*xf32> {tt.divisibility = 16 : i32}, [[PARAM_2_:%.+]]: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 16 : i32}, [[PARAM_3_:%.+]]: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 16 : i32}, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : i32
+// CHECK-DAG:       [[CST_5_:%.+]] = arith.constant 5 : i32
+// CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : i32
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: [0], sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_0_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
+// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
+// CHECK:           [[base_buffer_:%.+]], [[offset_:%.+]], [[sizes_:%.+]], [[VAR_strides_:%.+]] = memref.extract_strided_metadata [[VAR_reinterpret_cast_]] : memref<1xf32, strided<[1], offset: ?>> -> memref<f32>, index, index, index
+// CHECK:           [[VAR_2_:%.+]] = arith.addi [[offset_]], [[VAR_1_]] : index
+// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[base_buffer_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [1], strides: [1] : memref<f32> to memref<1xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.sitofp [[PARAM_7_]] : i32 to f32
+// CHECK-DAG:       [[VAR_4_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
+// CHECK:           [[VAR_5_:%.+]]:3 = scf.for [[VAR_arg10_:%.+]] = [[CST_0_]] to [[CST_5_]] step [[CST_1_]] iter_args([[VAR_arg11_:%.+]] = [[VAR_reinterpret_cast_0_]], [[VAR_arg12_:%.+]] = [[VAR_0_]], [[VAR_arg13_:%.+]] = [[VAR_4_]]) -> (memref<1xf32, strided<[1], offset: ?>>, index, index)  : i32 {
+// CHECK:             affine.store [[VAR_3_]], [[VAR_arg11_]][0] : memref<1xf32, strided<[1], offset: ?>>
+// CHECK:             [[VAR_6_:%.+]] = arith.index_cast [[VAR_arg10_]] : i32 to index
+// CHECK:             [[base_buffer_1_:%.+]], [[offset_2_:%.+]], [[sizes_3_:%.+]], [[VAR_strides_4_:%.+]] = memref.extract_strided_metadata [[VAR_arg11_]] : memref<1xf32, strided<[1], offset: ?>> -> memref<f32>, index, index, index
+// CHECK:             [[VAR_7_:%.+]] = arith.addi [[offset_2_]], [[VAR_6_]] : index
+// CHECK-DAG:         [[VAR_reinterpret_cast_5_:%.+]] = memref.reinterpret_cast [[base_buffer_1_]] to offset: {{.}}[[VAR_7_]]{{.}}, sizes: [1], strides: [1] : memref<f32> to memref<1xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_8_:%.+]] = arith.index_cast [[VAR_arg10_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_9_:%.+]] = arith.addi [[VAR_arg12_]], [[VAR_8_]] : index
+// CHECK-DAG:         [[VAR_10_:%.+]] = arith.index_cast [[VAR_arg10_]] : i32 to index
+// CHECK:             [[VAR_11_:%.+]] = arith.addi [[VAR_arg13_]], [[VAR_10_]] : index
+// CHECK:             scf.yield [[VAR_reinterpret_cast_5_]], [[VAR_9_]], [[VAR_11_]] : memref<1xf32, strided<[1], offset: ?>>, index, index
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/scalar_store_nested_loop.mlir
+++ b/test/Conversion/StructuredToMemref/scalar_store_nested_loop.mlir
@@ -1,0 +1,49 @@
+// RUN: triton-shared-opt --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+
+module {
+  func.func @reduce_kernel_2d_0d(%arg0: !tt.ptr<f32, 1> {tt.divisibility = 16 : i32}, %arg1: i32, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32, %arg6: i32) {
+    %c2_i32 = arith.constant 2 : i32
+    %c8_i32 = arith.constant 8 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %0 = tt.addptr %arg0, %arg4 : !tt.ptr<f32, 1>, i32
+    %1 = scf.for %arg7 = %c0_i32 to %c8_i32 step %c1_i32 iter_args(%arg8 = %0) -> (!tt.ptr<f32, 1>)  : i32 {
+      %2 = scf.for %arg9 = %c0_i32 to %c2_i32 step %c1_i32 iter_args(%arg10 = %arg8) -> (!tt.ptr<f32, 1>)  : i32 {
+        %3 = arith.muli %arg7, %arg9 : i32
+        %4 = arith.sitofp %3 : i32 to f32
+        tt.store %arg10, %4 {cache = 1 : i32, evict = 1 : i32} : f32
+        %5 = tt.addptr %arg10, %c1_i32 : !tt.ptr<f32, 1>, i32
+        scf.yield %5 : !tt.ptr<f32, 1>
+      }
+      scf.yield %2 : !tt.ptr<f32, 1>
+    }
+    return
+  }
+}
+
+// CHECK-LABEL:  func.func @reduce_kernel_2d_0d
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32> {tt.divisibility = 16 : i32}, [[PARAM_1_:%.+]]: i32, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : index
+// CHECK-DAG:       [[CST_1_1_:%.+]] = arith.constant 1 : i32
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : i32
+// CHECK-DAG:       [[CST_8_:%.+]] = arith.constant 8 : i32
+// CHECK-DAG:       [[CST_2_:%.+]] = arith.constant 2 : i32
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_0_:%.+]] = arith.index_cast [[PARAM_4_]] : i32 to index
+// CHECK:           [[base_buffer_:%.+]], [[offset_:%.+]], [[sizes_:%.+]], [[VAR_strides_:%.+]] = memref.extract_strided_metadata [[VAR_reinterpret_cast_]] : memref<1xf32, strided<[1], offset: ?>> -> memref<f32>, index, index, index
+// CHECK:           [[VAR_1_:%.+]] = arith.addi [[offset_]], [[VAR_0_]] : index
+// CHECK:           [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[base_buffer_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [1], strides: [1] : memref<f32> to memref<1xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_2_:%.+]] = scf.for [[VAR_arg7_:%.+]] = [[CST_0_]] to [[CST_8_]] step [[CST_1_1_]] iter_args([[VAR_arg8_:%.+]] = [[VAR_reinterpret_cast_0_]]) -> (memref<1xf32, strided<[1], offset: ?>>)  : i32 {
+// CHECK-DAG:         [[VAR_3_:%.+]] = scf.for [[VAR_arg9_:%.+]] = [[CST_0_]] to [[CST_2_]] step [[CST_1_1_]] iter_args([[VAR_arg10_:%.+]] = [[VAR_arg8_]]) -> (memref<1xf32, strided<[1], offset: ?>>)  : i32 {
+// CHECK-DAG:           [[VAR_4_:%.+]] = arith.muli [[VAR_arg7_]], [[VAR_arg9_]] : i32
+// CHECK:               [[VAR_5_:%.+]] = arith.sitofp [[VAR_4_]] : i32 to f32
+// CHECK:               affine.store [[VAR_5_]], [[VAR_arg10_]][0] : memref<1xf32, strided<[1], offset: ?>>
+// CHECK:               [[base_buffer_1_:%.+]], [[offset_2_:%.+]], [[sizes_3_:%.+]], [[VAR_strides_4_:%.+]] = memref.extract_strided_metadata [[VAR_arg10_]] : memref<1xf32, strided<[1], offset: ?>> -> memref<f32>, index, index, index
+// CHECK:               [[VAR_6_:%.+]] = arith.addi [[offset_2_]], [[CST_1_]] : index
+// CHECK:               [[VAR_reinterpret_cast_5_:%.+]] = memref.reinterpret_cast [[base_buffer_1_]] to offset: {{.}}[[VAR_6_]]{{.}}, sizes: [1], strides: [1] : memref<f32> to memref<1xf32, strided<[1], offset: ?>>
+// CHECK:               scf.yield [[VAR_reinterpret_cast_5_]] : memref<1xf32, strided<[1], offset: ?>>
+// CHECK:             }
+// CHECK:             scf.yield [[VAR_3_]] : memref<1xf32, strided<[1], offset: ?>>
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/scalar_store_no_iterargs.mlir
+++ b/test/Conversion/StructuredToMemref/scalar_store_no_iterargs.mlir
@@ -1,0 +1,37 @@
+// RUN: triton-shared-opt --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+
+module {
+  func.func @reduce_kernel_2d_0d1d2de3de(%arg0: !tt.ptr<f32, 1> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32, 1> {tt.divisibility = 16 : i32}, %arg2: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 16 : i32}, %arg3: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 16 : i32}, %arg4: i32, %arg5: i32, %arg6: i32, %arg7: i32, %arg8: i32, %arg9: i32) {
+    %c1_i32 = arith.constant 1 : i32
+    %c5_i32 = arith.constant 5 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %0 = tt.addptr %arg1, %arg7 : !tt.ptr<f32, 1>, i32
+    %1 = arith.sitofp %arg7 : i32 to f32
+    scf.for %arg10 = %c0_i32 to %c5_i32 step %c1_i32  : i32 {
+      %2 = tt.addptr %0, %arg10 : !tt.ptr<f32, 1>, i32
+      tt.store %2, %1 {cache = 1 : i32, evict = 1 : i32} : f32
+    }
+    return
+  }
+}
+
+// CHECK-LABEL:  func.func @reduce_kernel_2d_0d1d2de3de
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32> {tt.divisibility = 16 : i32}, [[PARAM_1_:%.+]]: memref<*xf32> {tt.divisibility = 16 : i32}, [[PARAM_2_:%.+]]: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 16 : i32}, [[PARAM_3_:%.+]]: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 16 : i32}, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : i32
+// CHECK-DAG:       [[CST_5_:%.+]] = arith.constant 5 : i32
+// CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : i32
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: [0], sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_0_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
+// CHECK:           [[base_buffer_:%.+]], [[offset_:%.+]], [[sizes_:%.+]], [[VAR_strides_:%.+]] = memref.extract_strided_metadata [[VAR_reinterpret_cast_]] : memref<1xf32, strided<[1], offset: ?>> -> memref<f32>, index, index, index
+// CHECK:           [[VAR_1_:%.+]] = arith.addi [[offset_]], [[VAR_0_]] : index
+// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[base_buffer_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [1], strides: [1] : memref<f32> to memref<1xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.sitofp [[PARAM_7_]] : i32 to f32
+// CHECK:           scf.for [[I_0_:%.+]] = [[CST_0_]] to [[CST_5_]] step [[CST_1_]]  : i32 {
+// CHECK:             [[VAR_3_:%.+]] = arith.index_cast [[I_0_]] : i32 to index
+// CHECK:             [[base_buffer_1_:%.+]], [[offset_2_:%.+]], [[sizes_3_:%.+]], [[VAR_strides_4_:%.+]] = memref.extract_strided_metadata [[VAR_reinterpret_cast_0_]] : memref<1xf32, strided<[1], offset: ?>> -> memref<f32>, index, index, index
+// CHECK:             [[VAR_4_:%.+]] = arith.addi [[offset_2_]], [[VAR_3_]] : index
+// CHECK:             [[VAR_reinterpret_cast_5_:%.+]] = memref.reinterpret_cast [[base_buffer_1_]] to offset: {{.}}[[VAR_4_]]{{.}}, sizes: [1], strides: [1] : memref<f32> to memref<1xf32, strided<[1], offset: ?>>
+// CHECK:             affine.store [[VAR_2_]], [[VAR_reinterpret_cast_5_]][0] : memref<1xf32, strided<[1], offset: ?>>
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/triton_assert.mlir
+++ b/test/Conversion/StructuredToMemref/triton_assert.mlir
@@ -1,0 +1,17 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+tt.func public @assert_lol(%arg0: i32) {
+  %c0_i32 = arith.constant 0 : i32
+  %0 = arith.cmpi sgt, %arg0, %c0_i32 : i32
+  %1 = tt.splat %0 : (i1) -> tensor<1xi1>
+  tt.assert %1, "lol", "", "", 0 : tensor<1xi1>
+  tt.return
+}
+
+// mlir2FileCheck.py
+// CHECK-LABEL:  func.func @assert_lol
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: i32, [[PARAM_1_:%.+]]: i32, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32) {
+// CHECK:           [[CST_0_:%.+]] = arith.constant 0 : i32
+// CHECK:           [[VAR_0_:%.+]] = arith.cmpi sgt, [[PARAM_0_]], [[CST_0_]] : i32
+// CHECK:           cf.assert [[VAR_0_]], ".py:0:  Assertion `lol` failed"
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/triton_assert.mlir
+++ b/test/Conversion/StructuredToMemref/triton_assert.mlir
@@ -2,7 +2,7 @@
 tt.func public @assert_lol(%arg0: i32) {
   %c0_i32 = arith.constant 0 : i32
   %0 = arith.cmpi sgt, %arg0, %c0_i32 : i32
-  %1 = tt.splat %0 : (i1) -> tensor<1xi1>
+  %1 = tt.splat %0 : i1 -> tensor<1xi1>
   tt.assert %1, "lol", "", "", 0 : tensor<1xi1>
   tt.return
 }

--- a/test/Conversion/StructuredToMemref/unsupported_extern_elementwise.mlir
+++ b/test/Conversion/StructuredToMemref/unsupported_extern_elementwise.mlir
@@ -3,11 +3,11 @@
 module {
   tt.func public @rand(%arg0: !tt.ptr<i32, 1>, %arg1: !tt.ptr<i32, 1>) attributes {noinline = false} {
     %0 = tt.make_range {end = 8 : i32, start = 0 : i32} : tensor<8xi32>
-    %1 = tt.splat %arg0 : (!tt.ptr<i32, 1>) -> tensor<8x!tt.ptr<i32, 1>>
+    %1 = tt.splat %arg0 : !tt.ptr<i32, 1> -> tensor<8x!tt.ptr<i32, 1>>
     %2 = tt.addptr %1, %0 : tensor<8x!tt.ptr<i32, 1>>, tensor<8xi32>
     %3 = tt.load %2 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<8xi32>
     %4 = tt.extern_elementwise %3, %0 {libname = "", libpath = "", pure = true, symbol = "some_symbol"} : (tensor<8xi32>, tensor<8xi32>) -> tensor<8xi32>
-    %5 = tt.splat %arg1 : (!tt.ptr<i32, 1>) -> tensor<8x!tt.ptr<i32, 1>>
+    %5 = tt.splat %arg1 : !tt.ptr<i32, 1> -> tensor<8x!tt.ptr<i32, 1>>
     %6 = tt.addptr %5, %0 : tensor<8x!tt.ptr<i32, 1>>, tensor<8xi32>
     tt.store %6, %4 {cache = 1 : i32, evict = 1 : i32} : tensor<8xi32>
     tt.return

--- a/test/Conversion/StructuredToMemref/unsupported_extern_elementwise.mlir
+++ b/test/Conversion/StructuredToMemref/unsupported_extern_elementwise.mlir
@@ -1,0 +1,36 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+
+module {
+  tt.func public @rand(%arg0: !tt.ptr<i32, 1>, %arg1: !tt.ptr<i32, 1>) attributes {noinline = false} {
+    %0 = tt.make_range {end = 8 : i32, start = 0 : i32} : tensor<8xi32>
+    %1 = tt.splat %arg0 : (!tt.ptr<i32, 1>) -> tensor<8x!tt.ptr<i32, 1>>
+    %2 = tt.addptr %1, %0 : tensor<8x!tt.ptr<i32, 1>>, tensor<8xi32>
+    %3 = tt.load %2 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<8xi32>
+    %4 = tt.extern_elementwise %3, %0 {libname = "", libpath = "", pure = true, symbol = "some_symbol"} : (tensor<8xi32>, tensor<8xi32>) -> tensor<8xi32>
+    %5 = tt.splat %arg1 : (!tt.ptr<i32, 1>) -> tensor<8x!tt.ptr<i32, 1>>
+    %6 = tt.addptr %5, %0 : tensor<8x!tt.ptr<i32, 1>>, tensor<8xi32>
+    tt.store %6, %4 {cache = 1 : i32, evict = 1 : i32} : tensor<8xi32>
+    tt.return
+  }
+}
+
+// mlir2FileCheck.py
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func @rand
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xi32>, [[PARAM_1_:%.+]]: memref<*xi32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32) {
+// CHECK:           [[VAR_0_:%.+]] = tensor.empty() : tensor<8xi32>
+// CHECK:           [[VAR_1_:%.+]] = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel"]} outs([[VAR_0_]] : tensor<8xi32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: i32):
+// CHECK:             [[VAR_4_:%.+]] = linalg.index 0 : index
+// CHECK:             [[VAR_5_:%.+]] = arith.index_cast [[VAR_4_]] : index to i32
+// CHECK:             linalg.yield [[VAR_5_]] : i32
+// CHECK:           } -> tensor<8xi32>
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [8], strides: [1] : memref<*xi32> to memref<8xi32, strided<[1]>>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<8xi32>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<8xi32, strided<[1]>> to memref<8xi32>
+// CHECK:           [[VAR_2_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<8xi32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tt.extern_elementwise [[VAR_2_]], [[VAR_1_]] {libname = "", libpath = "", pure = true, symbol = "some_symbol"} : (tensor<8xi32>, tensor<8xi32>) -> tensor<8xi32>
+// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: [0], sizes: [8], strides: [1] : memref<*xi32> to memref<8xi32, strided<[1]>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_3_]] in writable [[VAR_reinterpret_cast_0_]] : (tensor<8xi32>, memref<8xi32, strided<[1]>>) -> ()
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/use_dot_opc.mlir
+++ b/test/Conversion/StructuredToMemref/use_dot_opc.mlir
@@ -1,0 +1,77 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+module {
+  tt.func @kernel(
+    %arg0 : !tt.ptr<bf16>,
+    %arg1 : !tt.ptr<bf16>,
+    %arg2 : !tt.ptr<bf16>
+  )
+  {
+    %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %c64 = arith.constant 128 : i32
+    %1 = tt.splat %c64 : (i32) -> tensor<128xi32>
+    %2 = arith.muli %0, %1 : tensor<128xi32>
+    %3 = tt.expand_dims %2 {axis = 1 : i32} : (tensor<128xi32>) -> tensor<128x1xi32>
+    %4 = tt.broadcast %3 : (tensor<128x1xi32>) -> tensor<128x64xi32>
+    %5 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32>
+    %6 = tt.expand_dims %5 {axis = 0 : i32} : (tensor<64xi32>) -> tensor<1x64xi32>
+    %7 = tt.broadcast %6 : (tensor<1x64xi32>) -> tensor<128x64xi32>
+    %8 = arith.addi %4, %7 : tensor<128x64xi32>
+    %10 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
+    %11 = tt.expand_dims %10 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
+    %12 = tt.broadcast %11 : (tensor<1x256xi32>) -> tensor<64x256xi32>
+    %13 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32>
+    %c256 = arith.constant 256 : i32
+    %14 = tt.splat %c256 : (i32) -> tensor<64xi32>
+    %15 = arith.muli %13, %14 : tensor<64xi32>
+    %16 = tt.expand_dims %15 {axis = 1 : i32} : (tensor<64xi32>) -> tensor<64x1xi32>
+    %17 = tt.broadcast %16 : (tensor<64x1xi32>) -> tensor<64x256xi32>
+    %18 = arith.addi %12, %17 : tensor<64x256xi32>
+    %20 = tt.splat %c256 : (i32) -> tensor<128xi32>
+    %21 = arith.muli %0, %20 : tensor<128xi32>
+    %22 = tt.expand_dims %21 {axis = 1 : i32} : (tensor<128xi32>) -> tensor<128x1xi32>
+    %23 = tt.broadcast %22 : (tensor<128x1xi32>) -> tensor<128x256xi32>
+    %24 = tt.expand_dims %10 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
+    %25 = tt.broadcast %24 {axis = 0 : i32} : (tensor<1x256xi32>) -> tensor<128x256xi32>
+    %26 = arith.addi %23, %25 : tensor<128x256xi32>
+    %30 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<128x64x!tt.ptr<bf16>>
+    %31 = tt.addptr %30, %8 : tensor<128x64x!tt.ptr<bf16>>, tensor<128x64xi32>
+    %32 = tt.load %31 {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<128x64xbf16>
+    %40 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<64x256x!tt.ptr<bf16>>
+    %41 = tt.addptr %40, %18 : tensor<64x256x!tt.ptr<bf16>>, tensor<64x256xi32>
+    %42 = tt.load %41 {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<64x256xbf16>
+    %50 = tt.splat %arg2 : (!tt.ptr<bf16>) -> tensor<128x256x!tt.ptr<bf16>>
+    %51 = tt.addptr %50, %26 : tensor<128x256x!tt.ptr<bf16>>, tensor<128x256xi32>
+    %cf0 = arith.constant 0.0 : bf16
+    %71 = tt.splat %cf0 : (bf16) -> (tensor<128x256xbf16>)
+    %60 = tt.dot %32, %42, %71 {allowTF32 = false, maxNumImpreciseAcc = 0 : i32} : tensor<128x64xbf16> * tensor<64x256xbf16> -> tensor<128x256xbf16>
+    tt.store %51, %60 : tensor<128x256xbf16>
+    tt.store %51, %71 : tensor<128x256xbf16>
+    tt.return
+  }
+}
+
+// mlir2FileCheck.py
+// CHECK-LABEL:  func.func @kernel
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: memref<*xbf16>, [[PARAM_2_:%.+]]: memref<*xbf16>, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_256_:%.+]] = arith.constant 256 : index
+// CHECK-DAG:       [[CST_128_:%.+]] = arith.constant 128 : index
+// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : bf16
+// CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<128x256xbf16>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_1_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : bf16) outs([[VAR_0_]] : tensor<128x256xbf16>) -> tensor<128x256xbf16>
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [128, 64], strides: {{.}}[[CST_128_]], 1] : memref<*xbf16> to memref<128x64xbf16, strided<[?, 1]>>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<128x64xbf16>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<128x64xbf16, strided<[?, 1]>> to memref<128x64xbf16>
+// CHECK-DAG:       [[VAR_2_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<128x64xbf16>
+// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: [0], sizes: [64, 256], strides: {{.}}[[CST_256_]], 1] : memref<*xbf16> to memref<64x256xbf16, strided<[?, 1]>>
+// CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc() : memref<64x256xbf16>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_0_]], [[RES_1_]] : memref<64x256xbf16, strided<[?, 1]>> to memref<64x256xbf16>
+// CHECK-DAG:       [[VAR_3_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<64x256xbf16>
+// CHECK-DAG:       [[VAR_reinterpret_cast_2_:%.+]] = memref.reinterpret_cast [[PARAM_2_]] to offset: [0], sizes: [128, 256], strides: {{.}}[[CST_256_]], 1] : memref<*xbf16> to memref<128x256xbf16, strided<[?, 1]>>
+// CHECK-DAG:       [[VAR_4_:%.+]] = tensor.empty() : tensor<128x256xbf16>
+// CHECK:           [[VAR_5_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : bf16) outs([[VAR_4_]] : tensor<128x256xbf16>) -> tensor<128x256xbf16>
+// CHECK:           [[VAR_6_:%.+]] = linalg.matmul ins([[VAR_2_]], [[VAR_3_]] : tensor<128x64xbf16>, tensor<64x256xbf16>) outs([[VAR_5_]] : tensor<128x256xbf16>) -> tensor<128x256xbf16>
+// CHECK:           bufferization.materialize_in_destination [[VAR_6_]] in writable [[VAR_reinterpret_cast_2_]] : (tensor<128x256xbf16>, memref<128x256xbf16, strided<[?, 1]>>) -> ()
+// CHECK:           bufferization.materialize_in_destination [[VAR_1_]] in writable [[VAR_reinterpret_cast_2_]] : (tensor<128x256xbf16>, memref<128x256xbf16, strided<[?, 1]>>) -> ()
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/use_dot_opc.mlir
+++ b/test/Conversion/StructuredToMemref/use_dot_opc.mlir
@@ -8,41 +8,41 @@ module {
   {
     %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
     %c64 = arith.constant 128 : i32
-    %1 = tt.splat %c64 : (i32) -> tensor<128xi32>
+    %1 = tt.splat %c64 : i32 -> tensor<128xi32>
     %2 = arith.muli %0, %1 : tensor<128xi32>
-    %3 = tt.expand_dims %2 {axis = 1 : i32} : (tensor<128xi32>) -> tensor<128x1xi32>
-    %4 = tt.broadcast %3 : (tensor<128x1xi32>) -> tensor<128x64xi32>
+    %3 = tt.expand_dims %2 {axis = 1 : i32} : tensor<128xi32> -> tensor<128x1xi32>
+    %4 = tt.broadcast %3 : tensor<128x1xi32> -> tensor<128x64xi32>
     %5 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32>
-    %6 = tt.expand_dims %5 {axis = 0 : i32} : (tensor<64xi32>) -> tensor<1x64xi32>
-    %7 = tt.broadcast %6 : (tensor<1x64xi32>) -> tensor<128x64xi32>
+    %6 = tt.expand_dims %5 {axis = 0 : i32} : tensor<64xi32> -> tensor<1x64xi32>
+    %7 = tt.broadcast %6 : tensor<1x64xi32> -> tensor<128x64xi32>
     %8 = arith.addi %4, %7 : tensor<128x64xi32>
     %10 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
-    %11 = tt.expand_dims %10 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
-    %12 = tt.broadcast %11 : (tensor<1x256xi32>) -> tensor<64x256xi32>
+    %11 = tt.expand_dims %10 {axis = 0 : i32} : tensor<256xi32> -> tensor<1x256xi32>
+    %12 = tt.broadcast %11 : tensor<1x256xi32> -> tensor<64x256xi32>
     %13 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32>
     %c256 = arith.constant 256 : i32
-    %14 = tt.splat %c256 : (i32) -> tensor<64xi32>
+    %14 = tt.splat %c256 : i32 -> tensor<64xi32>
     %15 = arith.muli %13, %14 : tensor<64xi32>
-    %16 = tt.expand_dims %15 {axis = 1 : i32} : (tensor<64xi32>) -> tensor<64x1xi32>
-    %17 = tt.broadcast %16 : (tensor<64x1xi32>) -> tensor<64x256xi32>
+    %16 = tt.expand_dims %15 {axis = 1 : i32} : tensor<64xi32> -> tensor<64x1xi32>
+    %17 = tt.broadcast %16 : tensor<64x1xi32> -> tensor<64x256xi32>
     %18 = arith.addi %12, %17 : tensor<64x256xi32>
-    %20 = tt.splat %c256 : (i32) -> tensor<128xi32>
+    %20 = tt.splat %c256 : i32 -> tensor<128xi32>
     %21 = arith.muli %0, %20 : tensor<128xi32>
-    %22 = tt.expand_dims %21 {axis = 1 : i32} : (tensor<128xi32>) -> tensor<128x1xi32>
-    %23 = tt.broadcast %22 : (tensor<128x1xi32>) -> tensor<128x256xi32>
-    %24 = tt.expand_dims %10 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
-    %25 = tt.broadcast %24 {axis = 0 : i32} : (tensor<1x256xi32>) -> tensor<128x256xi32>
+    %22 = tt.expand_dims %21 {axis = 1 : i32} : tensor<128xi32> -> tensor<128x1xi32>
+    %23 = tt.broadcast %22 : tensor<128x1xi32> -> tensor<128x256xi32>
+    %24 = tt.expand_dims %10 {axis = 0 : i32} : tensor<256xi32> -> tensor<1x256xi32>
+    %25 = tt.broadcast %24 {axis = 0 : i32} : tensor<1x256xi32> -> tensor<128x256xi32>
     %26 = arith.addi %23, %25 : tensor<128x256xi32>
-    %30 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<128x64x!tt.ptr<bf16>>
+    %30 = tt.splat %arg0 : !tt.ptr<bf16> -> tensor<128x64x!tt.ptr<bf16>>
     %31 = tt.addptr %30, %8 : tensor<128x64x!tt.ptr<bf16>>, tensor<128x64xi32>
     %32 = tt.load %31 {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<128x64xbf16>
-    %40 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<64x256x!tt.ptr<bf16>>
+    %40 = tt.splat %arg1 : !tt.ptr<bf16> -> tensor<64x256x!tt.ptr<bf16>>
     %41 = tt.addptr %40, %18 : tensor<64x256x!tt.ptr<bf16>>, tensor<64x256xi32>
     %42 = tt.load %41 {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<64x256xbf16>
-    %50 = tt.splat %arg2 : (!tt.ptr<bf16>) -> tensor<128x256x!tt.ptr<bf16>>
+    %50 = tt.splat %arg2 : !tt.ptr<bf16> -> tensor<128x256x!tt.ptr<bf16>>
     %51 = tt.addptr %50, %26 : tensor<128x256x!tt.ptr<bf16>>, tensor<128x256xi32>
     %cf0 = arith.constant 0.0 : bf16
-    %71 = tt.splat %cf0 : (bf16) -> (tensor<128x256xbf16>)
+    %71 = tt.splat %cf0 : bf16 -> tensor<128x256xbf16>
     %60 = tt.dot %32, %42, %71 {allowTF32 = false, maxNumImpreciseAcc = 0 : i32} : tensor<128x64xbf16> * tensor<64x256xbf16> -> tensor<128x256xbf16>
     tt.store %51, %60 : tensor<128x256xbf16>
     tt.store %51, %71 : tensor<128x256xbf16>

--- a/test/Conversion/StructuredToMemref/use_end_chain.mlir
+++ b/test/Conversion/StructuredToMemref/use_end_chain.mlir
@@ -1,0 +1,98 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+module {
+  tt.func @kernel(
+  %arg0 : !tt.ptr<bf16>,
+  %arg1 : !tt.ptr<bf16>
+  )
+  {
+  %0 = tt.make_range {end = 768 : i32, start = 512 : i32}:tensor<256xi32>
+  // offset = [512] size = 256, stride = 1
+  %1 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<256xi32>) -> tensor<256x1xi32>
+  // offset = [512,0], size = [256,1], stride = [1,0]
+  %2 = tt.broadcast %1 : (tensor<256x1xi32>) -> tensor<256x128xi32>
+  // offset = [512,0], size = [256,128], stride = [1,0]
+  %5 = tt.make_range {end = 1152 : i32, start = 1024 : i32}:tensor<128xi32>
+  // offset = 1024, size = 128, stride = 1
+  %6 = tt.expand_dims %5 {axis = 0 : i32} : (tensor<128xi32>) -> tensor<1x128xi32>
+  // offset = [0,1024], size = [1,128], stride = [0,1]
+  %7 = tt.broadcast %6 : (tensor<1x128xi32>) -> tensor<256x128xi32>
+  // offset = [0,1024], size = [256,128], stride = [0,1]
+  %c6 = arith.constant 6 : i32
+  %splat6 = tt.splat %c6 : (i32) -> tensor<256x128xi32>
+  %scale7 = arith.muli %7, %splat6 : tensor<256x128xi32>
+  // offset = [0,6144], size = [256,128], stride = [0,6]
+  %14 = arith.addi %2, %scale7 : tensor<256x128xi32>
+  // offset = [512,6144], size = [256,128], stride = [1,6]
+  // mixed use
+  %17 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<256x128x!tt.ptr<bf16>>
+  %18 = tt.addptr %17, %14 : tensor<256x128x!tt.ptr<bf16>>, tensor<256x128xi32>
+  %19 = tt.load %18 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<256x128xbf16>
+  tt.store %18, %19 : tensor<256x128xbf16>
+  %20 = arith.sitofp %14 : tensor<256x128xi32> to tensor<256x128xbf16>
+  tt.store %18, %20 : tensor<256x128xbf16>
+  tt.return
+  }
+}
+// mlir2FileCheck.py
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-DAG:   [[MAP_1_:#.+]] = affine_map<(d0, d1) -> (d0, 0)>
+// CHECK-DAG:   [[MAP_2_:#.+]] = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK-DAG:   [[MAP_3_:#.+]] = affine_map<(d0, d1) -> (0, d1)>
+// CHECK-LABEL:  func.func @kernel
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: memref<*xbf16>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_6656_:%.+]] = arith.constant 6656 : index
+// CHECK-DAG:       [[CST_6_:%.+]] = arith.constant 6 : index
+// CHECK-DAG:       [[CST_6_1_:%.+]] = arith.constant 6 : i32
+// CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<256x128xi32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_1_:%.+]] = linalg.fill ins([[CST_6_1_]] : i32) outs([[VAR_0_]] : tensor<256x128xi32>) -> tensor<256x128xi32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tensor.empty() : tensor<256xi32>
+// CHECK:           [[VAR_3_:%.+]] = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel"]} outs([[VAR_2_]] : tensor<256xi32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: i32):
+// CHECK:             [[VAR_15_:%.+]] = linalg.index 0 : index
+// CHECK:             [[VAR_16_:%.+]] = arith.index_cast [[VAR_15_]] : index to i32
+// CHECK:             linalg.yield [[VAR_16_]] : i32
+// CHECK:           } -> tensor<256xi32>
+// CHECK-DAG:       [[VAR_expanded_:%.+]] = tensor.expand_shape [[VAR_3_]] {{.}}[0, 1]{{.}} : tensor<256xi32> into tensor<256x1xi32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = tensor.empty() : tensor<256x128xi32>
+// CHECK:           [[VAR_5_:%.+]] = linalg.generic {indexing_maps = [#map1, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_]] : tensor<256x1xi32>) outs([[VAR_4_]] : tensor<256x128xi32>) attrs =  {broadcastDims = array<i64: 1>} {
+// CHECK:           ^bb0([[IN_1_:%.+]]: i32, [[IN_2_:%.+]]: i32):
+// CHECK:             linalg.yield [[IN_1_]] : i32
+// CHECK:           } -> tensor<256x128xi32>
+// CHECK:           [[VAR_6_:%.+]] = tensor.empty() : tensor<128xi32>
+// CHECK:           [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel"]} outs([[VAR_6_]] : tensor<128xi32>) {
+// CHECK:           ^bb0([[IN_3_:%.+]]: i32):
+// CHECK:             [[VAR_15_1_:%.+]] = linalg.index 0 : index
+// CHECK:             [[VAR_16_1_:%.+]] = arith.index_cast [[VAR_15_1_]] : index to i32
+// CHECK:             linalg.yield [[VAR_16_1_]] : i32
+// CHECK:           } -> tensor<128xi32>
+// CHECK-DAG:       [[VAR_expanded_0_:%.+]] = tensor.expand_shape [[VAR_7_]] {{.}}[0, 1]{{.}} : tensor<128xi32> into tensor<1x128xi32>
+// CHECK-DAG:       [[VAR_8_:%.+]] = tensor.empty() : tensor<256x128xi32>
+// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map3, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_0_]] : tensor<1x128xi32>) outs([[VAR_8_]] : tensor<256x128xi32>) attrs =  {broadcastDims = array<i64: 0>} {
+// CHECK:           ^bb0([[IN_4_:%.+]]: i32, [[IN_5_:%.+]]: i32):
+// CHECK:             linalg.yield [[IN_4_]] : i32
+// CHECK:           } -> tensor<256x128xi32>
+// CHECK:           [[VAR_10_:%.+]] = linalg.generic {indexing_maps = [#map2, #map2, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_9_]], [[VAR_1_]] : tensor<256x128xi32>, tensor<256x128xi32>) outs([[VAR_9_]] : tensor<256x128xi32>) {
+// CHECK:           ^bb0([[IN_6_:%.+]]: i32, [[IN_7_:%.+]]: i32, [[IN_8_:%.+]]: i32):
+// CHECK:             [[VAR_15_2_:%.+]] = arith.muli [[IN_6_]], [[IN_7_]] : i32
+// CHECK:             linalg.yield [[VAR_15_2_]] : i32
+// CHECK:           } -> tensor<256x128xi32>
+// CHECK:           [[VAR_11_:%.+]] = linalg.generic {indexing_maps = [#map2, #map2, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_5_]], [[VAR_10_]] : tensor<256x128xi32>, tensor<256x128xi32>) outs([[VAR_5_]] : tensor<256x128xi32>) {
+// CHECK:           ^bb0([[IN_9_:%.+]]: i32, [[IN_10_:%.+]]: i32, [[IN_11_:%.+]]: i32):
+// CHECK:             [[VAR_15_3_:%.+]] = arith.addi [[IN_9_]], [[IN_10_]] : i32
+// CHECK:             linalg.yield [[VAR_15_3_]] : i32
+// CHECK:           } -> tensor<256x128xi32>
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[CST_6656_]]{{.}}, sizes: [256, 128], strides: [1, [[CST_6_]]{{.}} : memref<*xbf16> to memref<256x128xbf16, strided<[1, ?], offset: ?>>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<256x128xbf16>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<256x128xbf16, strided<[1, ?], offset: ?>> to memref<256x128xbf16>
+// CHECK:           [[VAR_12_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<256x128xbf16>
+// CHECK:           bufferization.materialize_in_destination [[VAR_12_]] in writable [[VAR_reinterpret_cast_]] : (tensor<256x128xbf16>, memref<256x128xbf16, strided<[1, ?], offset: ?>>) -> ()
+// CHECK:           [[VAR_13_:%.+]] = tensor.empty() : tensor<256x128xbf16>
+// CHECK:           [[VAR_14_:%.+]] = linalg.generic {indexing_maps = [#map2, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_11_]] : tensor<256x128xi32>) outs([[VAR_13_]] : tensor<256x128xbf16>) {
+// CHECK:           ^bb0([[IN_12_:%.+]]: i32, [[IN_13_:%.+]]: bf16):
+// CHECK:             [[VAR_15_4_:%.+]] = arith.sitofp [[IN_12_]] : i32 to bf16
+// CHECK:             linalg.yield [[VAR_15_4_]] : bf16
+// CHECK:           } -> tensor<256x128xbf16>
+// CHECK:           bufferization.materialize_in_destination [[VAR_14_]] in writable [[VAR_reinterpret_cast_]] : (tensor<256x128xbf16>, memref<256x128xbf16, strided<[1, ?], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/use_end_chain.mlir
+++ b/test/Conversion/StructuredToMemref/use_end_chain.mlir
@@ -7,24 +7,24 @@ module {
   {
   %0 = tt.make_range {end = 768 : i32, start = 512 : i32}:tensor<256xi32>
   // offset = [512] size = 256, stride = 1
-  %1 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<256xi32>) -> tensor<256x1xi32>
+  %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<256xi32> -> tensor<256x1xi32>
   // offset = [512,0], size = [256,1], stride = [1,0]
-  %2 = tt.broadcast %1 : (tensor<256x1xi32>) -> tensor<256x128xi32>
+  %2 = tt.broadcast %1 : tensor<256x1xi32> -> tensor<256x128xi32>
   // offset = [512,0], size = [256,128], stride = [1,0]
   %5 = tt.make_range {end = 1152 : i32, start = 1024 : i32}:tensor<128xi32>
   // offset = 1024, size = 128, stride = 1
-  %6 = tt.expand_dims %5 {axis = 0 : i32} : (tensor<128xi32>) -> tensor<1x128xi32>
+  %6 = tt.expand_dims %5 {axis = 0 : i32} : tensor<128xi32> -> tensor<1x128xi32>
   // offset = [0,1024], size = [1,128], stride = [0,1]
-  %7 = tt.broadcast %6 : (tensor<1x128xi32>) -> tensor<256x128xi32>
+  %7 = tt.broadcast %6 : tensor<1x128xi32> -> tensor<256x128xi32>
   // offset = [0,1024], size = [256,128], stride = [0,1]
   %c6 = arith.constant 6 : i32
-  %splat6 = tt.splat %c6 : (i32) -> tensor<256x128xi32>
+  %splat6 = tt.splat %c6 : i32 -> tensor<256x128xi32>
   %scale7 = arith.muli %7, %splat6 : tensor<256x128xi32>
   // offset = [0,6144], size = [256,128], stride = [0,6]
   %14 = arith.addi %2, %scale7 : tensor<256x128xi32>
   // offset = [512,6144], size = [256,128], stride = [1,6]
   // mixed use
-  %17 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<256x128x!tt.ptr<bf16>>
+  %17 = tt.splat %arg1 : !tt.ptr<bf16> -> tensor<256x128x!tt.ptr<bf16>>
   %18 = tt.addptr %17, %14 : tensor<256x128x!tt.ptr<bf16>>, tensor<256x128xi32>
   %19 = tt.load %18 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<256x128xbf16>
   tt.store %18, %19 : tensor<256x128xbf16>

--- a/test/Conversion/StructuredToMemref/use_mid_chain.mlir
+++ b/test/Conversion/StructuredToMemref/use_mid_chain.mlir
@@ -8,28 +8,28 @@ module {
   {
   %0 = tt.make_range {end = 768 : i32, start = 512 : i32}:tensor<256xi32>
   // offset = [512] size = 256, stride = 1
-  %1 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<256xi32>) -> tensor<256x1xi32>
+  %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<256xi32> -> tensor<256x1xi32>
   // offset = [512,0], size = [256,1], stride = [1,0]
-  %2 = tt.broadcast %1 : (tensor<256x1xi32>) -> tensor<256x128xi32>
+  %2 = tt.broadcast %1 : tensor<256x1xi32> -> tensor<256x128xi32>
   // offset = [512,0], size = [256,128], stride = [1,0]
   // mixed use
   %5 = tt.make_range {end = 1152 : i32, start = 1024 : i32}:tensor<128xi32>
   // offset = 1024, size = 128, stride = 1
-  %6 = tt.expand_dims %5 {axis = 0 : i32} : (tensor<128xi32>) -> tensor<1x128xi32>
+  %6 = tt.expand_dims %5 {axis = 0 : i32} : tensor<128xi32> -> tensor<1x128xi32>
   // offset = [0,1024], size = [1,128], stride = [0,1]
-  %7 = tt.broadcast %6 : (tensor<1x128xi32>) -> tensor<256x128xi32>
+  %7 = tt.broadcast %6 : tensor<1x128xi32> -> tensor<256x128xi32>
   // offset = [0,1024], size = [256,128], stride = [0,1]
   %c6 = arith.constant 6 : i32
-  %splat6 = tt.splat %c6 : (i32) -> tensor<256x128xi32>
+  %splat6 = tt.splat %c6 : i32 -> tensor<256x128xi32>
   %scale7 = arith.muli %7, %splat6 : tensor<256x128xi32>
   // offset = [0,6144], size = [256,128], stride = [0,6]
   %14 = arith.addi %2, %scale7 : tensor<256x128xi32>
   // offset = [512,6144], size = [256,128], stride = [1,6]
-  %17 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<256x128x!tt.ptr<bf16>>
+  %17 = tt.splat %arg1 : !tt.ptr<bf16> -> tensor<256x128x!tt.ptr<bf16>>
   %18 = tt.addptr %17, %14 : tensor<256x128x!tt.ptr<bf16>>, tensor<256x128xi32>
   %19 = tt.load %18 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<256x128xbf16>
   tt.store %18, %19 : tensor<256x128xbf16>
-  %20 = tt.splat %arg2 : (!tt.ptr<i32>) -> tensor<256x128x!tt.ptr<i32>>
+  %20 = tt.splat %arg2 : !tt.ptr<i32> -> tensor<256x128x!tt.ptr<i32>>
   %21 = tt.addptr %20, %14 : tensor<256x128x!tt.ptr<i32>>, tensor<256x128xi32>
   tt.store %21, %2 : tensor<256x128xi32>
   tt.return

--- a/test/Conversion/StructuredToMemref/use_mid_chain.mlir
+++ b/test/Conversion/StructuredToMemref/use_mid_chain.mlir
@@ -1,0 +1,67 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+module {
+  tt.func @kernel(
+  %arg0 : !tt.ptr<bf16>,
+  %arg1 : !tt.ptr<bf16>,
+  %arg2 : !tt.ptr<i32>
+  )
+  {
+  %0 = tt.make_range {end = 768 : i32, start = 512 : i32}:tensor<256xi32>
+  // offset = [512] size = 256, stride = 1
+  %1 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<256xi32>) -> tensor<256x1xi32>
+  // offset = [512,0], size = [256,1], stride = [1,0]
+  %2 = tt.broadcast %1 : (tensor<256x1xi32>) -> tensor<256x128xi32>
+  // offset = [512,0], size = [256,128], stride = [1,0]
+  // mixed use
+  %5 = tt.make_range {end = 1152 : i32, start = 1024 : i32}:tensor<128xi32>
+  // offset = 1024, size = 128, stride = 1
+  %6 = tt.expand_dims %5 {axis = 0 : i32} : (tensor<128xi32>) -> tensor<1x128xi32>
+  // offset = [0,1024], size = [1,128], stride = [0,1]
+  %7 = tt.broadcast %6 : (tensor<1x128xi32>) -> tensor<256x128xi32>
+  // offset = [0,1024], size = [256,128], stride = [0,1]
+  %c6 = arith.constant 6 : i32
+  %splat6 = tt.splat %c6 : (i32) -> tensor<256x128xi32>
+  %scale7 = arith.muli %7, %splat6 : tensor<256x128xi32>
+  // offset = [0,6144], size = [256,128], stride = [0,6]
+  %14 = arith.addi %2, %scale7 : tensor<256x128xi32>
+  // offset = [512,6144], size = [256,128], stride = [1,6]
+  %17 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<256x128x!tt.ptr<bf16>>
+  %18 = tt.addptr %17, %14 : tensor<256x128x!tt.ptr<bf16>>, tensor<256x128xi32>
+  %19 = tt.load %18 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<256x128xbf16>
+  tt.store %18, %19 : tensor<256x128xbf16>
+  %20 = tt.splat %arg2 : (!tt.ptr<i32>) -> tensor<256x128x!tt.ptr<i32>>
+  %21 = tt.addptr %20, %14 : tensor<256x128x!tt.ptr<i32>>, tensor<256x128xi32>
+  tt.store %21, %2 : tensor<256x128xi32>
+  tt.return
+  }
+}
+// mlir2FileCheck.py
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-DAG:   [[MAP_1_:#.+]] = affine_map<(d0, d1) -> (d0, 0)>
+// CHECK-DAG:   [[MAP_2_:#.+]] = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK-LABEL:  func.func @kernel
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: memref<*xbf16>, [[PARAM_2_:%.+]]: memref<*xi32>, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_6656_:%.+]] = arith.constant 6656 : index
+// CHECK-DAG:       [[CST_6_:%.+]] = arith.constant 6 : index
+// CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<256xi32>
+// CHECK:           [[VAR_1_:%.+]] = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel"]} outs([[VAR_0_]] : tensor<256xi32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: i32):
+// CHECK:             [[VAR_5_:%.+]] = linalg.index 0 : index
+// CHECK:             [[VAR_6_:%.+]] = arith.index_cast [[VAR_5_]] : index to i32
+// CHECK:             linalg.yield [[VAR_6_]] : i32
+// CHECK:           } -> tensor<256xi32>
+// CHECK-DAG:       [[VAR_expanded_:%.+]] = tensor.expand_shape [[VAR_1_]] {{.}}[0, 1]{{.}} : tensor<256xi32> into tensor<256x1xi32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tensor.empty() : tensor<256x128xi32>
+// CHECK:           [[VAR_3_:%.+]] = linalg.generic {indexing_maps = [#map1, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_]] : tensor<256x1xi32>) outs([[VAR_2_]] : tensor<256x128xi32>) attrs =  {broadcastDims = array<i64: 1>} {
+// CHECK:           ^bb0([[IN_1_:%.+]]: i32, [[IN_2_:%.+]]: i32):
+// CHECK:             linalg.yield [[IN_1_]] : i32
+// CHECK:           } -> tensor<256x128xi32>
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[CST_6656_]]{{.}}, sizes: [256, 128], strides: [1, [[CST_6_]]{{.}} : memref<*xbf16> to memref<256x128xbf16, strided<[1, ?], offset: ?>>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<256x128xbf16>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<256x128xbf16, strided<[1, ?], offset: ?>> to memref<256x128xbf16>
+// CHECK:           [[VAR_4_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<256x128xbf16>
+// CHECK:           bufferization.materialize_in_destination [[VAR_4_]] in writable [[VAR_reinterpret_cast_]] : (tensor<256x128xbf16>, memref<256x128xbf16, strided<[1, ?], offset: ?>>) -> ()
+// CHECK:           [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_2_]] to offset: {{.}}[[CST_6656_]]{{.}}, sizes: [256, 128], strides: [1, [[CST_6_]]{{.}} : memref<*xi32> to memref<256x128xi32, strided<[1, ?], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_3_]] in writable [[VAR_reinterpret_cast_0_]] : (tensor<256x128xi32>, memref<256x128xi32, strided<[1, ?], offset: ?>>) -> ()
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/wraparound_side_by_side.mlir
+++ b/test/Conversion/StructuredToMemref/wraparound_side_by_side.mlir
@@ -1,0 +1,115 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+
+module {
+  tt.func public @wrap_side_by_side_masked_loop_01234567(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32, %arg6: i32, %arg7: i32) {
+    %cst = arith.constant dense<-9.900000e+01> : tensor<4x4xf32>
+    %c1_i32 = arith.constant 1 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %cst_0 = arith.constant dense<2> : tensor<4x1xi32>
+    %cst_1 = arith.constant dense<6> : tensor<4xi32>
+    %cst_2 = arith.constant dense<2> : tensor<4xi32>
+    %c4_i32 = arith.constant 4 : i32
+    %0 = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32>
+    %1 = arith.addi %0, %cst_2 : tensor<4xi32>
+    %2 = arith.addi %0, %cst_1 : tensor<4xi32>
+    %3 = tt.splat %arg3 : (i32) -> tensor<4xi32>
+    %4 = arith.remsi %2, %3 : tensor<4xi32>
+    %5 = tt.expand_dims %1 {axis = 1 : i32} : (tensor<4xi32>) -> tensor<4x1xi32>
+    %6 = tt.splat %arg4 : (i32) -> tensor<4x1xi32>
+    %7 = arith.muli %5, %6 : tensor<4x1xi32>
+    %8 = tt.expand_dims %4 {axis = 0 : i32} : (tensor<4xi32>) -> tensor<1x4xi32>
+    %9 = tt.splat %arg5 : (i32) -> tensor<1x4xi32>
+    %10 = arith.muli %8, %9 : tensor<1x4xi32>
+    %11 = tt.broadcast %7 : (tensor<4x1xi32>) -> tensor<4x4xi32>
+    %12 = tt.broadcast %10 : (tensor<1x4xi32>) -> tensor<4x4xi32>
+    %13 = arith.addi %11, %12 : tensor<4x4xi32>
+    %14 = tt.splat %arg0 : (!tt.ptr<f32>) -> tensor<4x4x!tt.ptr<f32>>
+    %15 = tt.addptr %14, %13 : tensor<4x4x!tt.ptr<f32>>, tensor<4x4xi32>
+    %16 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<4xi32>) -> tensor<4x1xi32>
+    %17 = tt.splat %arg6 : (i32) -> tensor<4x1xi32>
+    %18 = arith.muli %17, %16 : tensor<4x1xi32>
+    %19 = tt.splat %arg1 : (!tt.ptr<f32>) -> tensor<4x1x!tt.ptr<f32>>
+    %20 = tt.addptr %19, %18 : tensor<4x1x!tt.ptr<f32>>, tensor<4x1xi32>
+    %21 = tt.expand_dims %0 {axis = 0 : i32} : (tensor<4xi32>) -> tensor<1x4xi32>
+    %22 = tt.splat %arg7 : (i32) -> tensor<1x4xi32>
+    %23 = arith.muli %22, %21 : tensor<1x4xi32>
+    %24 = tt.broadcast %20 : (tensor<4x1x!tt.ptr<f32>>) -> tensor<4x4x!tt.ptr<f32>>
+    %25 = tt.broadcast %23 : (tensor<1x4xi32>) -> tensor<4x4xi32>
+    %26 = tt.addptr %24, %25 : tensor<4x4x!tt.ptr<f32>>, tensor<4x4xi32>
+    %27 = arith.cmpi slt, %16, %cst_0 : tensor<4x1xi32>
+    %28 = tt.broadcast %27 : (tensor<4x1xi1>) -> tensor<4x4xi1>
+    %29 = arith.muli %arg4, %c4_i32 : i32
+    %30 = tt.splat %29 : (i32) -> tensor<4x4xi32>
+    %31 = arith.muli %arg5, %c4_i32 : i32
+    %32 = tt.splat %31 : (i32) -> tensor<4x4xi32>
+    %33:2 = scf.for %arg8 = %c0_i32 to %c2_i32 step %c1_i32 iter_args(%arg9 = %15, %arg10 = %26) -> (tensor<4x4x!tt.ptr<f32>>, tensor<4x4x!tt.ptr<f32>>)  : i32 {
+      %34 = tt.load %arg9, %28, %cst {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<4x4xf32>
+      tt.store %arg10, %34 {cache = 1 : i32, evict = 1 : i32} : tensor<4x4xf32>
+      %35 = tt.addptr %arg9, %30 : tensor<4x4x!tt.ptr<f32>>, tensor<4x4xi32>
+      %36 = tt.addptr %arg10, %32 : tensor<4x4x!tt.ptr<f32>>, tensor<4x4xi32>
+      scf.yield %35, %36 : tensor<4x4x!tt.ptr<f32>>, tensor<4x4x!tt.ptr<f32>>
+    }
+    tt.return
+  }
+}
+
+// mlir2FileCheck.py
+// CHECK-LABEL:  func.func @wrap_side_by_side_masked_loop_01234567
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32, [[PARAM_10_:%.+]]: i32, [[PARAM_11_:%.+]]: i32, [[PARAM_12_:%.+]]: i32, [[PARAM_13_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_4_:%.+]] = arith.constant 4 : index
+// CHECK-DAG:       [[CST_4_1_:%.+]] = arith.constant 4 : i32
+// CHECK-DAG:       [[CST_2_:%.+]] = arith.constant 2 : i32
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : i32
+// CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : i32
+// CHECK-DAG:       [[CST_2_1_:%.+]] = arith.constant 2 : index
+// CHECK-DAG:       [[CST_6_:%.+]] = arith.constant 6 : index
+// CHECK-DAG:       [[CST_0_1_:%.+]] = arith.constant 0 : index
+// CHECK-DAG:       [[CST_minus_9_dot_900000_:%.+]] = arith.constant -9.900000e+01 : f32
+// CHECK-DAG:       [[VAR_0_:%.+]] = arith.index_cast [[PARAM_4_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_1_:%.+]] = arith.muli [[VAR_0_]], [[CST_2_1_]] : index
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[PARAM_5_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_4_:%.+]] = arith.muli [[VAR_3_]], [[CST_6_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.muli [[VAR_2_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[VAR_6_:%.+]] = arith.index_cast [[PARAM_6_]] : i32 to index
+// CHECK-DAG:       [[VAR_7_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
+// CHECK-DAG:       [[VAR_8_:%.+]] = arith.muli [[PARAM_4_]], [[CST_4_1_]] : i32
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_9_:%.+]] = arith.index_cast [[VAR_8_]] : i32 to index
+// CHECK-DAG:       [[VAR_10_:%.+]] = arith.muli [[PARAM_5_]], [[CST_4_1_]] : i32
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_11_:%.+]] = arith.index_cast [[VAR_10_]] : i32 to index
+// CHECK-DAG:       [[VAR_12_:%.+]]:2 = scf.for [[VAR_arg14_:%.+]] = [[CST_0_]] to [[CST_2_]] step [[CST_1_]] iter_args([[VAR_arg15_:%.+]] = [[VAR_1_]], [[VAR_arg16_:%.+]] = [[CST_0_1_]]) -> (index, index)  : i32 {
+// CHECK-DAG:         [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_arg16_]]{{.}}, sizes: [4, 4], strides: {{.}}[[VAR_6_]], [[VAR_7_]]{{.}} : memref<*xf32> to memref<4x4xf32, strided<[?, ?], offset: ?>>
+// CHECK-DAG:         [[VAR_13_:%.+]] = arith.addi [[VAR_arg15_]], [[VAR_4_]] : index
+// CHECK:             [[VAR_14_:%.+]] = arith.remsi [[VAR_13_]], [[VAR_5_]] : index
+// CHECK-DAG:         [[VAR_15_:%.+]] = arith.subi [[VAR_13_]], [[VAR_14_]] : index
+// CHECK-DAG:         [[VAR_16_:%.+]] = arith.addi [[VAR_14_]], [[CST_4_]] : index
+// CHECK:             [[VAR_17_:%.+]] = arith.minsi [[VAR_16_]], [[VAR_5_]] : index
+// CHECK:             [[VAR_18_:%.+]] = arith.subi [[VAR_17_]], [[VAR_14_]] : index
+// CHECK-DAG:         [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_13_]]{{.}}, sizes: {{.}}[[CST_4_]], [[VAR_18_]]{{.}}, strides: {{.}}[[VAR_0_]], [[VAR_3_]]{{.}} : memref<*xf32> to memref<4x?xf32, strided<[?, ?], offset: ?>>
+// CHECK-DAG:         [[VAR_19_:%.+]] = arith.subi [[CST_4_]], [[VAR_18_]] : index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_15_]]{{.}}, sizes: {{.}}[[CST_4_]], [[VAR_19_]]{{.}}, strides: {{.}}[[VAR_0_]], [[VAR_3_]]{{.}} : memref<*xf32> to memref<4x?xf32, strided<[?, ?], offset: ?>>
+// CHECK-DAG:         [[RES_:%.+]] = memref.alloc() : memref<4x4xf32>
+// CHECK:             linalg.fill ins([[CST_minus_9_dot_900000_]] : f32) outs([[RES_]] : memref<4x4xf32>)
+// CHECK:             [[VAR_20_:%.+]] = arith.minsi [[VAR_18_]], [[CST_4_]] : index
+// CHECK-DAG:         [[VAR_21_:%.+]] = arith.subi [[CST_4_]], [[VAR_20_]] : index
+// CHECK-DAG:         [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_0_]][0, 0] [2, [[VAR_20_]]{{.}} [1, 1] : memref<4x?xf32, strided<[?, ?], offset: ?>> to memref<2x?xf32, strided<[?, ?], offset: ?>>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_subview_2_:%.+]] = memref.subview [[VAR_reinterpret_cast_1_]][0, 0] [2, [[VAR_21_]]{{.}} [1, 1] : memref<4x?xf32, strided<[?, ?], offset: ?>> to memref<2x?xf32, strided<[?, ?], offset: ?>>
+// CHECK-DAG:         [[VAR_subview_3_:%.+]] = memref.subview [[RES_]][0, 0] [2, [[VAR_20_]]{{.}} [1, 1] : memref<4x4xf32> to memref<2x?xf32, strided<[4, 1]>>
+// CHECK-DAG:         [[VAR_subview_4_:%.+]] = memref.subview [[RES_]][0, [[VAR_20_]]{{.}} [2, [[VAR_21_]]{{.}} [1, 1] : memref<4x4xf32> to memref<2x?xf32, strided<[4, 1], offset: ?>>
+// CHECK:             memref.copy [[VAR_subview_]], [[VAR_subview_3_]] : memref<2x?xf32, strided<[?, ?], offset: ?>> to memref<2x?xf32, strided<[4, 1]>>
+// CHECK:             memref.copy [[VAR_subview_2_]], [[VAR_subview_4_]] : memref<2x?xf32, strided<[?, ?], offset: ?>> to memref<2x?xf32, strided<[4, 1], offset: ?>>
+// CHECK:             [[VAR_22_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<4x4xf32>
+// CHECK:             bufferization.materialize_in_destination [[VAR_22_]] in writable [[VAR_reinterpret_cast_]] : (tensor<4x4xf32>, memref<4x4xf32, strided<[?, ?], offset: ?>>) -> ()
+// CHECK-DAG:         [[VAR_23_:%.+]] = arith.addi [[VAR_arg15_]], [[VAR_9_]] : index
+// CHECK-DAG:         [[VAR_24_:%.+]] = arith.addi [[VAR_arg16_]], [[VAR_11_]] : index
+// CHECK:             scf.yield [[VAR_23_]], [[VAR_24_]] : index, index
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/wraparound_side_by_side.mlir
+++ b/test/Conversion/StructuredToMemref/wraparound_side_by_side.mlir
@@ -13,36 +13,36 @@ module {
     %0 = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32>
     %1 = arith.addi %0, %cst_2 : tensor<4xi32>
     %2 = arith.addi %0, %cst_1 : tensor<4xi32>
-    %3 = tt.splat %arg3 : (i32) -> tensor<4xi32>
+    %3 = tt.splat %arg3 : i32 -> tensor<4xi32>
     %4 = arith.remsi %2, %3 : tensor<4xi32>
-    %5 = tt.expand_dims %1 {axis = 1 : i32} : (tensor<4xi32>) -> tensor<4x1xi32>
-    %6 = tt.splat %arg4 : (i32) -> tensor<4x1xi32>
+    %5 = tt.expand_dims %1 {axis = 1 : i32} : tensor<4xi32> -> tensor<4x1xi32>
+    %6 = tt.splat %arg4 : i32 -> tensor<4x1xi32>
     %7 = arith.muli %5, %6 : tensor<4x1xi32>
-    %8 = tt.expand_dims %4 {axis = 0 : i32} : (tensor<4xi32>) -> tensor<1x4xi32>
-    %9 = tt.splat %arg5 : (i32) -> tensor<1x4xi32>
+    %8 = tt.expand_dims %4 {axis = 0 : i32} : tensor<4xi32> -> tensor<1x4xi32>
+    %9 = tt.splat %arg5 : i32 -> tensor<1x4xi32>
     %10 = arith.muli %8, %9 : tensor<1x4xi32>
-    %11 = tt.broadcast %7 : (tensor<4x1xi32>) -> tensor<4x4xi32>
-    %12 = tt.broadcast %10 : (tensor<1x4xi32>) -> tensor<4x4xi32>
+    %11 = tt.broadcast %7 : tensor<4x1xi32> -> tensor<4x4xi32>
+    %12 = tt.broadcast %10 : tensor<1x4xi32> -> tensor<4x4xi32>
     %13 = arith.addi %11, %12 : tensor<4x4xi32>
-    %14 = tt.splat %arg0 : (!tt.ptr<f32>) -> tensor<4x4x!tt.ptr<f32>>
+    %14 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<4x4x!tt.ptr<f32>>
     %15 = tt.addptr %14, %13 : tensor<4x4x!tt.ptr<f32>>, tensor<4x4xi32>
-    %16 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<4xi32>) -> tensor<4x1xi32>
-    %17 = tt.splat %arg6 : (i32) -> tensor<4x1xi32>
+    %16 = tt.expand_dims %0 {axis = 1 : i32} : tensor<4xi32> -> tensor<4x1xi32>
+    %17 = tt.splat %arg6 : i32 -> tensor<4x1xi32>
     %18 = arith.muli %17, %16 : tensor<4x1xi32>
-    %19 = tt.splat %arg1 : (!tt.ptr<f32>) -> tensor<4x1x!tt.ptr<f32>>
+    %19 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<4x1x!tt.ptr<f32>>
     %20 = tt.addptr %19, %18 : tensor<4x1x!tt.ptr<f32>>, tensor<4x1xi32>
-    %21 = tt.expand_dims %0 {axis = 0 : i32} : (tensor<4xi32>) -> tensor<1x4xi32>
-    %22 = tt.splat %arg7 : (i32) -> tensor<1x4xi32>
+    %21 = tt.expand_dims %0 {axis = 0 : i32} : tensor<4xi32> -> tensor<1x4xi32>
+    %22 = tt.splat %arg7 : i32 -> tensor<1x4xi32>
     %23 = arith.muli %22, %21 : tensor<1x4xi32>
-    %24 = tt.broadcast %20 : (tensor<4x1x!tt.ptr<f32>>) -> tensor<4x4x!tt.ptr<f32>>
-    %25 = tt.broadcast %23 : (tensor<1x4xi32>) -> tensor<4x4xi32>
+    %24 = tt.broadcast %20 : tensor<4x1x!tt.ptr<f32>> -> tensor<4x4x!tt.ptr<f32>>
+    %25 = tt.broadcast %23 : tensor<1x4xi32> -> tensor<4x4xi32>
     %26 = tt.addptr %24, %25 : tensor<4x4x!tt.ptr<f32>>, tensor<4x4xi32>
     %27 = arith.cmpi slt, %16, %cst_0 : tensor<4x1xi32>
-    %28 = tt.broadcast %27 : (tensor<4x1xi1>) -> tensor<4x4xi1>
+    %28 = tt.broadcast %27 : tensor<4x1xi1> -> tensor<4x4xi1>
     %29 = arith.muli %arg4, %c4_i32 : i32
-    %30 = tt.splat %29 : (i32) -> tensor<4x4xi32>
+    %30 = tt.splat %29 : i32 -> tensor<4x4xi32>
     %31 = arith.muli %arg5, %c4_i32 : i32
-    %32 = tt.splat %31 : (i32) -> tensor<4x4xi32>
+    %32 = tt.splat %31 : i32 -> tensor<4x4xi32>
     %33:2 = scf.for %arg8 = %c0_i32 to %c2_i32 step %c1_i32 iter_args(%arg9 = %15, %arg10 = %26) -> (tensor<4x4x!tt.ptr<f32>>, tensor<4x4x!tt.ptr<f32>>)  : i32 {
       %34 = tt.load %arg9, %28, %cst {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<4x4xf32>
       tt.store %arg10, %34 {cache = 1 : i32, evict = 1 : i32} : tensor<4x4xf32>

--- a/test/Conversion/StructuredToMemref/wraparound_stacked.mlir
+++ b/test/Conversion/StructuredToMemref/wraparound_stacked.mlir
@@ -12,35 +12,35 @@ module {
     %c4_i32 = arith.constant 4 : i32
     %0 = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32>
     %1 = arith.addi %0, %cst_2 : tensor<4xi32>
-    %2 = tt.splat %arg2 : (i32) -> tensor<4xi32>
+    %2 = tt.splat %arg2 : i32 -> tensor<4xi32>
     %3 = arith.remsi %1, %2 : tensor<4xi32>
     %4 = arith.addi %0, %cst_1 : tensor<4xi32>
-    %5 = tt.expand_dims %3 {axis = 1 : i32} : (tensor<4xi32>) -> tensor<4x1xi32>
-    %6 = tt.splat %arg4 : (i32) -> tensor<4x1xi32>
+    %5 = tt.expand_dims %3 {axis = 1 : i32} : tensor<4xi32> -> tensor<4x1xi32>
+    %6 = tt.splat %arg4 : i32 -> tensor<4x1xi32>
     %7 = arith.muli %5, %6 : tensor<4x1xi32>
-    %8 = tt.expand_dims %4 {axis = 0 : i32} : (tensor<4xi32>) -> tensor<1x4xi32>
-    %9 = tt.splat %arg5 : (i32) -> tensor<1x4xi32>
+    %8 = tt.expand_dims %4 {axis = 0 : i32} : tensor<4xi32> -> tensor<1x4xi32>
+    %9 = tt.splat %arg5 : i32 -> tensor<1x4xi32>
     %10 = arith.muli %8, %9 : tensor<1x4xi32>
-    %11 = tt.broadcast %7 : (tensor<4x1xi32>) -> tensor<4x4xi32>
-    %12 = tt.broadcast %10 : (tensor<1x4xi32>) -> tensor<4x4xi32>
+    %11 = tt.broadcast %7 : tensor<4x1xi32> -> tensor<4x4xi32>
+    %12 = tt.broadcast %10 : tensor<1x4xi32> -> tensor<4x4xi32>
     %13 = arith.addi %11, %12 : tensor<4x4xi32>
-    %14 = tt.splat %arg0 : (!tt.ptr<f32>) -> tensor<4x4x!tt.ptr<f32>>
+    %14 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<4x4x!tt.ptr<f32>>
     %15 = tt.addptr %14, %13 : tensor<4x4x!tt.ptr<f32>>, tensor<4x4xi32>
-    %16 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<4xi32>) -> tensor<4x1xi32>
-    %17 = tt.splat %arg6 : (i32) -> tensor<4x1xi32>
+    %16 = tt.expand_dims %0 {axis = 1 : i32} : tensor<4xi32> -> tensor<4x1xi32>
+    %17 = tt.splat %arg6 : i32 -> tensor<4x1xi32>
     %18 = arith.muli %17, %16 : tensor<4x1xi32>
-    %19 = tt.splat %arg1 : (!tt.ptr<f32>) -> tensor<4x1x!tt.ptr<f32>>
+    %19 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<4x1x!tt.ptr<f32>>
     %20 = tt.addptr %19, %18 : tensor<4x1x!tt.ptr<f32>>, tensor<4x1xi32>
-    %21 = tt.expand_dims %0 {axis = 0 : i32} : (tensor<4xi32>) -> tensor<1x4xi32>
-    %22 = tt.splat %arg7 : (i32) -> tensor<1x4xi32>
+    %21 = tt.expand_dims %0 {axis = 0 : i32} : tensor<4xi32> -> tensor<1x4xi32>
+    %22 = tt.splat %arg7 : i32 -> tensor<1x4xi32>
     %23 = arith.muli %22, %21 : tensor<1x4xi32>
-    %24 = tt.broadcast %20 : (tensor<4x1x!tt.ptr<f32>>) -> tensor<4x4x!tt.ptr<f32>>
-    %25 = tt.broadcast %23 : (tensor<1x4xi32>) -> tensor<4x4xi32>
+    %24 = tt.broadcast %20 : tensor<4x1x!tt.ptr<f32>> -> tensor<4x4x!tt.ptr<f32>>
+    %25 = tt.broadcast %23 : tensor<1x4xi32> -> tensor<4x4xi32>
     %26 = tt.addptr %24, %25 : tensor<4x4x!tt.ptr<f32>>, tensor<4x4xi32>
     %27 = arith.cmpi slt, %21, %cst_0 : tensor<1x4xi32>
-    %28 = tt.broadcast %27 : (tensor<1x4xi1>) -> tensor<4x4xi1>
+    %28 = tt.broadcast %27 : tensor<1x4xi1> -> tensor<4x4xi1>
     %29 = arith.muli %arg5, %c4_i32 : i32
-    %30 = tt.splat %29 : (i32) -> tensor<4x4xi32>
+    %30 = tt.splat %29 : i32 -> tensor<4x4xi32>
     %31:2 = scf.for %arg8 = %c0_i32 to %c2_i32 step %c1_i32 iter_args(%arg9 = %15, %arg10 = %26) -> (tensor<4x4x!tt.ptr<f32>>, tensor<4x4x!tt.ptr<f32>>)  : i32 {
       %32 = tt.load %arg9, %28, %cst {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<4x4xf32>
       tt.store %arg10, %32 {cache = 1 : i32, evict = 1 : i32} : tensor<4x4xf32>

--- a/test/Conversion/StructuredToMemref/wraparound_stacked.mlir
+++ b/test/Conversion/StructuredToMemref/wraparound_stacked.mlir
@@ -1,0 +1,110 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+
+module {
+  tt.func public @wrap_stacked_masked_loop_01234567(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32, %arg6: i32, %arg7: i32) {
+    %cst = arith.constant dense<-9.900000e+01> : tensor<4x4xf32>
+    %c1_i32 = arith.constant 1 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %cst_0 = arith.constant dense<3> : tensor<1x4xi32>
+    %cst_1 = arith.constant dense<3> : tensor<4xi32>
+    %cst_2 = arith.constant dense<2> : tensor<4xi32>
+    %c4_i32 = arith.constant 4 : i32
+    %0 = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32>
+    %1 = arith.addi %0, %cst_2 : tensor<4xi32>
+    %2 = tt.splat %arg2 : (i32) -> tensor<4xi32>
+    %3 = arith.remsi %1, %2 : tensor<4xi32>
+    %4 = arith.addi %0, %cst_1 : tensor<4xi32>
+    %5 = tt.expand_dims %3 {axis = 1 : i32} : (tensor<4xi32>) -> tensor<4x1xi32>
+    %6 = tt.splat %arg4 : (i32) -> tensor<4x1xi32>
+    %7 = arith.muli %5, %6 : tensor<4x1xi32>
+    %8 = tt.expand_dims %4 {axis = 0 : i32} : (tensor<4xi32>) -> tensor<1x4xi32>
+    %9 = tt.splat %arg5 : (i32) -> tensor<1x4xi32>
+    %10 = arith.muli %8, %9 : tensor<1x4xi32>
+    %11 = tt.broadcast %7 : (tensor<4x1xi32>) -> tensor<4x4xi32>
+    %12 = tt.broadcast %10 : (tensor<1x4xi32>) -> tensor<4x4xi32>
+    %13 = arith.addi %11, %12 : tensor<4x4xi32>
+    %14 = tt.splat %arg0 : (!tt.ptr<f32>) -> tensor<4x4x!tt.ptr<f32>>
+    %15 = tt.addptr %14, %13 : tensor<4x4x!tt.ptr<f32>>, tensor<4x4xi32>
+    %16 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<4xi32>) -> tensor<4x1xi32>
+    %17 = tt.splat %arg6 : (i32) -> tensor<4x1xi32>
+    %18 = arith.muli %17, %16 : tensor<4x1xi32>
+    %19 = tt.splat %arg1 : (!tt.ptr<f32>) -> tensor<4x1x!tt.ptr<f32>>
+    %20 = tt.addptr %19, %18 : tensor<4x1x!tt.ptr<f32>>, tensor<4x1xi32>
+    %21 = tt.expand_dims %0 {axis = 0 : i32} : (tensor<4xi32>) -> tensor<1x4xi32>
+    %22 = tt.splat %arg7 : (i32) -> tensor<1x4xi32>
+    %23 = arith.muli %22, %21 : tensor<1x4xi32>
+    %24 = tt.broadcast %20 : (tensor<4x1x!tt.ptr<f32>>) -> tensor<4x4x!tt.ptr<f32>>
+    %25 = tt.broadcast %23 : (tensor<1x4xi32>) -> tensor<4x4xi32>
+    %26 = tt.addptr %24, %25 : tensor<4x4x!tt.ptr<f32>>, tensor<4x4xi32>
+    %27 = arith.cmpi slt, %21, %cst_0 : tensor<1x4xi32>
+    %28 = tt.broadcast %27 : (tensor<1x4xi1>) -> tensor<4x4xi1>
+    %29 = arith.muli %arg5, %c4_i32 : i32
+    %30 = tt.splat %29 : (i32) -> tensor<4x4xi32>
+    %31:2 = scf.for %arg8 = %c0_i32 to %c2_i32 step %c1_i32 iter_args(%arg9 = %15, %arg10 = %26) -> (tensor<4x4x!tt.ptr<f32>>, tensor<4x4x!tt.ptr<f32>>)  : i32 {
+      %32 = tt.load %arg9, %28, %cst {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<4x4xf32>
+      tt.store %arg10, %32 {cache = 1 : i32, evict = 1 : i32} : tensor<4x4xf32>
+      %33 = tt.addptr %arg9, %30 : tensor<4x4x!tt.ptr<f32>>, tensor<4x4xi32>
+      %34 = tt.addptr %arg10, %30 : tensor<4x4x!tt.ptr<f32>>, tensor<4x4xi32>
+      scf.yield %33, %34 : tensor<4x4x!tt.ptr<f32>>, tensor<4x4x!tt.ptr<f32>>
+    }
+    tt.return
+  }
+}
+
+// mlir2FileCheck.py
+// CHECK-LABEL:  func.func @wrap_stacked_masked_loop_01234567
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32, [[PARAM_10_:%.+]]: i32, [[PARAM_11_:%.+]]: i32, [[PARAM_12_:%.+]]: i32, [[PARAM_13_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_4_:%.+]] = arith.constant 4 : index
+// CHECK-DAG:       [[CST_4_1_:%.+]] = arith.constant 4 : i32
+// CHECK-DAG:       [[CST_2_:%.+]] = arith.constant 2 : i32
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : i32
+// CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : i32
+// CHECK-DAG:       [[CST_2_1_:%.+]] = arith.constant 2 : index
+// CHECK-DAG:       [[CST_3_:%.+]] = arith.constant 3 : index
+// CHECK-DAG:       [[CST_0_1_:%.+]] = arith.constant 0 : index
+// CHECK-DAG:       [[CST_minus_9_dot_900000_:%.+]] = arith.constant -9.900000e+01 : f32
+// CHECK-DAG:       [[VAR_0_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[PARAM_4_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.muli [[VAR_1_]], [[CST_2_1_]] : index
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.muli [[VAR_0_]], [[VAR_1_]] : index
+// CHECK-DAG:       [[VAR_4_:%.+]] = arith.index_cast [[PARAM_5_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.muli [[VAR_4_]], [[CST_3_]] : index
+// CHECK-DAG:       [[VAR_6_:%.+]] = arith.index_cast [[PARAM_6_]] : i32 to index
+// CHECK-DAG:       [[VAR_7_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
+// CHECK-DAG:       [[VAR_8_:%.+]] = arith.muli [[PARAM_5_]], [[CST_4_1_]] : i32
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_9_:%.+]] = arith.index_cast [[VAR_8_]] : i32 to index
+// CHECK-DAG:       [[VAR_10_:%.+]] = arith.index_cast [[VAR_8_]] : i32 to index
+// CHECK-DAG:       [[VAR_11_:%.+]]:2 = scf.for [[VAR_arg14_:%.+]] = [[CST_0_]] to [[CST_2_]] step [[CST_1_]] iter_args([[VAR_arg15_:%.+]] = [[VAR_2_]], [[VAR_arg16_:%.+]] = [[CST_0_1_]]) -> (index, index)  : i32 {
+// CHECK-DAG:         [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_arg16_]]{{.}}, sizes: [4, 4], strides: {{.}}[[VAR_6_]], [[VAR_7_]]{{.}} : memref<*xf32> to memref<4x4xf32, strided<[?, ?], offset: ?>>
+// CHECK-DAG:         [[VAR_12_:%.+]] = arith.addi [[VAR_arg15_]], [[VAR_5_]] : index
+// CHECK:             [[VAR_13_:%.+]] = arith.remsi [[VAR_12_]], [[VAR_1_]] : index
+// CHECK:             [[VAR_14_:%.+]] = arith.addi [[VAR_3_]], [[VAR_13_]] : index
+// CHECK:             [[VAR_15_:%.+]] = arith.subi [[VAR_14_]], [[VAR_12_]] : index
+// CHECK:             [[VAR_16_:%.+]] = arith.divsi [[VAR_15_]], [[VAR_1_]] : index
+// CHECK-DAG:         [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_12_]]{{.}}, sizes: {{.}}[[VAR_16_]], [[CST_4_]]{{.}}, strides: {{.}}[[VAR_1_]], [[VAR_4_]]{{.}} : memref<*xf32> to memref<?x4xf32, strided<[?, ?], offset: ?>>
+// CHECK-DAG:         [[VAR_17_:%.+]] = arith.subi [[CST_4_]], [[VAR_16_]] : index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_13_]]{{.}}, sizes: {{.}}[[VAR_17_]], [[CST_4_]]{{.}}, strides: {{.}}[[VAR_1_]], [[VAR_4_]]{{.}} : memref<*xf32> to memref<?x4xf32, strided<[?, ?], offset: ?>>
+// CHECK-DAG:         [[RES_:%.+]] = memref.alloc() : memref<4x4xf32>
+// CHECK:             linalg.fill ins([[CST_minus_9_dot_900000_]] : f32) outs([[RES_]] : memref<4x4xf32>)
+// CHECK:             [[VAR_18_:%.+]] = arith.minsi [[VAR_16_]], [[CST_4_]] : index
+// CHECK-DAG:         [[VAR_19_:%.+]] = arith.subi [[CST_4_]], [[VAR_18_]] : index
+// CHECK-DAG:         [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_0_]][0, 0] {{.}}[[VAR_18_]], 3] [1, 1] : memref<?x4xf32, strided<[?, ?], offset: ?>> to memref<?x3xf32, strided<[?, ?], offset: ?>>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_subview_2_:%.+]] = memref.subview [[VAR_reinterpret_cast_1_]][0, 0] {{.}}[[VAR_19_]], 3] [1, 1] : memref<?x4xf32, strided<[?, ?], offset: ?>> to memref<?x3xf32, strided<[?, ?], offset: ?>>
+// CHECK-DAG:         [[VAR_subview_3_:%.+]] = memref.subview [[RES_]][0, 0] {{.}}[[VAR_18_]], 3] [1, 1] : memref<4x4xf32> to memref<?x3xf32, strided<[4, 1]>>
+// CHECK-DAG:         [[VAR_subview_4_:%.+]] = memref.subview [[RES_]]{{.}}[[VAR_18_]], 0] {{.}}[[VAR_19_]], 3] [1, 1] : memref<4x4xf32> to memref<?x3xf32, strided<[4, 1], offset: ?>>
+// CHECK:             memref.copy [[VAR_subview_]], [[VAR_subview_3_]] : memref<?x3xf32, strided<[?, ?], offset: ?>> to memref<?x3xf32, strided<[4, 1]>>
+// CHECK:             memref.copy [[VAR_subview_2_]], [[VAR_subview_4_]] : memref<?x3xf32, strided<[?, ?], offset: ?>> to memref<?x3xf32, strided<[4, 1], offset: ?>>
+// CHECK:             [[VAR_20_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<4x4xf32>
+// CHECK:             bufferization.materialize_in_destination [[VAR_20_]] in writable [[VAR_reinterpret_cast_]] : (tensor<4x4xf32>, memref<4x4xf32, strided<[?, ?], offset: ?>>) -> ()
+// CHECK-DAG:         [[VAR_21_:%.+]] = arith.addi [[VAR_arg15_]], [[VAR_10_]] : index
+// CHECK-DAG:         [[VAR_22_:%.+]] = arith.addi [[VAR_arg16_]], [[VAR_9_]] : index
+// CHECK:             scf.yield [[VAR_21_]], [[VAR_22_]] : index, index
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/wraparound_unsupported_add_offset.mlir
+++ b/test/Conversion/StructuredToMemref/wraparound_unsupported_add_offset.mlir
@@ -14,37 +14,37 @@ module {
     %c4_i32 = arith.constant 4 : i32
     %0 = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32>
     %1 = arith.addi %0, %cst_2 : tensor<4xi32>
-    %2 = tt.splat %arg3 : (i32) -> tensor<4xi32>
+    %2 = tt.splat %arg3 : i32 -> tensor<4xi32>
     %3 = arith.remsi %0, %2 : tensor<4xi32>
     %4 = arith.addi %3, %cst_1 : tensor<4xi32>
-    %5 = tt.expand_dims %1 {axis = 1 : i32} : (tensor<4xi32>) -> tensor<4x1xi32>
-    %6 = tt.splat %arg4 : (i32) -> tensor<4x1xi32>
+    %5 = tt.expand_dims %1 {axis = 1 : i32} : tensor<4xi32> -> tensor<4x1xi32>
+    %6 = tt.splat %arg4 : i32 -> tensor<4x1xi32>
     %7 = arith.muli %5, %6 : tensor<4x1xi32>
-    %8 = tt.expand_dims %4 {axis = 0 : i32} : (tensor<4xi32>) -> tensor<1x4xi32>
-    %9 = tt.splat %arg5 : (i32) -> tensor<1x4xi32>
+    %8 = tt.expand_dims %4 {axis = 0 : i32} : tensor<4xi32> -> tensor<1x4xi32>
+    %9 = tt.splat %arg5 : i32 -> tensor<1x4xi32>
     %10 = arith.muli %8, %9 : tensor<1x4xi32>
-    %11 = tt.broadcast %7 : (tensor<4x1xi32>) -> tensor<4x4xi32>
-    %12 = tt.broadcast %10 : (tensor<1x4xi32>) -> tensor<4x4xi32>
+    %11 = tt.broadcast %7 : tensor<4x1xi32> -> tensor<4x4xi32>
+    %12 = tt.broadcast %10 : tensor<1x4xi32> -> tensor<4x4xi32>
     %13 = arith.addi %11, %12 : tensor<4x4xi32>
-    %14 = tt.splat %arg0 : (!tt.ptr<f32>) -> tensor<4x4x!tt.ptr<f32>>
+    %14 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<4x4x!tt.ptr<f32>>
     %15 = tt.addptr %14, %13 : tensor<4x4x!tt.ptr<f32>>, tensor<4x4xi32>
-    %16 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<4xi32>) -> tensor<4x1xi32>
-    %17 = tt.splat %arg6 : (i32) -> tensor<4x1xi32>
+    %16 = tt.expand_dims %0 {axis = 1 : i32} : tensor<4xi32> -> tensor<4x1xi32>
+    %17 = tt.splat %arg6 : i32 -> tensor<4x1xi32>
     %18 = arith.muli %17, %16 : tensor<4x1xi32>
-    %19 = tt.splat %arg1 : (!tt.ptr<f32>) -> tensor<4x1x!tt.ptr<f32>>
+    %19 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<4x1x!tt.ptr<f32>>
     %20 = tt.addptr %19, %18 : tensor<4x1x!tt.ptr<f32>>, tensor<4x1xi32>
-    %21 = tt.expand_dims %0 {axis = 0 : i32} : (tensor<4xi32>) -> tensor<1x4xi32>
-    %22 = tt.splat %arg7 : (i32) -> tensor<1x4xi32>
+    %21 = tt.expand_dims %0 {axis = 0 : i32} : tensor<4xi32> -> tensor<1x4xi32>
+    %22 = tt.splat %arg7 : i32 -> tensor<1x4xi32>
     %23 = arith.muli %22, %21 : tensor<1x4xi32>
-    %24 = tt.broadcast %20 : (tensor<4x1x!tt.ptr<f32>>) -> tensor<4x4x!tt.ptr<f32>>
-    %25 = tt.broadcast %23 : (tensor<1x4xi32>) -> tensor<4x4xi32>
+    %24 = tt.broadcast %20 : tensor<4x1x!tt.ptr<f32>> -> tensor<4x4x!tt.ptr<f32>>
+    %25 = tt.broadcast %23 : tensor<1x4xi32> -> tensor<4x4xi32>
     %26 = tt.addptr %24, %25 : tensor<4x4x!tt.ptr<f32>>, tensor<4x4xi32>
     %27 = arith.cmpi slt, %16, %cst_0 : tensor<4x1xi32>
-    %28 = tt.broadcast %27 : (tensor<4x1xi1>) -> tensor<4x4xi1>
+    %28 = tt.broadcast %27 : tensor<4x1xi1> -> tensor<4x4xi1>
     %29 = arith.muli %arg4, %c4_i32 : i32
-    %30 = tt.splat %29 : (i32) -> tensor<4x4xi32>
+    %30 = tt.splat %29 : i32 -> tensor<4x4xi32>
     %31 = arith.muli %arg5, %c4_i32 : i32
-    %32 = tt.splat %31 : (i32) -> tensor<4x4xi32>
+    %32 = tt.splat %31 : i32 -> tensor<4x4xi32>
     %33:2 = scf.for %arg8 = %c0_i32 to %c2_i32 step %c1_i32 iter_args(%arg9 = %15, %arg10 = %26) -> (tensor<4x4x!tt.ptr<f32>>, tensor<4x4x!tt.ptr<f32>>)  : i32 {
       %34 = tt.load %arg9, %28, %cst {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<4x4xf32>
       tt.store %arg10, %34 {cache = 1 : i32, evict = 1 : i32} : tensor<4x4xf32>

--- a/test/Conversion/StructuredToMemref/wraparound_unsupported_add_offset.mlir
+++ b/test/Conversion/StructuredToMemref/wraparound_unsupported_add_offset.mlir
@@ -1,0 +1,57 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// XFAIL: *
+// We currently do not support this kind of modulo pattern:
+// (a + arrange(0, K)) % M
+module {
+  tt.func public @wrap_side_by_side_masked_loop_01234567(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32, %arg6: i32, %arg7: i32) {
+    %cst = arith.constant dense<-9.900000e+01> : tensor<4x4xf32>
+    %c1_i32 = arith.constant 1 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %cst_0 = arith.constant dense<2> : tensor<4x1xi32>
+    %cst_1 = arith.constant dense<6> : tensor<4xi32>
+    %cst_2 = arith.constant dense<2> : tensor<4xi32>
+    %c4_i32 = arith.constant 4 : i32
+    %0 = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32>
+    %1 = arith.addi %0, %cst_2 : tensor<4xi32>
+    %2 = tt.splat %arg3 : (i32) -> tensor<4xi32>
+    %3 = arith.remsi %0, %2 : tensor<4xi32>
+    %4 = arith.addi %3, %cst_1 : tensor<4xi32>
+    %5 = tt.expand_dims %1 {axis = 1 : i32} : (tensor<4xi32>) -> tensor<4x1xi32>
+    %6 = tt.splat %arg4 : (i32) -> tensor<4x1xi32>
+    %7 = arith.muli %5, %6 : tensor<4x1xi32>
+    %8 = tt.expand_dims %4 {axis = 0 : i32} : (tensor<4xi32>) -> tensor<1x4xi32>
+    %9 = tt.splat %arg5 : (i32) -> tensor<1x4xi32>
+    %10 = arith.muli %8, %9 : tensor<1x4xi32>
+    %11 = tt.broadcast %7 : (tensor<4x1xi32>) -> tensor<4x4xi32>
+    %12 = tt.broadcast %10 : (tensor<1x4xi32>) -> tensor<4x4xi32>
+    %13 = arith.addi %11, %12 : tensor<4x4xi32>
+    %14 = tt.splat %arg0 : (!tt.ptr<f32>) -> tensor<4x4x!tt.ptr<f32>>
+    %15 = tt.addptr %14, %13 : tensor<4x4x!tt.ptr<f32>>, tensor<4x4xi32>
+    %16 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<4xi32>) -> tensor<4x1xi32>
+    %17 = tt.splat %arg6 : (i32) -> tensor<4x1xi32>
+    %18 = arith.muli %17, %16 : tensor<4x1xi32>
+    %19 = tt.splat %arg1 : (!tt.ptr<f32>) -> tensor<4x1x!tt.ptr<f32>>
+    %20 = tt.addptr %19, %18 : tensor<4x1x!tt.ptr<f32>>, tensor<4x1xi32>
+    %21 = tt.expand_dims %0 {axis = 0 : i32} : (tensor<4xi32>) -> tensor<1x4xi32>
+    %22 = tt.splat %arg7 : (i32) -> tensor<1x4xi32>
+    %23 = arith.muli %22, %21 : tensor<1x4xi32>
+    %24 = tt.broadcast %20 : (tensor<4x1x!tt.ptr<f32>>) -> tensor<4x4x!tt.ptr<f32>>
+    %25 = tt.broadcast %23 : (tensor<1x4xi32>) -> tensor<4x4xi32>
+    %26 = tt.addptr %24, %25 : tensor<4x4x!tt.ptr<f32>>, tensor<4x4xi32>
+    %27 = arith.cmpi slt, %16, %cst_0 : tensor<4x1xi32>
+    %28 = tt.broadcast %27 : (tensor<4x1xi1>) -> tensor<4x4xi1>
+    %29 = arith.muli %arg4, %c4_i32 : i32
+    %30 = tt.splat %29 : (i32) -> tensor<4x4xi32>
+    %31 = arith.muli %arg5, %c4_i32 : i32
+    %32 = tt.splat %31 : (i32) -> tensor<4x4xi32>
+    %33:2 = scf.for %arg8 = %c0_i32 to %c2_i32 step %c1_i32 iter_args(%arg9 = %15, %arg10 = %26) -> (tensor<4x4x!tt.ptr<f32>>, tensor<4x4x!tt.ptr<f32>>)  : i32 {
+      %34 = tt.load %arg9, %28, %cst {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<4x4xf32>
+      tt.store %arg10, %34 {cache = 1 : i32, evict = 1 : i32} : tensor<4x4xf32>
+      %35 = tt.addptr %arg9, %30 : tensor<4x4x!tt.ptr<f32>>, tensor<4x4xi32>
+      %36 = tt.addptr %arg10, %32 : tensor<4x4x!tt.ptr<f32>>, tensor<4x4xi32>
+      scf.yield %35, %36 : tensor<4x4x!tt.ptr<f32>>, tensor<4x4x!tt.ptr<f32>>
+    }
+    tt.return
+  }
+}

--- a/test/Conversion/TritonToStructured/addptr_2d_example.mlir
+++ b/test/Conversion/TritonToStructured/addptr_2d_example.mlir
@@ -50,13 +50,13 @@ module {
 // CHECK-DAG:       [[CST_5_:%.+]] = arith.constant 5 : index
 // CHECK-DAG:       [[VAR_0_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
 // CHECK:           [[VAR_1_:%.+]] = tts.make_tptr [[PARAM_0_]] to sizes: [4, 256], strides: [1, [[CST_5_]]{{.}}, offsets: {{.}}[[VAR_0_]], 0], shape: [0, 0], order: [] : <bf16, 1> to tensor<4x256x!tt.ptr<bf16, 1>>
-// CHECK-DAG:       [[VAR_2_:%.+]] = "tts.load"([[VAR_1_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_dims = array<i64>}> : (tensor<4x256x!tt.ptr<bf16, 1>>) -> tensor<4x256xbf16>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "tts.load"([[VAR_1_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<4x256x!tt.ptr<bf16, 1>>) -> tensor<4x256xbf16>
 // CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
 // CHECK:           [[VAR_4_:%.+]] = tts.make_tptr [[PARAM_1_]] to sizes: [4, 256], strides: [1, [[CST_5_]]{{.}}, offsets: {{.}}[[VAR_3_]], 0], shape: [0, 0], order: [] : <bf16, 1> to tensor<4x256x!tt.ptr<bf16, 1>>
-// CHECK:           [[VAR_5_:%.+]] = "tts.load"([[VAR_4_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_dims = array<i64>}> : (tensor<4x256x!tt.ptr<bf16, 1>>) -> tensor<4x256xbf16>
+// CHECK:           [[VAR_5_:%.+]] = "tts.load"([[VAR_4_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<4x256x!tt.ptr<bf16, 1>>) -> tensor<4x256xbf16>
 // CHECK-DAG:       [[VAR_6_:%.+]] = arith.addf [[VAR_2_]], [[VAR_5_]] : tensor<4x256xbf16>
 // CHECK-DAG:       [[VAR_7_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
 // CHECK:           [[VAR_8_:%.+]] = tts.make_tptr [[PARAM_2_]] to sizes: [4, 256], strides: [1, [[CST_5_]]{{.}}, offsets: {{.}}[[VAR_7_]], 0], shape: [0, 0], order: [] : <bf16, 1> to tensor<4x256x!tt.ptr<bf16, 1>>
-// CHECK:           "tts.store"([[VAR_8_]], [[VAR_6_]]) <{static_dims = array<i64>}> : (tensor<4x256x!tt.ptr<bf16, 1>>, tensor<4x256xbf16>) -> ()
+// CHECK:           "tts.store"([[VAR_8_]], [[VAR_6_]]) <{static_mask_dims = array<i64>}> : (tensor<4x256x!tt.ptr<bf16, 1>>, tensor<4x256xbf16>) -> ()
 // CHECK:           tt.return
 // CHECK:         }

--- a/test/Conversion/TritonToStructured/addptr_add_value.mlir
+++ b/test/Conversion/TritonToStructured/addptr_add_value.mlir
@@ -61,7 +61,7 @@ module {
 // CHECK:           [[VAR_7_:%.+]] = arith.addi [[VAR_5_]], [[VAR_6_]] : index
 // CHECK:           [[VAR_8_:%.+]] = arith.addi [[VAR_7_]], [[CST_10_]] : index
 // CHECK-DAG:       [[VAR_9_:%.+]] = tts.make_tptr [[PARAM_1_]] to sizes: [4, 256], strides: [1, [[CST_6_]]{{.}}, offsets: {{.}}[[VAR_8_]], 0], shape: [0, 0], order: [] : <bf16, 1> to tensor<4x256x!tt.ptr<bf16, 1>>
-// CHECK-DAG:       [[VAR_10_:%.+]] = "tts.load"([[VAR_4_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_dims = array<i64>}> : (tensor<4x256x!tt.ptr<bf16, 1>>) -> tensor<4x256xbf16>
-// CHECK:           "tts.store"([[VAR_9_]], [[VAR_10_]]) <{static_dims = array<i64>}> : (tensor<4x256x!tt.ptr<bf16, 1>>, tensor<4x256xbf16>) -> ()
+// CHECK-DAG:       [[VAR_10_:%.+]] = "tts.load"([[VAR_4_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<4x256x!tt.ptr<bf16, 1>>) -> tensor<4x256xbf16>
+// CHECK:           "tts.store"([[VAR_9_]], [[VAR_10_]]) <{static_mask_dims = array<i64>}> : (tensor<4x256x!tt.ptr<bf16, 1>>, tensor<4x256xbf16>) -> ()
 // CHECK:           tt.return
 // CHECK:         }

--- a/test/Conversion/TritonToStructured/addptr_dim1.mlir
+++ b/test/Conversion/TritonToStructured/addptr_dim1.mlir
@@ -80,21 +80,21 @@ module {
 // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
 // CHECK-DAG:       [[VAR_0_:%.+]] = tts.make_tptr [[PARAM_0_]] to sizes: [1, 256], strides: [0, 1], offsets: [0, 0], shape: [0, 0], order: [] : <bf16, 1> to tensor<1x256x!tt.ptr<bf16, 1>>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_1_:%.+]] = "tts.load"([[VAR_0_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_dims = array<i64>}> : (tensor<1x256x!tt.ptr<bf16, 1>>) -> tensor<1x256xbf16>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "tts.load"([[VAR_0_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<1x256x!tt.ptr<bf16, 1>>) -> tensor<1x256xbf16>
 // CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[PARAM_1_]] : i32 to index
 // CHECK:           [[VAR_3_:%.+]] = tts.make_tptr [[PARAM_0_]] to sizes: [1, 256], strides: [0, 1], offsets: {{.}}[[VAR_2_]], 0], shape: [0, 0], order: [] : <bf16, 1> to tensor<1x256x!tt.ptr<bf16, 1>>
-// CHECK:           "tts.store"([[VAR_3_]], [[VAR_1_]]) <{static_dims = array<i64>}> : (tensor<1x256x!tt.ptr<bf16, 1>>, tensor<1x256xbf16>) -> ()
+// CHECK:           "tts.store"([[VAR_3_]], [[VAR_1_]]) <{static_mask_dims = array<i64>}> : (tensor<1x256x!tt.ptr<bf16, 1>>, tensor<1x256xbf16>) -> ()
 // CHECK-DAG:       [[VAR_4_:%.+]]:2 = scf.for [[VAR_arg2_:%.+]] = [[CST_0_]] to [[CST_12_]] step [[CST_3_]] iter_args([[VAR_arg3_:%.+]] = [[VAR_cst_]], [[VAR_arg4_:%.+]] = [[CST_0_]]) -> (tensor<4x256xbf16>, index) {
 // CHECK-DAG:         [[VAR_6_:%.+]] = arith.index_cast [[VAR_arg2_]] : index to i32
 // CHECK:             [[VAR_7_:%.+]] = arith.muli [[VAR_6_]], [[CST_256_1_]] : i32
 // CHECK:             [[VAR_8_:%.+]] = arith.index_cast [[VAR_7_]] : i32 to index
 // CHECK:             [[VAR_9_:%.+]] = tts.make_tptr [[PARAM_0_]] to sizes: [4, 256], strides: {{.}}[[VAR_8_]], [[CST_1_]]{{.}}, offsets: {{.}}[[VAR_arg4_]], [[CST_0_]]{{.}}, shape: [0, 0], order: [] : <bf16, 1> to tensor<4x256x!tt.ptr<bf16, 1>>
-// CHECK:             [[VAR_10_:%.+]] = "tts.load"([[VAR_9_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_dims = array<i64>}> : (tensor<4x256x!tt.ptr<bf16, 1>>) -> tensor<4x256xbf16>
+// CHECK:             [[VAR_10_:%.+]] = "tts.load"([[VAR_9_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<4x256x!tt.ptr<bf16, 1>>) -> tensor<4x256xbf16>
 // CHECK-DAG:         [[VAR_11_:%.+]] = arith.addf [[VAR_arg3_]], [[VAR_10_]] : tensor<4x256xbf16>
 // CHECK-DAG:         [[VAR_12_:%.+]] = arith.addi [[VAR_arg4_]], [[CST_256_]] : index
 // CHECK:             scf.yield [[VAR_11_]], [[VAR_12_]] : tensor<4x256xbf16>, index
 // CHECK:           }
 // CHECK:           [[VAR_5_:%.+]] = tts.make_tptr [[PARAM_0_]] to sizes: [4, 256], strides: {{.}}[[CST_256_]], 1], offsets: [0, 0], shape: [0, 0], order: [] : <bf16, 1> to tensor<4x256x!tt.ptr<bf16, 1>>
-// CHECK:           "tts.store"([[VAR_5_]], [[VAR_4_]]#0) <{static_dims = array<i64>}> : (tensor<4x256x!tt.ptr<bf16, 1>>, tensor<4x256xbf16>) -> ()
+// CHECK:           "tts.store"([[VAR_5_]], [[VAR_4_]]#0) <{static_mask_dims = array<i64>}> : (tensor<4x256x!tt.ptr<bf16, 1>>, tensor<4x256xbf16>) -> ()
 // CHECK:           tt.return
 // CHECK:         }

--- a/test/Conversion/TritonToStructured/addptr_for_accumulation.mlir
+++ b/test/Conversion/TritonToStructured/addptr_for_accumulation.mlir
@@ -68,18 +68,18 @@ module {
 // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
 // CHECK-DAG:       [[VAR_0_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
 // CHECK:           [[VAR_1_:%.+]] = tts.make_tptr [[PARAM_0_]] to sizes: [4, 256], strides: [1, [[CST_5_]]{{.}}, offsets: {{.}}[[VAR_0_]], 0], shape: [0, 0], order: [] : <bf16, 1> to tensor<4x256x!tt.ptr<bf16, 1>>
-// CHECK-DAG:       [[VAR_2_:%.+]] = "tts.load"([[VAR_1_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_dims = array<i64>}> : (tensor<4x256x!tt.ptr<bf16, 1>>) -> tensor<4x256xbf16>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "tts.load"([[VAR_1_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<4x256x!tt.ptr<bf16, 1>>) -> tensor<4x256xbf16>
 // CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_4_:%.+]]:2 = scf.for [[VAR_arg5_:%.+]] = [[CST_0_]] to [[CST_12_]] step [[CST_3_]] iter_args([[VAR_arg6_:%.+]] = [[VAR_2_]], [[VAR_arg7_:%.+]] = [[VAR_3_]]) -> (tensor<4x256xbf16>, index) {
 // CHECK-DAG:         [[VAR_7_:%.+]] = tts.make_tptr [[PARAM_1_]] to sizes: [4, 256], strides: {{.}}[[CST_1_]], [[CST_5_]]{{.}}, offsets: {{.}}[[VAR_arg7_]], [[CST_0_]]{{.}}, shape: [0, 0], order: [] : <bf16, 1> to tensor<4x256x!tt.ptr<bf16, 1>>
-// CHECK:             [[VAR_8_:%.+]] = "tts.load"([[VAR_7_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_dims = array<i64>}> : (tensor<4x256x!tt.ptr<bf16, 1>>) -> tensor<4x256xbf16>
+// CHECK:             [[VAR_8_:%.+]] = "tts.load"([[VAR_7_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<4x256x!tt.ptr<bf16, 1>>) -> tensor<4x256xbf16>
 // CHECK-DAG:         [[VAR_9_:%.+]] = arith.addf [[VAR_arg6_]], [[VAR_8_]] : tensor<4x256xbf16>
 // CHECK-DAG:         [[VAR_10_:%.+]] = arith.addi [[VAR_arg7_]], [[CST_3_]] : index
 // CHECK:             scf.yield [[VAR_9_]], [[VAR_10_]] : tensor<4x256xbf16>, index
 // CHECK:           }
 // CHECK:           [[VAR_5_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
 // CHECK:           [[VAR_6_:%.+]] = tts.make_tptr [[PARAM_2_]] to sizes: [4, 256], strides: [1, [[CST_5_]]{{.}}, offsets: {{.}}[[VAR_5_]], 0], shape: [0, 0], order: [] : <bf16, 1> to tensor<4x256x!tt.ptr<bf16, 1>>
-// CHECK:           "tts.store"([[VAR_6_]], [[VAR_4_]]#0) <{static_dims = array<i64>}> : (tensor<4x256x!tt.ptr<bf16, 1>>, tensor<4x256xbf16>) -> ()
+// CHECK:           "tts.store"([[VAR_6_]], [[VAR_4_]]#0) <{static_mask_dims = array<i64>}> : (tensor<4x256x!tt.ptr<bf16, 1>>, tensor<4x256xbf16>) -> ()
 // CHECK:           tt.return
 // CHECK:         }

--- a/test/Conversion/TritonToStructured/addptr_for_expand_ptr.mlir
+++ b/test/Conversion/TritonToStructured/addptr_for_expand_ptr.mlir
@@ -62,8 +62,8 @@ module {
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_0_:%.+]] = scf.for [[VAR_arg1_:%.+]] = [[CST_0_]] to [[CST_12_]] step [[CST_3_]] iter_args([[VAR_arg2_:%.+]] = [[CST_1024_]]) -> (index) {
 // CHECK-DAG:         [[VAR_1_:%.+]] = tts.make_tptr [[PARAM_0_]] to sizes: [256, 256], strides: {{.}}[[CST_2_]], 1], offsets: {{.}}[[VAR_arg2_]], 256], shape: [0, 0], order: [] : <bf16, 1> to tensor<256x256x!tt.ptr<bf16, 1>>
-// CHECK:             [[VAR_2_:%.+]] = "tts.load"([[VAR_1_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_dims = array<i64>}> : (tensor<256x256x!tt.ptr<bf16, 1>>) -> tensor<256x256xbf16>
-// CHECK:             "tts.store"([[VAR_1_]], [[VAR_2_]]) <{static_dims = array<i64>}> : (tensor<256x256x!tt.ptr<bf16, 1>>, tensor<256x256xbf16>) -> ()
+// CHECK:             [[VAR_2_:%.+]] = "tts.load"([[VAR_1_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<256x256x!tt.ptr<bf16, 1>>) -> tensor<256x256xbf16>
+// CHECK:             "tts.store"([[VAR_1_]], [[VAR_2_]]) <{static_mask_dims = array<i64>}> : (tensor<256x256x!tt.ptr<bf16, 1>>, tensor<256x256xbf16>) -> ()
 // CHECK:             [[VAR_3_:%.+]] = arith.addi [[VAR_arg2_]], [[CST_3_]] : index
 // CHECK:             scf.yield [[VAR_3_]] : index
 // CHECK:           }

--- a/test/Conversion/TritonToStructured/addptr_for_more_init_args.mlir
+++ b/test/Conversion/TritonToStructured/addptr_for_more_init_args.mlir
@@ -54,8 +54,8 @@ module {
 // CHECK-DAG:       [[VAR_0_:%.+]]:5 = scf.for [[VAR_arg2_:%.+]] = [[CST_0_]] to [[CST_12_]] step [[CST_3_]] iter_args([[VAR_arg3_:%.+]] = [[CST_1_]], [[VAR_arg4_:%.+]] = [[CST_2_]], [[VAR_arg5_:%.+]] = [[CST_3_]], [[VAR_arg6_:%.+]] = [[CST_1_]]024, [[VAR_arg7_:%.+]] = [[CST_1_]]024) -> (index, index, index, index, index) {
 // CHECK-DAG:         [[VAR_1_:%.+]] = tts.make_tptr [[PARAM_1_]] to sizes: [256], strides: {{.}}[[CST_1_]]{{.}}, offsets: {{.}}[[VAR_arg7_]]{{.}}, shape: [0], order: [] : <bf16, 1> to tensor<256x!tt.ptr<bf16, 1>>
 // CHECK-DAG:         [[VAR_2_:%.+]] = tts.make_tptr [[PARAM_0_]] to sizes: [256], strides: {{.}}[[CST_1_]]{{.}}, offsets: {{.}}[[VAR_arg6_]]{{.}}, shape: [0], order: [] : <bf16, 1> to tensor<256x!tt.ptr<bf16, 1>>
-// CHECK:             [[VAR_3_:%.+]] = "tts.load"([[VAR_2_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_dims = array<i64>}> : (tensor<256x!tt.ptr<bf16, 1>>) -> tensor<256xbf16>
-// CHECK:             "tts.store"([[VAR_1_]], [[VAR_3_]]) <{static_dims = array<i64>}> : (tensor<256x!tt.ptr<bf16, 1>>, tensor<256xbf16>) -> ()
+// CHECK:             [[VAR_3_:%.+]] = "tts.load"([[VAR_2_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<256x!tt.ptr<bf16, 1>>) -> tensor<256xbf16>
+// CHECK:             "tts.store"([[VAR_1_]], [[VAR_3_]]) <{static_mask_dims = array<i64>}> : (tensor<256x!tt.ptr<bf16, 1>>, tensor<256xbf16>) -> ()
 // CHECK-DAG:         [[VAR_4_:%.+]] = arith.addi [[VAR_arg6_]], [[CST_3_]] : index
 // CHECK-DAG:         [[VAR_5_:%.+]] = arith.addi [[VAR_arg3_]], [[CST_3_]] : index
 // CHECK-DAG:         [[VAR_6_:%.+]] = arith.addi [[VAR_arg4_]], [[CST_3_]] : index

--- a/test/Conversion/TritonToStructured/addptr_for_used_after_update.mlir
+++ b/test/Conversion/TritonToStructured/addptr_for_used_after_update.mlir
@@ -90,8 +90,8 @@ module {
 // CHECK-DAG:       [[VAR_0_:%.+]] = scf.for [[VAR_arg1_:%.+]] = [[CST_0_]] to [[CST_12_]] step [[CST_3_]] iter_args([[VAR_arg2_:%.+]] = [[CST_1024_]]) -> (index) {
 // CHECK-DAG:         [[VAR_1_:%.+]] = arith.addi [[VAR_arg2_]], [[CST_3_]] : index
 // CHECK:             [[VAR_2_:%.+]] = tts.make_tptr [[PARAM_0_]] to sizes: [256], strides: {{.}}[[CST_1_]]{{.}}, offsets: {{.}}[[VAR_1_]]{{.}}, shape: [0], order: [] : <bf16, 1> to tensor<256x!tt.ptr<bf16, 1>>
-// CHECK:             [[VAR_3_:%.+]] = "tts.load"([[VAR_2_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_dims = array<i64>}> : (tensor<256x!tt.ptr<bf16, 1>>) -> tensor<256xbf16>
-// CHECK:             "tts.store"([[VAR_2_]], [[VAR_3_]]) <{static_dims = array<i64>}> : (tensor<256x!tt.ptr<bf16, 1>>, tensor<256xbf16>) -> ()
+// CHECK:             [[VAR_3_:%.+]] = "tts.load"([[VAR_2_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<256x!tt.ptr<bf16, 1>>) -> tensor<256xbf16>
+// CHECK:             "tts.store"([[VAR_2_]], [[VAR_3_]]) <{static_mask_dims = array<i64>}> : (tensor<256x!tt.ptr<bf16, 1>>, tensor<256xbf16>) -> ()
 // CHECK:             scf.yield [[VAR_1_]] : index
 // CHECK:           }
 // CHECK:           tt.return

--- a/test/Conversion/TritonToStructured/addptr_for_used_before_update.mlir
+++ b/test/Conversion/TritonToStructured/addptr_for_used_before_update.mlir
@@ -45,8 +45,8 @@ module {
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_0_:%.+]] = scf.for [[VAR_arg1_:%.+]] = [[CST_0_]] to [[CST_12_]] step [[CST_3_]] iter_args([[VAR_arg2_:%.+]] = [[CST_1024_]]) -> (index) {
 // CHECK-DAG:         [[VAR_1_:%.+]] = tts.make_tptr [[PARAM_0_]] to sizes: [256], strides: {{.}}[[CST_1_]]{{.}}, offsets: {{.}}[[VAR_arg2_]]{{.}}, shape: [0], order: [] : <bf16, 1> to tensor<256x!tt.ptr<bf16, 1>>
-// CHECK:             [[VAR_2_:%.+]] = "tts.load"([[VAR_1_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_dims = array<i64>}> : (tensor<256x!tt.ptr<bf16, 1>>) -> tensor<256xbf16>
-// CHECK:             "tts.store"([[VAR_1_]], [[VAR_2_]]) <{static_dims = array<i64>}> : (tensor<256x!tt.ptr<bf16, 1>>, tensor<256xbf16>) -> ()
+// CHECK:             [[VAR_2_:%.+]] = "tts.load"([[VAR_1_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<256x!tt.ptr<bf16, 1>>) -> tensor<256xbf16>
+// CHECK:             "tts.store"([[VAR_1_]], [[VAR_2_]]) <{static_mask_dims = array<i64>}> : (tensor<256x!tt.ptr<bf16, 1>>, tensor<256xbf16>) -> ()
 // CHECK:             [[VAR_3_:%.+]] = arith.addi [[VAR_arg2_]], [[CST_3_]] : index
 // CHECK:             scf.yield [[VAR_3_]] : index
 // CHECK:           }

--- a/test/Conversion/TritonToStructured/addptr_loopback.mlir
+++ b/test/Conversion/TritonToStructured/addptr_loopback.mlir
@@ -48,7 +48,7 @@ module {
 // CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_3_:%.+]] = tts.make_tptr [[PARAM_1_]] to sizes: [4, 256], strides: [1, [[CST_6_]]{{.}}, offsets: {{.}}[[VAR_2_]], 0], shape: [0, 0], order: [] : <bf16, 1> to tensor<4x256x!tt.ptr<bf16, 1>>
-// CHECK-DAG:       [[VAR_4_:%.+]] = "tts.load"([[VAR_1_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_dims = array<i64>}> : (tensor<4x256x!tt.ptr<bf16, 1>>) -> tensor<4x256xbf16>
-// CHECK:           "tts.store"([[VAR_3_]], [[VAR_4_]]) <{static_dims = array<i64>}> : (tensor<4x256x!tt.ptr<bf16, 1>>, tensor<4x256xbf16>) -> ()
+// CHECK-DAG:       [[VAR_4_:%.+]] = "tts.load"([[VAR_1_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<4x256x!tt.ptr<bf16, 1>>) -> tensor<4x256xbf16>
+// CHECK:           "tts.store"([[VAR_3_]], [[VAR_4_]]) <{static_mask_dims = array<i64>}> : (tensor<4x256x!tt.ptr<bf16, 1>>, tensor<4x256xbf16>) -> ()
 // CHECK:           tt.return
 // CHECK:         }

--- a/test/Conversion/TritonToStructured/addptr_mul_const_const.mlir
+++ b/test/Conversion/TritonToStructured/addptr_mul_const_const.mlir
@@ -44,7 +44,7 @@ module {
 // CHECK:           [[VAR_3_:%.+]] = arith.addi [[VAR_2_]], [[CST_20480_]] : index
 // CHECK-DAG:       [[VAR_4_:%.+]] = tts.make_tptr [[PARAM_0_]] to sizes: [1024], strides: {{.}}[[CST_11_]]{{.}}, offsets: {{.}}[[VAR_3_]]{{.}}, shape: [0], order: [] : <bf16, 1> to tensor<1024x!tt.ptr<bf16, 1>>
 // CHECK-DAG:       [[VAR_5_:%.+]] = tts.make_tptr [[PARAM_1_]] to sizes: [1024], strides: [1], offsets: {{.}}[[VAR_1_]]{{.}}, shape: [0], order: [] : <bf16, 1> to tensor<1024x!tt.ptr<bf16, 1>>
-// CHECK:           [[VAR_6_:%.+]] = "tts.load"([[VAR_4_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_dims = array<i64>}> : (tensor<1024x!tt.ptr<bf16, 1>>) -> tensor<1024xbf16>
-// CHECK:           "tts.store"([[VAR_5_]], [[VAR_6_]]) <{static_dims = array<i64>}> : (tensor<1024x!tt.ptr<bf16, 1>>, tensor<1024xbf16>) -> ()
+// CHECK:           [[VAR_6_:%.+]] = "tts.load"([[VAR_4_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<1024x!tt.ptr<bf16, 1>>) -> tensor<1024xbf16>
+// CHECK:           "tts.store"([[VAR_5_]], [[VAR_6_]]) <{static_mask_dims = array<i64>}> : (tensor<1024x!tt.ptr<bf16, 1>>, tensor<1024xbf16>) -> ()
 // CHECK:           tt.return
 // CHECK:         }

--- a/test/Conversion/TritonToStructured/addptr_mul_value_const.mlir
+++ b/test/Conversion/TritonToStructured/addptr_mul_value_const.mlir
@@ -47,7 +47,7 @@ module {
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_7_:%.+]] = tts.make_tptr [[PARAM_0_]] to sizes: [1024], strides: {{.}}[[VAR_6_]]{{.}}, offsets: {{.}}[[VAR_5_]]{{.}}, shape: [0], order: [] : <bf16, 1> to tensor<1024x!tt.ptr<bf16, 1>>
 // CHECK-DAG:       [[VAR_8_:%.+]] = tts.make_tptr [[PARAM_1_]] to sizes: [1024], strides: [1], offsets: {{.}}[[VAR_1_]]{{.}}, shape: [0], order: [] : <bf16, 1> to tensor<1024x!tt.ptr<bf16, 1>>
-// CHECK:           [[VAR_9_:%.+]] = "tts.load"([[VAR_7_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_dims = array<i64>}> : (tensor<1024x!tt.ptr<bf16, 1>>) -> tensor<1024xbf16>
-// CHECK:           "tts.store"([[VAR_8_]], [[VAR_9_]]) <{static_dims = array<i64>}> : (tensor<1024x!tt.ptr<bf16, 1>>, tensor<1024xbf16>) -> ()
+// CHECK:           [[VAR_9_:%.+]] = "tts.load"([[VAR_7_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<1024x!tt.ptr<bf16, 1>>) -> tensor<1024xbf16>
+// CHECK:           "tts.store"([[VAR_8_]], [[VAR_9_]]) <{static_mask_dims = array<i64>}> : (tensor<1024x!tt.ptr<bf16, 1>>, tensor<1024xbf16>) -> ()
 // CHECK:           tt.return
 // CHECK:         }

--- a/test/Conversion/TritonToStructured/addptr_nested.mlir
+++ b/test/Conversion/TritonToStructured/addptr_nested.mlir
@@ -48,15 +48,15 @@ module {
 // CHECK-DAG:       [[CST_5_:%.+]] = arith.constant 5 : index
 // CHECK-DAG:       [[VAR_0_:%.+]] = arith.index_cast [[PARAM_1_]] : i32 to index
 // CHECK:           [[VAR_1_:%.+]] = tts.make_tptr [[PARAM_0_]] to sizes: [4, 256], strides: [1, [[CST_5_]]{{.}}, offsets: {{.}}[[VAR_0_]], 0], shape: [0, 0], order: [] : <bf16, 1> to tensor<4x256x!tt.ptr<bf16, 1>>
-// CHECK-DAG:       [[VAR_2_:%.+]] = "tts.load"([[VAR_1_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_dims = array<i64>}> : (tensor<4x256x!tt.ptr<bf16, 1>>) -> tensor<4x256xbf16>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "tts.load"([[VAR_1_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<4x256x!tt.ptr<bf16, 1>>) -> tensor<4x256xbf16>
 // CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[PARAM_1_]] : i32 to index
 // CHECK:           [[VAR_4_:%.+]] = arith.addi [[VAR_0_]], [[VAR_3_]] : index
 // CHECK:           [[VAR_5_:%.+]] = tts.make_tptr [[PARAM_0_]] to sizes: [4, 256], strides: [2, [[CST_10_]]{{.}}, offsets: {{.}}[[VAR_4_]], 0], shape: [0, 0], order: [] : <bf16, 1> to tensor<4x256x!tt.ptr<bf16, 1>>
-// CHECK:           [[VAR_6_:%.+]] = "tts.load"([[VAR_5_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_dims = array<i64>}> : (tensor<4x256x!tt.ptr<bf16, 1>>) -> tensor<4x256xbf16>
+// CHECK:           [[VAR_6_:%.+]] = "tts.load"([[VAR_5_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<4x256x!tt.ptr<bf16, 1>>) -> tensor<4x256xbf16>
 // CHECK-DAG:       [[VAR_7_:%.+]] = arith.addf [[VAR_2_]], [[VAR_6_]] : tensor<4x256xbf16>
 // CHECK-DAG:       [[VAR_8_:%.+]] = arith.index_cast [[PARAM_1_]] : i32 to index
 // CHECK:           [[VAR_9_:%.+]] = arith.addi [[VAR_4_]], [[VAR_8_]] : index
 // CHECK:           [[VAR_10_:%.+]] = tts.make_tptr [[PARAM_0_]] to sizes: [4, 256], strides: [3, [[CST_15_]]{{.}}, offsets: {{.}}[[VAR_9_]], 0], shape: [0, 0], order: [] : <bf16, 1> to tensor<4x256x!tt.ptr<bf16, 1>>
-// CHECK:           "tts.store"([[VAR_10_]], [[VAR_7_]]) <{static_dims = array<i64>}> : (tensor<4x256x!tt.ptr<bf16, 1>>, tensor<4x256xbf16>) -> ()
+// CHECK:           "tts.store"([[VAR_10_]], [[VAR_7_]]) <{static_mask_dims = array<i64>}> : (tensor<4x256x!tt.ptr<bf16, 1>>, tensor<4x256xbf16>) -> ()
 // CHECK:           tt.return
 // CHECK:         }

--- a/test/Conversion/TritonToStructured/addptr_reshape_broadcast.mlir
+++ b/test/Conversion/TritonToStructured/addptr_reshape_broadcast.mlir
@@ -37,7 +37,7 @@ module {
 // CHECK-DAG:       [[CST_6144_:%.+]] = arith.constant 6144 : index
 // CHECK-DAG:       [[CST_6_:%.+]] = arith.constant 6 : index
 // CHECK:           [[VAR_0_:%.+]] = tts.make_tptr [[PARAM_1_]] to sizes: [256, 128], strides: [1, [[CST_6_]]{{.}}, offsets: [512, [[CST_6144_]]{{.}}, shape: [0, 0], order: [] : <bf16, 1> to tensor<256x128x!tt.ptr<bf16, 1>>
-// CHECK:           [[VAR_1_:%.+]] = "tts.load"([[VAR_0_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_dims = array<i64>}> : (tensor<256x128x!tt.ptr<bf16, 1>>) -> tensor<256x128xbf16>
-// CHECK:           "tts.store"([[VAR_0_]], [[VAR_1_]]) <{static_dims = array<i64>}> : (tensor<256x128x!tt.ptr<bf16, 1>>, tensor<256x128xbf16>) -> ()
+// CHECK:           [[VAR_1_:%.+]] = "tts.load"([[VAR_0_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<256x128x!tt.ptr<bf16, 1>>) -> tensor<256x128xbf16>
+// CHECK:           "tts.store"([[VAR_0_]], [[VAR_1_]]) <{static_mask_dims = array<i64>}> : (tensor<256x128x!tt.ptr<bf16, 1>>, tensor<256x128xbf16>) -> ()
 // CHECK:           tt.return
 // CHECK:         }

--- a/test/Conversion/TritonToStructured/addptr_scalar_broadcast.mlir
+++ b/test/Conversion/TritonToStructured/addptr_scalar_broadcast.mlir
@@ -51,11 +51,11 @@ module {
 // CHECK:           [[VAR_1_:%.+]] = arith.muli [[VAR_0_]], [[PARAM_2_]] : i32
 // CHECK:           [[VAR_2_:%.+]] = arith.index_cast [[VAR_1_]] : i32 to index
 // CHECK:           [[VAR_3_:%.+]] = tts.make_tptr [[PARAM_1_]] to sizes: [1024, 1024], strides: [1, 1], offsets: {{.}}[[VAR_2_]], 0], shape: [0, 0], order: [] : <f32, 1> to tensor<1024x1024x!tt.ptr<f32, 1>>
-// CHECK:           [[VAR_4_:%.+]] = "tts.load"([[VAR_3_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_dims = array<i64>}> : (tensor<1024x1024x!tt.ptr<f32, 1>>) -> tensor<1024x1024xf32>
+// CHECK:           [[VAR_4_:%.+]] = "tts.load"([[VAR_3_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<1024x1024x!tt.ptr<f32, 1>>) -> tensor<1024x1024xf32>
 // CHECK-DAG:       [[VAR_5_:%.+]] = math.exp [[VAR_4_]] : tensor<1024x1024xf32>
 // CHECK-DAG:       [[VAR_6_:%.+]] = arith.muli [[VAR_0_]], [[PARAM_3_]] : i32
 // CHECK:           [[VAR_7_:%.+]] = arith.index_cast [[VAR_6_]] : i32 to index
 // CHECK:           [[VAR_8_:%.+]] = tts.make_tptr [[PARAM_0_]] to sizes: [1024, 1024], strides: [1, 1], offsets: {{.}}[[VAR_7_]], 0], shape: [0, 0], order: [] : <f32, 1> to tensor<1024x1024x!tt.ptr<f32, 1>>
-// CHECK:           "tts.store"([[VAR_8_]], [[VAR_5_]]) <{static_dims = array<i64>}> : (tensor<1024x1024x!tt.ptr<f32, 1>>, tensor<1024x1024xf32>) -> ()
+// CHECK:           "tts.store"([[VAR_8_]], [[VAR_5_]]) <{static_mask_dims = array<i64>}> : (tensor<1024x1024x!tt.ptr<f32, 1>>, tensor<1024x1024xf32>) -> ()
 // CHECK:           tt.return
 // CHECK:         }

--- a/test/Conversion/TritonToStructured/addptr_scalar_for.mlir
+++ b/test/Conversion/TritonToStructured/addptr_scalar_for.mlir
@@ -45,7 +45,7 @@ module {
 // CHECK:           [[VAR_2_:%.+]] = arith.index_cast [[VAR_1_]] : i32 to index
 // CHECK-DAG:       [[VAR_3_:%.+]]:2 = scf.for [[VAR_arg5_:%.+]] = [[CST_0_]] to [[CST_12_]] step [[CST_3_]] iter_args([[VAR_arg6_:%.+]] = [[VAR_cst_]], [[VAR_arg7_:%.+]] = [[VAR_2_]]) -> (tensor<1024xf32>, index) {
 // CHECK-DAG:         [[VAR_7_:%.+]] = tts.make_tptr [[PARAM_1_]] to sizes: [1024], strides: [1], offsets: {{.}}[[VAR_arg7_]]{{.}}, shape: [0], order: [] : <f32, 1> to tensor<1024x!tt.ptr<f32, 1>>
-// CHECK:             [[VAR_8_:%.+]] = "tts.load"([[VAR_7_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_dims = array<i64>}> : (tensor<1024x!tt.ptr<f32, 1>>) -> tensor<1024xf32>
+// CHECK:             [[VAR_8_:%.+]] = "tts.load"([[VAR_7_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<1024x!tt.ptr<f32, 1>>) -> tensor<1024xf32>
 // CHECK:             [[VAR_9_:%.+]] = math.exp [[VAR_8_]] : tensor<1024xf32>
 // CHECK-DAG:         [[VAR_10_:%.+]] = arith.addf [[VAR_arg6_]], [[VAR_9_]] : tensor<1024xf32>
 // CHECK-DAG:         [[VAR_11_:%.+]] = arith.addi [[VAR_arg7_]], [[VAR_arg5_]] : index
@@ -54,6 +54,6 @@ module {
 // CHECK:           [[VAR_4_:%.+]] = arith.muli [[VAR_0_]], [[PARAM_3_]] : i32
 // CHECK:           [[VAR_5_:%.+]] = arith.index_cast [[VAR_4_]] : i32 to index
 // CHECK:           [[VAR_6_:%.+]] = tts.make_tptr [[PARAM_0_]] to sizes: [1024], strides: [1], offsets: {{.}}[[VAR_5_]]{{.}}, shape: [0], order: [] : <f32, 1> to tensor<1024x!tt.ptr<f32, 1>>
-// CHECK:           "tts.store"([[VAR_6_]], [[VAR_3_]]#0) <{static_dims = array<i64>}> : (tensor<1024x!tt.ptr<f32, 1>>, tensor<1024xf32>) -> ()
+// CHECK:           "tts.store"([[VAR_6_]], [[VAR_3_]]#0) <{static_mask_dims = array<i64>}> : (tensor<1024x!tt.ptr<f32, 1>>, tensor<1024xf32>) -> ()
 // CHECK:           tt.return
 // CHECK:         }

--- a/test/Conversion/TritonToStructured/addptr_scalar_for_2d.mlir
+++ b/test/Conversion/TritonToStructured/addptr_scalar_for_2d.mlir
@@ -66,7 +66,7 @@ module {
 // CHECK-DAG:       [[VAR_3_:%.+]]:2 = scf.for [[VAR_arg5_:%.+]] = [[CST_0_]] to [[CST_12_]] step [[CST_3_]] iter_args([[VAR_arg6_:%.+]] = [[VAR_cst_]], [[VAR_arg7_:%.+]] = [[VAR_2_]]) -> (tensor<128x128xf32>, index) {
 // CHECK-DAG:         [[VAR_8_:%.+]] = arith.addi [[VAR_arg7_]], [[CST_128_]] : index
 // CHECK:             [[VAR_9_:%.+]] = tts.make_tptr [[PARAM_1_]] to sizes: [128, 128], strides: [1, 1], offsets: {{.}}[[VAR_8_]], 0], shape: [0, 0], order: [] : <f32, 1> to tensor<128x128x!tt.ptr<f32, 1>>
-// CHECK:             [[VAR_10_:%.+]] = "tts.load"([[VAR_9_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_dims = array<i64>}> : (tensor<128x128x!tt.ptr<f32, 1>>) -> tensor<128x128xf32>
+// CHECK:             [[VAR_10_:%.+]] = "tts.load"([[VAR_9_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<128x128x!tt.ptr<f32, 1>>) -> tensor<128x128xf32>
 // CHECK:             [[VAR_11_:%.+]] = math.exp [[VAR_10_]] : tensor<128x128xf32>
 // CHECK-DAG:         [[VAR_12_:%.+]] = arith.addf [[VAR_arg6_]], [[VAR_11_]] : tensor<128x128xf32>
 // CHECK-DAG:         [[VAR_13_:%.+]] = arith.addi [[VAR_arg7_]], [[VAR_arg5_]] : index
@@ -76,6 +76,6 @@ module {
 // CHECK:           [[VAR_5_:%.+]] = arith.index_cast [[VAR_4_]] : i32 to index
 // CHECK:           [[VAR_6_:%.+]] = arith.addi [[VAR_5_]], [[CST_128_]] : index
 // CHECK:           [[VAR_7_:%.+]] = tts.make_tptr [[PARAM_0_]] to sizes: [128, 128], strides: [1, 1], offsets: {{.}}[[VAR_6_]], 0], shape: [0, 0], order: [] : <f32, 1> to tensor<128x128x!tt.ptr<f32, 1>>
-// CHECK:           "tts.store"([[VAR_7_]], [[VAR_3_]]#0) <{static_dims = array<i64>}> : (tensor<128x128x!tt.ptr<f32, 1>>, tensor<128x128xf32>) -> ()
+// CHECK:           "tts.store"([[VAR_7_]], [[VAR_3_]]#0) <{static_mask_dims = array<i64>}> : (tensor<128x128x!tt.ptr<f32, 1>>, tensor<128x128xf32>) -> ()
 // CHECK:           tt.return
 // CHECK:         }

--- a/test/Conversion/TritonToStructured/addptr_scalar_nested.mlir
+++ b/test/Conversion/TritonToStructured/addptr_scalar_nested.mlir
@@ -43,11 +43,11 @@ module {
 // CHECK:           [[VAR_7_:%.+]] = arith.index_cast [[VAR_6_]] : i32 to index
 // CHECK:           [[VAR_8_:%.+]] = arith.addi [[VAR_5_]], [[VAR_7_]] : index
 // CHECK:           [[VAR_9_:%.+]] = tts.make_tptr [[PARAM_1_]] to sizes: [1024], strides: [1], offsets: {{.}}[[VAR_8_]]{{.}}, shape: [0], order: [] : <f32, 1> to tensor<1024x!tt.ptr<f32, 1>>
-// CHECK:           [[VAR_10_:%.+]] = "tts.load"([[VAR_9_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_dims = array<i64>}> : (tensor<1024x!tt.ptr<f32, 1>>) -> tensor<1024xf32>
+// CHECK:           [[VAR_10_:%.+]] = "tts.load"([[VAR_9_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<1024x!tt.ptr<f32, 1>>) -> tensor<1024xf32>
 // CHECK-DAG:       [[VAR_11_:%.+]] = math.exp [[VAR_10_]] : tensor<1024xf32>
 // CHECK-DAG:       [[VAR_12_:%.+]] = arith.muli [[VAR_0_]], [[PARAM_3_]] : i32
 // CHECK:           [[VAR_13_:%.+]] = arith.index_cast [[VAR_12_]] : i32 to index
 // CHECK:           [[VAR_14_:%.+]] = tts.make_tptr [[PARAM_0_]] to sizes: [1024], strides: [1], offsets: {{.}}[[VAR_13_]]{{.}}, shape: [0], order: [] : <f32, 1> to tensor<1024x!tt.ptr<f32, 1>>
-// CHECK:           "tts.store"([[VAR_14_]], [[VAR_11_]]) <{static_dims = array<i64>}> : (tensor<1024x!tt.ptr<f32, 1>>, tensor<1024xf32>) -> ()
+// CHECK:           "tts.store"([[VAR_14_]], [[VAR_11_]]) <{static_mask_dims = array<i64>}> : (tensor<1024x!tt.ptr<f32, 1>>, tensor<1024xf32>) -> ()
 // CHECK:           tt.return
 // CHECK:         }

--- a/test/Conversion/TritonToStructured/addptr_scalar_splat.mlir
+++ b/test/Conversion/TritonToStructured/addptr_scalar_splat.mlir
@@ -31,11 +31,11 @@ module {
 // CHECK:           [[VAR_1_:%.+]] = arith.muli [[VAR_0_]], [[PARAM_2_]] : i32
 // CHECK:           [[VAR_2_:%.+]] = arith.index_cast [[VAR_1_]] : i32 to index
 // CHECK:           [[VAR_3_:%.+]] = tts.make_tptr [[PARAM_1_]] to sizes: [1024], strides: [1], offsets: {{.}}[[VAR_2_]]{{.}}, shape: [0], order: [] : <f32, 1> to tensor<1024x!tt.ptr<f32, 1>>
-// CHECK:           [[VAR_4_:%.+]] = "tts.load"([[VAR_3_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_dims = array<i64>}> : (tensor<1024x!tt.ptr<f32, 1>>) -> tensor<1024xf32>
+// CHECK:           [[VAR_4_:%.+]] = "tts.load"([[VAR_3_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<1024x!tt.ptr<f32, 1>>) -> tensor<1024xf32>
 // CHECK-DAG:       [[VAR_5_:%.+]] = math.exp [[VAR_4_]] : tensor<1024xf32>
 // CHECK-DAG:       [[VAR_6_:%.+]] = arith.muli [[VAR_0_]], [[PARAM_3_]] : i32
 // CHECK:           [[VAR_7_:%.+]] = arith.index_cast [[VAR_6_]] : i32 to index
 // CHECK:           [[VAR_8_:%.+]] = tts.make_tptr [[PARAM_0_]] to sizes: [1024], strides: [1], offsets: {{.}}[[VAR_7_]]{{.}}, shape: [0], order: [] : <f32, 1> to tensor<1024x!tt.ptr<f32, 1>>
-// CHECK:           "tts.store"([[VAR_8_]], [[VAR_5_]]) <{static_dims = array<i64>}> : (tensor<1024x!tt.ptr<f32, 1>>, tensor<1024xf32>) -> ()
+// CHECK:           "tts.store"([[VAR_8_]], [[VAR_5_]]) <{static_mask_dims = array<i64>}> : (tensor<1024x!tt.ptr<f32, 1>>, tensor<1024xf32>) -> ()
 // CHECK:           tt.return
 // CHECK:         }

--- a/test/Conversion/TritonToStructured/addptr_scalar_splat_2d.mlir
+++ b/test/Conversion/TritonToStructured/addptr_scalar_splat_2d.mlir
@@ -41,12 +41,12 @@ module {
 // CHECK:           [[VAR_2_:%.+]] = arith.index_cast [[VAR_1_]] : i32 to index
 // CHECK:           [[VAR_3_:%.+]] = arith.addi [[VAR_2_]], [[CST_128_]] : index
 // CHECK:           [[VAR_4_:%.+]] = tts.make_tptr [[PARAM_1_]] to sizes: [128, 128], strides: [1, 1], offsets: {{.}}[[VAR_3_]], 0], shape: [0, 0], order: [] : <f32, 1> to tensor<128x128x!tt.ptr<f32, 1>>
-// CHECK:           [[VAR_5_:%.+]] = "tts.load"([[VAR_4_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_dims = array<i64>}> : (tensor<128x128x!tt.ptr<f32, 1>>) -> tensor<128x128xf32>
+// CHECK:           [[VAR_5_:%.+]] = "tts.load"([[VAR_4_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<128x128x!tt.ptr<f32, 1>>) -> tensor<128x128xf32>
 // CHECK-DAG:       [[VAR_6_:%.+]] = math.exp [[VAR_5_]] : tensor<128x128xf32>
 // CHECK-DAG:       [[VAR_7_:%.+]] = arith.muli [[VAR_0_]], [[PARAM_3_]] : i32
 // CHECK:           [[VAR_8_:%.+]] = arith.index_cast [[VAR_7_]] : i32 to index
 // CHECK:           [[VAR_9_:%.+]] = arith.addi [[VAR_8_]], [[CST_128_]] : index
 // CHECK:           [[VAR_10_:%.+]] = tts.make_tptr [[PARAM_0_]] to sizes: [128, 128], strides: [1, 1], offsets: {{.}}[[VAR_9_]], 0], shape: [0, 0], order: [] : <f32, 1> to tensor<128x128x!tt.ptr<f32, 1>>
-// CHECK:           "tts.store"([[VAR_10_]], [[VAR_6_]]) <{static_dims = array<i64>}> : (tensor<128x128x!tt.ptr<f32, 1>>, tensor<128x128xf32>) -> ()
+// CHECK:           "tts.store"([[VAR_10_]], [[VAR_6_]]) <{static_mask_dims = array<i64>}> : (tensor<128x128x!tt.ptr<f32, 1>>, tensor<128x128xf32>) -> ()
 // CHECK:           tt.return
 // CHECK:         }

--- a/test/Conversion/TritonToStructured/arith_not_ptr_arith.mlir
+++ b/test/Conversion/TritonToStructured/arith_not_ptr_arith.mlir
@@ -25,9 +25,9 @@ module {
 // CHECK-DAG:       [[VAR_0_:%.+]] = tts.make_tptr [[PARAM_0_]] to sizes: [1024], strides: [1], offsets: [0], shape: [0], order: [] : <i32, 1> to tensor<1024x!tt.ptr<i32, 1>>
 // CHECK-DAG:       [[VAR_1_:%.+]] = tts.make_tptr [[PARAM_1_]] to sizes: [1024], strides: [1], offsets: [0], shape: [0], order: [] : <i32, 1> to tensor<1024x!tt.ptr<i32, 1>>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_2_:%.+]] = "tts.load"([[VAR_0_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_dims = array<i64>}> : (tensor<1024x!tt.ptr<i32, 1>>) -> tensor<1024xi32>
-// CHECK-DAG:       [[VAR_3_:%.+]] = "tts.load"([[VAR_1_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_dims = array<i64>}> : (tensor<1024x!tt.ptr<i32, 1>>) -> tensor<1024xi32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "tts.load"([[VAR_0_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<1024x!tt.ptr<i32, 1>>) -> tensor<1024xi32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "tts.load"([[VAR_1_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<1024x!tt.ptr<i32, 1>>) -> tensor<1024xi32>
 // CHECK:           [[VAR_4_:%.+]] = arith.addi [[VAR_2_]], [[VAR_3_]] : tensor<1024xi32>
-// CHECK:           "tts.store"([[VAR_1_]], [[VAR_4_]]) <{static_dims = array<i64>}> : (tensor<1024x!tt.ptr<i32, 1>>, tensor<1024xi32>) -> ()
+// CHECK:           "tts.store"([[VAR_1_]], [[VAR_4_]]) <{static_mask_dims = array<i64>}> : (tensor<1024x!tt.ptr<i32, 1>>, tensor<1024xi32>) -> ()
 // CHECK:           tt.return
 // CHECK:         }

--- a/test/Conversion/TritonToStructured/bitcast.mlir
+++ b/test/Conversion/TritonToStructured/bitcast.mlir
@@ -27,8 +27,8 @@ module {
 // CHECK:         tt.func @kernel([[PARAM_0_:%.+]]: !tt.ptr<i32, 1>, [[PARAM_1_:%.+]]: !tt.ptr<f32, 1>) {
 // CHECK-DAG:       [[VAR_0_:%.+]] = tts.make_tptr [[PARAM_0_]] to sizes: [1024], strides: [1], offsets: [0], shape: [0], order: [] : <i32, 1> to tensor<1024x!tt.ptr<i32, 1>>
 // CHECK-DAG:       [[VAR_1_:%.+]] = tts.make_tptr [[PARAM_1_]] to sizes: [1024], strides: [1], offsets: [0], shape: [0], order: [] : <f32, 1> to tensor<1024x!tt.ptr<f32, 1>>
-// CHECK:           [[VAR_2_:%.+]] = "tts.load"([[VAR_0_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_dims = array<i64>}> : (tensor<1024x!tt.ptr<i32, 1>>) -> tensor<1024xi32>
+// CHECK:           [[VAR_2_:%.+]] = "tts.load"([[VAR_0_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<1024x!tt.ptr<i32, 1>>) -> tensor<1024xi32>
 // CHECK:           [[VAR_3_:%.+]] = tt.bitcast [[VAR_2_]] : tensor<1024xi32> -> tensor<1024xf32>
-// CHECK:           "tts.store"([[VAR_1_]], [[VAR_3_]]) <{static_dims = array<i64>}> : (tensor<1024x!tt.ptr<f32, 1>>, tensor<1024xf32>) -> ()
+// CHECK:           "tts.store"([[VAR_1_]], [[VAR_3_]]) <{static_mask_dims = array<i64>}> : (tensor<1024x!tt.ptr<f32, 1>>, tensor<1024xf32>) -> ()
 // CHECK:           tt.return
 // CHECK:         }

--- a/test/Conversion/TritonToStructured/block_ptr_advance.mlir
+++ b/test/Conversion/TritonToStructured/block_ptr_advance.mlir
@@ -55,8 +55,8 @@ module {
 // CHECK-DAG:         [[VAR_18_:%.+]] = tts.make_tptr [[PARAM_0_]] to sizes: [128, 64], strides: {{.}}[[VAR_0_]], [[VAR_4_]]{{.}}, offsets: {{.}}[[VAR_arg17_]], [[CST_0_]]{{.}}, shape: {{.}}[[VAR_3_]], [[VAR_5_]]{{.}}, order: [1, 0] : <bf16, 1> to !tt.ptr<tensor<128x64xbf16>, 1>
 // CHECK-DAG:         [[VAR_19_:%.+]] = tts.make_tptr [[PARAM_0_]] to sizes: [128, 64], strides: {{.}}[[VAR_0_]], [[VAR_4_]]{{.}}, offsets: {{.}}[[VAR_2_]], [[VAR_arg16_]]{{.}}, shape: {{.}}[[VAR_3_]], [[VAR_5_]]{{.}}, order: [1, 0] : <bf16, 1> to !tt.ptr<tensor<128x64xbf16>, 1>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_20_:%.+]] = "tts.load"([[VAR_19_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_dims = array<i64>}> : (!tt.ptr<tensor<128x64xbf16>, 1>) -> tensor<128x64xbf16>
-// CHECK-DAG:         [[VAR_21_:%.+]] = "tts.load"([[VAR_18_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_dims = array<i64>}> : (!tt.ptr<tensor<128x64xbf16>, 1>) -> tensor<128x64xbf16>
+// CHECK-DAG:         [[VAR_20_:%.+]] = "tts.load"([[VAR_19_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (!tt.ptr<tensor<128x64xbf16>, 1>) -> tensor<128x64xbf16>
+// CHECK-DAG:         [[VAR_21_:%.+]] = "tts.load"([[VAR_18_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (!tt.ptr<tensor<128x64xbf16>, 1>) -> tensor<128x64xbf16>
 // CHECK:             [[VAR_22_:%.+]] = arith.addf [[VAR_20_]], [[VAR_21_]] : tensor<128x64xbf16>
 // CHECK-DAG:         [[VAR_23_:%.+]] = arith.addf [[VAR_arg15_]], [[VAR_22_]] : tensor<128x64xbf16>
 // CHECK-DAG:         [[VAR_24_:%.+]] = arith.muli [[VAR_4_]], [[CST_64_]] : index
@@ -78,6 +78,6 @@ module {
 // CHECK-DAG:       [[VAR_15_:%.+]] = arith.muli [[VAR_14_]], [[VAR_13_]] : index
 // CHECK-DAG:       [[VAR_16_:%.+]] = arith.index_cast [[PARAM_4_]] : i32 to index
 // CHECK:           [[VAR_17_:%.+]] = tts.make_tptr [[PARAM_2_]] to sizes: [128, 64], strides: {{.}}[[VAR_9_]], [[VAR_13_]]{{.}}, offsets: {{.}}[[VAR_11_]], [[VAR_15_]]{{.}}, shape: {{.}}[[VAR_12_]], [[VAR_16_]]{{.}}, order: [1, 0] : <bf16, 1> to !tt.ptr<tensor<128x64xbf16>, 1>
-// CHECK:           "tts.store"([[VAR_17_]], [[VAR_7_]]#0) <{static_dims = array<i64>}> : (!tt.ptr<tensor<128x64xbf16>, 1>, tensor<128x64xbf16>) -> ()
+// CHECK:           "tts.store"([[VAR_17_]], [[VAR_7_]]#0) <{static_mask_dims = array<i64>}> : (!tt.ptr<tensor<128x64xbf16>, 1>, tensor<128x64xbf16>) -> ()
 // CHECK:           tt.return
 // CHECK:         }

--- a/test/Conversion/TritonToStructured/dot.mlir
+++ b/test/Conversion/TritonToStructured/dot.mlir
@@ -54,13 +54,13 @@ module {
 // CHECK-DAG:       [[CST_256_:%.+]] = arith.constant 256 : index
 // CHECK-DAG:       [[CST_128_:%.+]] = arith.constant 128 : index
 // CHECK:           [[VAR_0_:%.+]] = tts.make_tptr [[PARAM_0_]] to sizes: [128, 64], strides: {{.}}[[CST_128_]], 1], offsets: [0, 0], shape: [0, 0], order: [] : <bf16, 1> to tensor<128x64x!tt.ptr<bf16, 1>>
-// CHECK-DAG:       [[VAR_1_:%.+]] = "tts.load"([[VAR_0_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_dims = array<i64>}> : (tensor<128x64x!tt.ptr<bf16, 1>>) -> tensor<128x64xbf16>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "tts.load"([[VAR_0_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<128x64x!tt.ptr<bf16, 1>>) -> tensor<128x64xbf16>
 // CHECK-DAG:       [[VAR_2_:%.+]] = tts.make_tptr [[PARAM_1_]] to sizes: [256, 64], strides: [1, [[CST_256_]]{{.}}, offsets: [0, 0], shape: [0, 0], order: [] : <bf16, 1> to tensor<256x64x!tt.ptr<bf16, 1>>
-// CHECK:           [[VAR_3_:%.+]] = "tts.load"([[VAR_2_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_dims = array<i64>}> : (tensor<256x64x!tt.ptr<bf16, 1>>) -> tensor<256x64xbf16>
+// CHECK:           [[VAR_3_:%.+]] = "tts.load"([[VAR_2_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<256x64x!tt.ptr<bf16, 1>>) -> tensor<256x64xbf16>
 // CHECK-DAG:       [[VAR_4_:%.+]] = tt.trans [[VAR_3_]] {order = array<i32: 1, 0>} : tensor<256x64xbf16> -> tensor<64x256xbf16>
 // CHECK-DAG:       [[VAR_5_:%.+]] = tts.make_tptr [[PARAM_2_]] to sizes: [128, 256], strides: {{.}}[[CST_256_]], 1], offsets: [0, 0], shape: [0, 0], order: [] : <bf16, 1> to tensor<128x256x!tt.ptr<bf16, 1>>
-// CHECK:           [[VAR_6_:%.+]] = "tts.load"([[VAR_5_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_dims = array<i64>}> : (tensor<128x256x!tt.ptr<bf16, 1>>) -> tensor<128x256xbf16>
+// CHECK:           [[VAR_6_:%.+]] = "tts.load"([[VAR_5_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<128x256x!tt.ptr<bf16, 1>>) -> tensor<128x256xbf16>
 // CHECK:           [[VAR_7_:%.+]] = tt.dot [[VAR_1_]], [[VAR_4_]], [[VAR_6_]] {allowTF32 = false, maxNumImpreciseAcc = 0 : i32} : tensor<128x64xbf16> * tensor<64x256xbf16> -> tensor<128x256xbf16>
-// CHECK:           "tts.store"([[VAR_5_]], [[VAR_7_]]) <{static_dims = array<i64>}> : (tensor<128x256x!tt.ptr<bf16, 1>>, tensor<128x256xbf16>) -> ()
+// CHECK:           "tts.store"([[VAR_5_]], [[VAR_7_]]) <{static_mask_dims = array<i64>}> : (tensor<128x256x!tt.ptr<bf16, 1>>, tensor<128x256xbf16>) -> ()
 // CHECK:           tt.return
 // CHECK:         }

--- a/test/Conversion/TritonToStructured/kernel-01-vector-add.mlir
+++ b/test/Conversion/TritonToStructured/kernel-01-vector-add.mlir
@@ -40,7 +40,7 @@ module {
 // CHECK-DAG:       [[VAR_8_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
 // CHECK:           [[VAR_9_:%.+]] = arith.minsi [[VAR_7_]], [[VAR_8_]] : index
 // CHECK:           [[VAR_10_:%.+]] = arith.subi [[VAR_9_]], [[VAR_6_]] : index
-// CHECK-DAG:       [[VAR_11_:%.+]] = "tts.load"([[VAR_5_]], [[VAR_10_]]) <{operandSegmentSizes = array<i32: 1, 1, 0>, static_dims = array<i64: -9223372036854775808>}> : (tensor<1024x!tt.ptr<f32, 1>>, index) -> tensor<1024xf32>
+// CHECK-DAG:       [[VAR_11_:%.+]] = "tts.load"([[VAR_5_]], [[VAR_10_]]) <{operandSegmentSizes = array<i32: 1, 1, 0>, static_mask_dims = array<i64: -9223372036854775808>}> : (tensor<1024x!tt.ptr<f32, 1>>, index) -> tensor<1024xf32>
 // CHECK-DAG:       [[VAR_12_:%.+]] = tts.make_tptr [[PARAM_1_]] to sizes: [1024], strides: [1], offsets: {{.}}[[VAR_3_]]{{.}}, shape: [0], order: [] : <f32, 1> to tensor<1024x!tt.ptr<f32, 1>>
 // CHECK-DAG:       [[VAR_13_:%.+]] = arith.index_cast [[VAR_1_]] : i32 to index
 // CHECK-NOT: separator of consecutive DAGs
@@ -48,7 +48,7 @@ module {
 // CHECK-DAG:       [[VAR_15_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
 // CHECK:           [[VAR_16_:%.+]] = arith.minsi [[VAR_14_]], [[VAR_15_]] : index
 // CHECK:           [[VAR_17_:%.+]] = arith.subi [[VAR_16_]], [[VAR_13_]] : index
-// CHECK:           [[VAR_18_:%.+]] = "tts.load"([[VAR_12_]], [[VAR_17_]]) <{operandSegmentSizes = array<i32: 1, 1, 0>, static_dims = array<i64: -9223372036854775808>}> : (tensor<1024x!tt.ptr<f32, 1>>, index) -> tensor<1024xf32>
+// CHECK:           [[VAR_18_:%.+]] = "tts.load"([[VAR_12_]], [[VAR_17_]]) <{operandSegmentSizes = array<i32: 1, 1, 0>, static_mask_dims = array<i64: -9223372036854775808>}> : (tensor<1024x!tt.ptr<f32, 1>>, index) -> tensor<1024xf32>
 // CHECK-DAG:       [[VAR_19_:%.+]] = arith.addf [[VAR_11_]], [[VAR_18_]] : tensor<1024xf32>
 // CHECK-DAG:       [[VAR_20_:%.+]] = tts.make_tptr [[PARAM_2_]] to sizes: [1024], strides: [1], offsets: {{.}}[[VAR_2_]]{{.}}, shape: [0], order: [] : <f32, 1> to tensor<1024x!tt.ptr<f32, 1>>
 // CHECK-DAG:       [[VAR_21_:%.+]] = arith.index_cast [[VAR_1_]] : i32 to index
@@ -57,6 +57,6 @@ module {
 // CHECK-DAG:       [[VAR_23_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
 // CHECK:           [[VAR_24_:%.+]] = arith.minsi [[VAR_22_]], [[VAR_23_]] : index
 // CHECK:           [[VAR_25_:%.+]] = arith.subi [[VAR_24_]], [[VAR_21_]] : index
-// CHECK:           "tts.store"([[VAR_20_]], [[VAR_19_]], [[VAR_25_]]) <{static_dims = array<i64: -9223372036854775808>}> : (tensor<1024x!tt.ptr<f32, 1>>, tensor<1024xf32>, index) -> ()
+// CHECK:           "tts.store"([[VAR_20_]], [[VAR_19_]], [[VAR_25_]]) <{static_mask_dims = array<i64: -9223372036854775808>}> : (tensor<1024x!tt.ptr<f32, 1>>, tensor<1024xf32>, index) -> ()
 // CHECK:           tt.return
 // CHECK:         }

--- a/test/Conversion/TritonToStructured/kernel-02-fused-softmax.mlir
+++ b/test/Conversion/TritonToStructured/kernel-02-fused-softmax.mlir
@@ -47,7 +47,7 @@ module {
 // CHECK-DAG:       [[VAR_3_:%.+]] = tts.make_tptr [[PARAM_1_]] to sizes: [128], strides: [1], offsets: {{.}}[[VAR_2_]]{{.}}, shape: [0], order: [] : <f32, 1> to tensor<128x!tt.ptr<f32, 1>>
 // CHECK-DAG:       [[VAR_4_:%.+]] = arith.index_cast [[PARAM_4_]] : i32 to index
 // CHECK:           [[VAR_5_:%.+]] = arith.minsi [[VAR_4_]], [[CST_128_]] : index
-// CHECK:           [[VAR_6_:%.+]] = "tts.load"([[VAR_3_]], [[VAR_5_]], [[CST_0_]]) <{operandSegmentSizes = array<i32: 1, 1, 1>, static_dims = array<i64: -9223372036854775808>}> : (tensor<128x!tt.ptr<f32, 1>>, index, f32) -> tensor<128xf32>
+// CHECK:           [[VAR_6_:%.+]] = "tts.load"([[VAR_3_]], [[VAR_5_]], [[CST_0_]]) <{operandSegmentSizes = array<i32: 1, 1, 1>, static_mask_dims = array<i64: -9223372036854775808>}> : (tensor<128x!tt.ptr<f32, 1>>, index, f32) -> tensor<128xf32>
 // CHECK:           [[VAR_7_:%.+]] = "tt.reduce"([[VAR_6_]]) <{axis = 0 : i32}> ({
 // CHECK:           ^bb0([[arg5_:%.+]]: f32, [[arg6_:%.+]]: f32):
 // CHECK:             [[VAR_19_:%.+]] = arith.cmpf ogt, [[arg5_]], [[arg6_]] : f32
@@ -69,6 +69,6 @@ module {
 // CHECK-DAG:       [[VAR_16_:%.+]] = tts.make_tptr [[PARAM_0_]] to sizes: [128], strides: [1], offsets: {{.}}[[VAR_15_]]{{.}}, shape: [0], order: [] : <f32, 1> to tensor<128x!tt.ptr<f32, 1>>
 // CHECK-DAG:       [[VAR_17_:%.+]] = arith.index_cast [[PARAM_4_]] : i32 to index
 // CHECK:           [[VAR_18_:%.+]] = arith.minsi [[VAR_17_]], [[CST_128_]] : index
-// CHECK:           "tts.store"([[VAR_16_]], [[VAR_13_]], [[VAR_18_]]) <{static_dims = array<i64: -9223372036854775808>}> : (tensor<128x!tt.ptr<f32, 1>>, tensor<128xf32>, index) -> ()
+// CHECK:           "tts.store"([[VAR_16_]], [[VAR_13_]], [[VAR_18_]]) <{static_mask_dims = array<i64: -9223372036854775808>}> : (tensor<128x!tt.ptr<f32, 1>>, tensor<128xf32>, index) -> ()
 // CHECK:           tt.return
 // CHECK:         }

--- a/test/Conversion/TritonToStructured/kernel-03-matrix-multiplication.mlir
+++ b/test/Conversion/TritonToStructured/kernel-03-matrix-multiplication.mlir
@@ -156,8 +156,8 @@ module {
 // CHECK-DAG:         [[VAR_52_:%.+]] = tts.make_tptr [[PARAM_1_]] to sizes: [64, 256], strides: {{.}}[[VAR_26_]], [[VAR_27_]]{{.}}, offsets: {{.}}[[PARAM_1_]]5, [[VAR_28_]]{{.}}, shape: [0, 0], order: [] : <bf16, 1> to tensor<64x256x!tt.ptr<bf16, 1>>
 // CHECK-DAG:         [[VAR_53_:%.+]] = tts.make_tptr [[PARAM_0_]] to sizes: [128, 64], strides: {{.}}[[VAR_23_]], [[VAR_25_]]{{.}}, offsets: {{.}}[[VAR_arg14_]], [[CST_0_]]{{.}}, shape: [0, 0], order: [] : <bf16, 1> to tensor<128x64x!tt.ptr<bf16, 1>>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_54_:%.+]] = "tts.load"([[VAR_53_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_dims = array<i64>}> : (tensor<128x64x!tt.ptr<bf16, 1>>) -> tensor<128x64xbf16>
-// CHECK-DAG:         [[VAR_55_:%.+]] = "tts.load"([[VAR_52_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_dims = array<i64>}> : (tensor<64x256x!tt.ptr<bf16, 1>>) -> tensor<64x256xbf16>
+// CHECK-DAG:         [[VAR_54_:%.+]] = "tts.load"([[VAR_53_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<128x64x!tt.ptr<bf16, 1>>) -> tensor<128x64xbf16>
+// CHECK-DAG:         [[VAR_55_:%.+]] = "tts.load"([[VAR_52_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<64x256x!tt.ptr<bf16, 1>>) -> tensor<64x256xbf16>
 // CHECK:             [[VAR_56_:%.+]] = tt.dot [[VAR_54_]], [[VAR_55_]], [[VAR_cst_]] {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<128x64xbf16> * tensor<64x256xbf16> -> tensor<128x256xf32>
 // CHECK-DAG:         [[VAR_57_:%.+]] = arith.addf [[VAR_arg13_]], [[VAR_56_]] : tensor<128x256xf32>
 // CHECK-DAG:         [[VAR_58_:%.+]] = arith.addi [[VAR_arg14_]], [[VAR_30_]] : index
@@ -185,6 +185,6 @@ module {
 // CHECK-DAG:       [[VAR_49_:%.+]] = arith.subi [[VAR_48_]], [[VAR_45_]] : index
 // CHECK-DAG:       [[VAR_50_:%.+]] = arith.minsi [[VAR_44_]], [[CST_128_]] : index
 // CHECK:           [[VAR_51_:%.+]] = arith.minsi [[VAR_49_]], [[CST_256_]] : index
-// CHECK:           "tts.store"([[VAR_39_]], [[VAR_34_]], [[VAR_50_]], [[VAR_51_]]) <{static_dims = array<i64: -9223372036854775808, -9223372036854775808>}> : (tensor<128x256x!tt.ptr<bf16, 1>>, tensor<128x256xbf16>, index, index) -> ()
+// CHECK:           "tts.store"([[VAR_39_]], [[VAR_34_]], [[VAR_50_]], [[VAR_51_]]) <{static_mask_dims = array<i64: -9223372036854775808, -9223372036854775808>}> : (tensor<128x256x!tt.ptr<bf16, 1>>, tensor<128x256xbf16>, index, index) -> ()
 // CHECK:           tt.return
 // CHECK:         }

--- a/test/Conversion/TritonToStructured/kernel-05-layer-norm-dwdb.mlir
+++ b/test/Conversion/TritonToStructured/kernel-05-layer-norm-dwdb.mlir
@@ -91,7 +91,7 @@ module {
 // CHECK-DAG:         [[VAR_34_:%.+]] = arith.subi [[VAR_33_]], [[VAR_30_]] : index
 // CHECK-DAG:         [[VAR_35_:%.+]] = arith.minsi [[VAR_29_]], [[CST_256_]] : index
 // CHECK:             [[VAR_36_:%.+]] = arith.minsi [[VAR_34_]], [[CST_256_]] : index
-// CHECK:             [[VAR_37_:%.+]] = "tts.load"([[VAR_24_]], [[VAR_35_]], [[VAR_36_]], [[CST_0_dot_000000_]]) <{operandSegmentSizes = array<i32: 1, 2, 1>, static_dims = array<i64: -9223372036854775808, -9223372036854775808>}> : (tensor<256x256x!tt.ptr<f32, 1>>, index, index, f32) -> tensor<256x256xf32>
+// CHECK:             [[VAR_37_:%.+]] = "tts.load"([[VAR_24_]], [[VAR_35_]], [[VAR_36_]], [[CST_0_dot_000000_]]) <{operandSegmentSizes = array<i32: 1, 2, 1>, static_mask_dims = array<i64: -9223372036854775808, -9223372036854775808>}> : (tensor<256x256x!tt.ptr<f32, 1>>, index, index, f32) -> tensor<256x256xf32>
 // CHECK-DAG:         [[VAR_38_:%.+]] = arith.addf [[VAR_arg7_]], [[VAR_37_]] : tensor<256x256xf32>
 // CHECK-DAG:         [[VAR_39_:%.+]] = arith.index_cast [[VAR_arg6_]] : i32 to index
 // CHECK-DAG:         [[VAR_40_:%.+]] = arith.index_cast [[PARAM_5_]] : i32 to index
@@ -111,7 +111,7 @@ module {
 // CHECK-DAG:         [[VAR_52_:%.+]] = arith.subi [[VAR_51_]], [[VAR_48_]] : index
 // CHECK-DAG:         [[VAR_53_:%.+]] = arith.minsi [[VAR_47_]], [[CST_256_]] : index
 // CHECK:             [[VAR_54_:%.+]] = arith.minsi [[VAR_52_]], [[CST_256_]] : index
-// CHECK:             [[VAR_55_:%.+]] = "tts.load"([[VAR_42_]], [[VAR_53_]], [[VAR_54_]], [[CST_0_dot_000000_]]) <{operandSegmentSizes = array<i32: 1, 2, 1>, static_dims = array<i64: -9223372036854775808, -9223372036854775808>}> : (tensor<256x256x!tt.ptr<f32, 1>>, index, index, f32) -> tensor<256x256xf32>
+// CHECK:             [[VAR_55_:%.+]] = "tts.load"([[VAR_42_]], [[VAR_53_]], [[VAR_54_]], [[CST_0_dot_000000_]]) <{operandSegmentSizes = array<i32: 1, 2, 1>, static_mask_dims = array<i64: -9223372036854775808, -9223372036854775808>}> : (tensor<256x256x!tt.ptr<f32, 1>>, index, index, f32) -> tensor<256x256xf32>
 // CHECK:             [[VAR_56_:%.+]] = arith.addf [[VAR_arg8_]], [[VAR_55_]] : tensor<256x256xf32>
 // CHECK:             scf.yield [[VAR_38_]], [[VAR_56_]] : tensor<256x256xf32>, tensor<256x256xf32>
 // CHECK:           }
@@ -132,7 +132,7 @@ module {
 // CHECK-DAG:       [[VAR_12_:%.+]] = arith.index_cast [[PARAM_5_]] : i32 to index
 // CHECK:           [[VAR_13_:%.+]] = arith.minsi [[VAR_11_]], [[VAR_12_]] : index
 // CHECK:           [[VAR_14_:%.+]] = arith.subi [[VAR_13_]], [[VAR_10_]] : index
-// CHECK:           "tts.store"([[VAR_9_]], [[VAR_7_]], [[VAR_14_]]) <{static_dims = array<i64: -9223372036854775808>}> : (tensor<256x!tt.ptr<f32, 1>>, tensor<256xf32>, index) -> ()
+// CHECK:           "tts.store"([[VAR_9_]], [[VAR_7_]], [[VAR_14_]]) <{static_mask_dims = array<i64: -9223372036854775808>}> : (tensor<256x!tt.ptr<f32, 1>>, tensor<256xf32>, index) -> ()
 // CHECK-DAG:       [[VAR_15_:%.+]] = tts.make_tptr [[PARAM_3_]] to sizes: [256], strides: [1], offsets: {{.}}[[VAR_2_]]{{.}}, shape: [0], order: [] : <f32, 1> to tensor<256x!tt.ptr<f32, 1>>
 // CHECK-DAG:       [[VAR_16_:%.+]] = arith.index_cast [[VAR_1_]] : i32 to index
 // CHECK-NOT: separator of consecutive DAGs
@@ -140,6 +140,6 @@ module {
 // CHECK-DAG:       [[VAR_18_:%.+]] = arith.index_cast [[PARAM_5_]] : i32 to index
 // CHECK:           [[VAR_19_:%.+]] = arith.minsi [[VAR_17_]], [[VAR_18_]] : index
 // CHECK:           [[VAR_20_:%.+]] = arith.subi [[VAR_19_]], [[VAR_16_]] : index
-// CHECK:           "tts.store"([[VAR_15_]], [[VAR_8_]], [[VAR_20_]]) <{static_dims = array<i64: -9223372036854775808>}> : (tensor<256x!tt.ptr<f32, 1>>, tensor<256xf32>, index) -> ()
+// CHECK:           "tts.store"([[VAR_15_]], [[VAR_8_]], [[VAR_20_]]) <{static_mask_dims = array<i64: -9223372036854775808>}> : (tensor<256x!tt.ptr<f32, 1>>, tensor<256xf32>, index) -> ()
 // CHECK:           tt.return
 // CHECK:         }

--- a/test/Conversion/TritonToStructured/kernel-05-layer-norm-fwd.mlir
+++ b/test/Conversion/TritonToStructured/kernel-05-layer-norm-fwd.mlir
@@ -109,7 +109,7 @@ module {
 // CHECK-DAG:         [[VAR_26_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
 // CHECK:             [[VAR_27_:%.+]] = arith.minsi [[VAR_25_]], [[VAR_26_]] : index
 // CHECK:             [[VAR_28_:%.+]] = arith.subi [[VAR_27_]], [[VAR_24_]] : index
-// CHECK:             [[VAR_29_:%.+]] = "tts.load"([[VAR_23_]], [[VAR_28_]], [[CST_0_dot_000000_]]) <{operandSegmentSizes = array<i32: 1, 1, 1>, static_dims = array<i64: -9223372036854775808>}> : (tensor<256x!tt.ptr<f32, 1>>, index, f32) -> tensor<256xf32>
+// CHECK:             [[VAR_29_:%.+]] = "tts.load"([[VAR_23_]], [[VAR_28_]], [[CST_0_dot_000000_]]) <{operandSegmentSizes = array<i32: 1, 1, 1>, static_mask_dims = array<i64: -9223372036854775808>}> : (tensor<256x!tt.ptr<f32, 1>>, index, f32) -> tensor<256xf32>
 // CHECK:             [[VAR_30_:%.+]] = arith.addf [[VAR_arg10_]], [[VAR_29_]] : tensor<256xf32>
 // CHECK:             scf.yield [[VAR_30_]] : tensor<256xf32>
 // CHECK:           }
@@ -137,7 +137,7 @@ module {
 // CHECK-DAG:         [[VAR_29_1_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
 // CHECK:             [[VAR_30_1_:%.+]] = arith.minsi [[VAR_28_1_]], [[VAR_29_1_]] : index
 // CHECK:             [[VAR_31_:%.+]] = arith.subi [[VAR_30_1_]], [[VAR_27_1_]] : index
-// CHECK:             [[VAR_32_:%.+]] = "tts.load"([[VAR_26_1_]], [[VAR_31_]], [[CST_0_dot_000000_]]) <{operandSegmentSizes = array<i32: 1, 1, 1>, static_dims = array<i64: -9223372036854775808>}> : (tensor<256x!tt.ptr<f32, 1>>, index, f32) -> tensor<256xf32>
+// CHECK:             [[VAR_32_:%.+]] = "tts.load"([[VAR_26_1_]], [[VAR_31_]], [[CST_0_dot_000000_]]) <{operandSegmentSizes = array<i32: 1, 1, 1>, static_mask_dims = array<i64: -9223372036854775808>}> : (tensor<256x!tt.ptr<f32, 1>>, index, f32) -> tensor<256xf32>
 // CHECK:             [[VAR_33_:%.+]] = arith.subf [[VAR_32_]], [[VAR_10_]] : tensor<256xf32>
 // CHECK:             [[VAR_34_:%.+]] = arith.select [[VAR_23_1_]], [[VAR_33_]], [[VAR_cst_]] : tensor<256xi1>, tensor<256xf32>
 // CHECK:             [[VAR_35_:%.+]] = arith.mulf [[VAR_34_]], [[VAR_34_]] : tensor<256xf32>
@@ -168,7 +168,7 @@ module {
 // CHECK-DAG:         [[VAR_25_2_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
 // CHECK:             [[VAR_26_2_:%.+]] = arith.minsi [[VAR_24_2_]], [[VAR_25_2_]] : index
 // CHECK:             [[VAR_27_2_:%.+]] = arith.subi [[VAR_26_2_]], [[VAR_23_2_]] : index
-// CHECK-DAG:         [[VAR_28_2_:%.+]] = "tts.load"([[VAR_22_2_]], [[VAR_27_2_]]) <{operandSegmentSizes = array<i32: 1, 1, 0>, static_dims = array<i64: -9223372036854775808>}> : (tensor<256x!tt.ptr<f32, 1>>, index) -> tensor<256xf32>
+// CHECK-DAG:         [[VAR_28_2_:%.+]] = "tts.load"([[VAR_22_2_]], [[VAR_27_2_]]) <{operandSegmentSizes = array<i32: 1, 1, 0>, static_mask_dims = array<i64: -9223372036854775808>}> : (tensor<256x!tt.ptr<f32, 1>>, index) -> tensor<256xf32>
 // CHECK-DAG:         [[VAR_29_2_:%.+]] = arith.index_cast [[VAR_arg9_1_]] : i32 to index
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:         [[VAR_30_2_:%.+]] = tts.make_tptr [[PARAM_3_]] to sizes: [256], strides: [1], offsets: {{.}}[[VAR_29_2_]]{{.}}, shape: [0], order: [] : <f32, 1> to tensor<256x!tt.ptr<f32, 1>>
@@ -178,7 +178,7 @@ module {
 // CHECK-DAG:         [[VAR_33_1_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
 // CHECK:             [[VAR_34_1_:%.+]] = arith.minsi [[VAR_32_1_]], [[VAR_33_1_]] : index
 // CHECK:             [[VAR_35_1_:%.+]] = arith.subi [[VAR_34_1_]], [[VAR_31_1_]] : index
-// CHECK-DAG:         [[VAR_36_1_:%.+]] = "tts.load"([[VAR_30_2_]], [[VAR_35_1_]]) <{operandSegmentSizes = array<i32: 1, 1, 0>, static_dims = array<i64: -9223372036854775808>}> : (tensor<256x!tt.ptr<f32, 1>>, index) -> tensor<256xf32>
+// CHECK-DAG:         [[VAR_36_1_:%.+]] = "tts.load"([[VAR_30_2_]], [[VAR_35_1_]]) <{operandSegmentSizes = array<i32: 1, 1, 0>, static_mask_dims = array<i64: -9223372036854775808>}> : (tensor<256x!tt.ptr<f32, 1>>, index) -> tensor<256xf32>
 // CHECK-DAG:         [[VAR_37_:%.+]] = arith.index_cast [[VAR_arg9_1_]] : i32 to index
 // CHECK:             [[VAR_38_:%.+]] = arith.addi [[VAR_2_]], [[VAR_37_]] : index
 // CHECK-DAG:         [[VAR_39_:%.+]] = tts.make_tptr [[PARAM_0_]] to sizes: [256], strides: [1], offsets: {{.}}[[VAR_38_]]{{.}}, shape: [0], order: [] : <f32, 1> to tensor<256x!tt.ptr<f32, 1>>
@@ -188,7 +188,7 @@ module {
 // CHECK-DAG:         [[VAR_42_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
 // CHECK:             [[VAR_43_:%.+]] = arith.minsi [[VAR_41_]], [[VAR_42_]] : index
 // CHECK:             [[VAR_44_:%.+]] = arith.subi [[VAR_43_]], [[VAR_40_]] : index
-// CHECK:             [[VAR_45_:%.+]] = "tts.load"([[VAR_39_]], [[VAR_44_]], [[CST_0_dot_000000_]]) <{operandSegmentSizes = array<i32: 1, 1, 1>, static_dims = array<i64: -9223372036854775808>}> : (tensor<256x!tt.ptr<f32, 1>>, index, f32) -> tensor<256xf32>
+// CHECK:             [[VAR_45_:%.+]] = "tts.load"([[VAR_39_]], [[VAR_44_]], [[CST_0_dot_000000_]]) <{operandSegmentSizes = array<i32: 1, 1, 1>, static_mask_dims = array<i64: -9223372036854775808>}> : (tensor<256x!tt.ptr<f32, 1>>, index, f32) -> tensor<256xf32>
 // CHECK:             [[VAR_46_:%.+]] = arith.subf [[VAR_45_]], [[VAR_19_]] : tensor<256xf32>
 // CHECK:             [[VAR_47_:%.+]] = arith.mulf [[VAR_46_]], [[VAR_20_]] : tensor<256xf32>
 // CHECK:             [[VAR_48_:%.+]] = arith.mulf [[VAR_47_]], [[VAR_28_2_]] : tensor<256xf32>
@@ -202,7 +202,7 @@ module {
 // CHECK-DAG:         [[VAR_55_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
 // CHECK:             [[VAR_56_:%.+]] = arith.minsi [[VAR_54_]], [[VAR_55_]] : index
 // CHECK:             [[VAR_57_:%.+]] = arith.subi [[VAR_56_]], [[VAR_53_]] : index
-// CHECK:             "tts.store"([[VAR_52_]], [[VAR_49_]], [[VAR_57_]]) <{static_dims = array<i64: -9223372036854775808>}> : (tensor<256x!tt.ptr<f32, 1>>, tensor<256xf32>, index) -> ()
+// CHECK:             "tts.store"([[VAR_52_]], [[VAR_49_]], [[VAR_57_]]) <{static_mask_dims = array<i64: -9223372036854775808>}> : (tensor<256x!tt.ptr<f32, 1>>, tensor<256xf32>, index) -> ()
 // CHECK:           }
 // CHECK:           tt.return
 // CHECK:         }

--- a/test/Conversion/TritonToStructured/masked_ldst_1d.mlir
+++ b/test/Conversion/TritonToStructured/masked_ldst_1d.mlir
@@ -28,9 +28,9 @@ module {
 // CHECK-DAG:       [[VAR_1_:%.+]] = tts.make_tptr [[PARAM_1_]] to sizes: [128], strides: [1], offsets: [0], shape: [0], order: [] : <bf16, 1> to tensor<128x!tt.ptr<bf16, 1>>
 // CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
 // CHECK:           [[VAR_3_:%.+]] = arith.minsi [[VAR_2_]], [[CST_128_]] : index
-// CHECK-DAG:       [[VAR_4_:%.+]] = "tts.load"([[VAR_0_]], [[VAR_3_]], [[CST_0_]]) <{operandSegmentSizes = array<i32: 1, 1, 1>, static_dims = array<i64: -9223372036854775808>}> : (tensor<128x!tt.ptr<bf16, 1>>, index, bf16) -> tensor<128xbf16>
+// CHECK-DAG:       [[VAR_4_:%.+]] = "tts.load"([[VAR_0_]], [[VAR_3_]], [[CST_0_]]) <{operandSegmentSizes = array<i32: 1, 1, 1>, static_mask_dims = array<i64: -9223372036854775808>}> : (tensor<128x!tt.ptr<bf16, 1>>, index, bf16) -> tensor<128xbf16>
 // CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
 // CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_5_]], [[CST_128_]] : index
-// CHECK:           "tts.store"([[VAR_1_]], [[VAR_4_]], [[VAR_6_]]) <{static_dims = array<i64: -9223372036854775808>}> : (tensor<128x!tt.ptr<bf16, 1>>, tensor<128xbf16>, index) -> ()
+// CHECK:           "tts.store"([[VAR_1_]], [[VAR_4_]], [[VAR_6_]]) <{static_mask_dims = array<i64: -9223372036854775808>}> : (tensor<128x!tt.ptr<bf16, 1>>, tensor<128xbf16>, index) -> ()
 // CHECK:           tt.return
 // CHECK:         }

--- a/test/Conversion/TritonToStructured/masked_ldst_2d.mlir
+++ b/test/Conversion/TritonToStructured/masked_ldst_2d.mlir
@@ -83,7 +83,7 @@ module {
 // CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[CST_3_]] : index
 // CHECK-DAG:       [[VAR_8_:%.+]] = arith.minsi [[VAR_4_]], [[CST_128_]] : index
 // CHECK:           [[VAR_9_:%.+]] = arith.minsi [[VAR_7_]], [[CST_256_]] : index
-// CHECK-DAG:       [[VAR_10_:%.+]] = "tts.load"([[VAR_0_]], [[VAR_8_]], [[VAR_9_]], [[CST_0_]]) <{operandSegmentSizes = array<i32: 1, 2, 1>, static_dims = array<i64: -9223372036854775808, -9223372036854775808>}> : (tensor<128x256x!tt.ptr<bf16, 1>>, index, index, bf16) -> tensor<128x256xbf16>
+// CHECK-DAG:       [[VAR_10_:%.+]] = "tts.load"([[VAR_0_]], [[VAR_8_]], [[VAR_9_]], [[CST_0_]]) <{operandSegmentSizes = array<i32: 1, 2, 1>, static_mask_dims = array<i64: -9223372036854775808, -9223372036854775808>}> : (tensor<128x256x!tt.ptr<bf16, 1>>, index, index, bf16) -> tensor<128x256xbf16>
 // CHECK-DAG:       [[VAR_11_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
 // CHECK:           [[VAR_12_:%.+]] = arith.minsi [[VAR_11_]], [[CST_130_]] : index
 // CHECK-DAG:       [[VAR_13_:%.+]] = arith.subi [[VAR_12_]], [[CST_2_]] : index
@@ -92,6 +92,6 @@ module {
 // CHECK-DAG:       [[VAR_16_:%.+]] = arith.subi [[VAR_15_]], [[CST_3_]] : index
 // CHECK-DAG:       [[VAR_17_:%.+]] = arith.minsi [[VAR_13_]], [[CST_128_]] : index
 // CHECK:           [[VAR_18_:%.+]] = arith.minsi [[VAR_16_]], [[CST_256_]] : index
-// CHECK:           "tts.store"([[VAR_1_]], [[VAR_1_]]0, [[VAR_1_]]7, [[VAR_1_]]8) <{static_dims = array<i64: -9223372036854775808, -9223372036854775808>}> : (tensor<128x256x!tt.ptr<bf16, 1>>, tensor<128x256xbf16>, index, index) -> ()
+// CHECK:           "tts.store"([[VAR_1_]], [[VAR_1_]]0, [[VAR_1_]]7, [[VAR_1_]]8) <{static_mask_dims = array<i64: -9223372036854775808, -9223372036854775808>}> : (tensor<128x256x!tt.ptr<bf16, 1>>, tensor<128x256xbf16>, index, index) -> ()
 // CHECK:           tt.return
 // CHECK:         }

--- a/test/Conversion/TritonToStructured/masked_ldst_sitofp_other.mlir
+++ b/test/Conversion/TritonToStructured/masked_ldst_sitofp_other.mlir
@@ -30,9 +30,9 @@ module {
 // CHECK-DAG:       [[VAR_1_:%.+]] = tts.make_tptr [[PARAM_1_]] to sizes: [128], strides: [1], offsets: [0], shape: [0], order: [] : <bf16, 1> to tensor<128x!tt.ptr<bf16, 1>>
 // CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
 // CHECK:           [[VAR_3_:%.+]] = arith.minsi [[VAR_2_]], [[CST_128_]] : index
-// CHECK-DAG:       [[VAR_4_:%.+]] = "tts.load"([[VAR_0_]], [[VAR_3_]], [[CST_7_dot_000000_]]) <{operandSegmentSizes = array<i32: 1, 1, 1>, static_dims = array<i64: -9223372036854775808>}> : (tensor<128x!tt.ptr<bf16, 1>>, index, bf16) -> tensor<128xbf16>
+// CHECK-DAG:       [[VAR_4_:%.+]] = "tts.load"([[VAR_0_]], [[VAR_3_]], [[CST_7_dot_000000_]]) <{operandSegmentSizes = array<i32: 1, 1, 1>, static_mask_dims = array<i64: -9223372036854775808>}> : (tensor<128x!tt.ptr<bf16, 1>>, index, bf16) -> tensor<128xbf16>
 // CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
 // CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_5_]], [[CST_128_]] : index
-// CHECK:           "tts.store"([[VAR_1_]], [[VAR_4_]], [[VAR_6_]]) <{static_dims = array<i64: -9223372036854775808>}> : (tensor<128x!tt.ptr<bf16, 1>>, tensor<128xbf16>, index) -> ()
+// CHECK:           "tts.store"([[VAR_1_]], [[VAR_4_]], [[VAR_6_]]) <{static_mask_dims = array<i64: -9223372036854775808>}> : (tensor<128x!tt.ptr<bf16, 1>>, tensor<128xbf16>, index) -> ()
 // CHECK:           tt.return
 // CHECK:         }

--- a/test/Conversion/TritonToStructured/use_dot_opc.mlir
+++ b/test/Conversion/TritonToStructured/use_dot_opc.mlir
@@ -56,13 +56,13 @@ module {
 // CHECK-DAG:       [[CST_256_:%.+]] = arith.constant 256 : index
 // CHECK-DAG:       [[CST_128_:%.+]] = arith.constant 128 : index
 // CHECK:           [[VAR_0_:%.+]] = tts.make_tptr [[PARAM_0_]] to sizes: [128, 64], strides: {{.}}[[CST_128_]], 1], offsets: [0, 0], shape: [0, 0], order: [] : <bf16, 1> to tensor<128x64x!tt.ptr<bf16, 1>>
-// CHECK-DAG:       [[VAR_1_:%.+]] = "tts.load"([[VAR_0_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_dims = array<i64>}> : (tensor<128x64x!tt.ptr<bf16, 1>>) -> tensor<128x64xbf16>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "tts.load"([[VAR_0_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<128x64x!tt.ptr<bf16, 1>>) -> tensor<128x64xbf16>
 // CHECK-DAG:       [[VAR_2_:%.+]] = tts.make_tptr [[PARAM_1_]] to sizes: [64, 256], strides: {{.}}[[CST_256_]], 1], offsets: [0, 0], shape: [0, 0], order: [] : <bf16, 1> to tensor<64x256x!tt.ptr<bf16, 1>>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_3_:%.+]] = "tts.load"([[VAR_2_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_dims = array<i64>}> : (tensor<64x256x!tt.ptr<bf16, 1>>) -> tensor<64x256xbf16>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "tts.load"([[VAR_2_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<64x256x!tt.ptr<bf16, 1>>) -> tensor<64x256xbf16>
 // CHECK-DAG:       [[VAR_4_:%.+]] = tts.make_tptr [[PARAM_2_]] to sizes: [128, 256], strides: {{.}}[[CST_256_]], 1], offsets: [0, 0], shape: [0, 0], order: [] : <bf16, 1> to tensor<128x256x!tt.ptr<bf16, 1>>
 // CHECK:           [[VAR_5_:%.+]] = tt.dot [[VAR_1_]], [[VAR_3_]], [[VAR_cst_]] {allowTF32 = false, maxNumImpreciseAcc = 0 : i32} : tensor<128x64xbf16> * tensor<64x256xbf16> -> tensor<128x256xbf16>
-// CHECK:           "tts.store"([[VAR_4_]], [[VAR_5_]]) <{static_dims = array<i64>}> : (tensor<128x256x!tt.ptr<bf16, 1>>, tensor<128x256xbf16>) -> ()
-// CHECK:           "tts.store"([[VAR_4_]], [[VAR_cst_]]) <{static_dims = array<i64>}> : (tensor<128x256x!tt.ptr<bf16, 1>>, tensor<128x256xbf16>) -> ()
+// CHECK:           "tts.store"([[VAR_4_]], [[VAR_5_]]) <{static_mask_dims = array<i64>}> : (tensor<128x256x!tt.ptr<bf16, 1>>, tensor<128x256xbf16>) -> ()
+// CHECK:           "tts.store"([[VAR_4_]], [[VAR_cst_]]) <{static_mask_dims = array<i64>}> : (tensor<128x256x!tt.ptr<bf16, 1>>, tensor<128x256xbf16>) -> ()
 // CHECK:           tt.return
 // CHECK:         }

--- a/test/Conversion/TritonToStructured/use_end_chain.mlir
+++ b/test/Conversion/TritonToStructured/use_end_chain.mlir
@@ -48,9 +48,9 @@ module {
 // CHECK:           [[VAR_6_:%.+]] = arith.muli [[VAR_5_]], [[VAR_cst_]] : tensor<256x128xi32>
 // CHECK-DAG:       [[VAR_7_:%.+]] = arith.addi [[VAR_2_]], [[VAR_6_]] : tensor<256x128xi32>
 // CHECK-DAG:       [[VAR_8_:%.+]] = tts.make_tptr [[PARAM_1_]] to sizes: [256, 128], strides: [1, [[CST_6_]]{{.}}, offsets: [512, [[CST_6144_]]{{.}}, shape: [0, 0], order: [] : <bf16, 1> to tensor<256x128x!tt.ptr<bf16, 1>>
-// CHECK:           [[VAR_9_:%.+]] = "tts.load"([[VAR_8_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_dims = array<i64>}> : (tensor<256x128x!tt.ptr<bf16, 1>>) -> tensor<256x128xbf16>
-// CHECK:           "tts.store"([[VAR_8_]], [[VAR_9_]]) <{static_dims = array<i64>}> : (tensor<256x128x!tt.ptr<bf16, 1>>, tensor<256x128xbf16>) -> ()
+// CHECK:           [[VAR_9_:%.+]] = "tts.load"([[VAR_8_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<256x128x!tt.ptr<bf16, 1>>) -> tensor<256x128xbf16>
+// CHECK:           "tts.store"([[VAR_8_]], [[VAR_9_]]) <{static_mask_dims = array<i64>}> : (tensor<256x128x!tt.ptr<bf16, 1>>, tensor<256x128xbf16>) -> ()
 // CHECK:           [[VAR_10_:%.+]] = arith.sitofp [[VAR_7_]] : tensor<256x128xi32> to tensor<256x128xbf16>
-// CHECK:           "tts.store"([[VAR_8_]], [[VAR_10_]]) <{static_dims = array<i64>}> : (tensor<256x128x!tt.ptr<bf16, 1>>, tensor<256x128xbf16>) -> ()
+// CHECK:           "tts.store"([[VAR_8_]], [[VAR_10_]]) <{static_mask_dims = array<i64>}> : (tensor<256x128x!tt.ptr<bf16, 1>>, tensor<256x128xbf16>) -> ()
 // CHECK:           tt.return
 // CHECK:         }

--- a/test/Conversion/TritonToStructured/use_mid_chain.mlir
+++ b/test/Conversion/TritonToStructured/use_mid_chain.mlir
@@ -44,9 +44,9 @@ module {
 // CHECK:           [[VAR_1_:%.+]] = tt.expand_dims [[VAR_0_]] {axis = 1 : i32} : tensor<256xi32> -> tensor<256x1xi32>
 // CHECK-DAG:       [[VAR_2_:%.+]] = tt.broadcast [[VAR_1_]] : tensor<256x1xi32> -> tensor<256x128xi32>
 // CHECK-DAG:       [[VAR_3_:%.+]] = tts.make_tptr [[PARAM_1_]] to sizes: [256, 128], strides: [1, [[CST_6_]]{{.}}, offsets: [512, [[CST_6_]]144], shape: [0, 0], order: [] : <bf16, 1> to tensor<256x128x!tt.ptr<bf16, 1>>
-// CHECK:           [[VAR_4_:%.+]] = "tts.load"([[VAR_3_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_dims = array<i64>}> : (tensor<256x128x!tt.ptr<bf16, 1>>) -> tensor<256x128xbf16>
-// CHECK:           "tts.store"([[VAR_3_]], [[VAR_4_]]) <{static_dims = array<i64>}> : (tensor<256x128x!tt.ptr<bf16, 1>>, tensor<256x128xbf16>) -> ()
+// CHECK:           [[VAR_4_:%.+]] = "tts.load"([[VAR_3_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<256x128x!tt.ptr<bf16, 1>>) -> tensor<256x128xbf16>
+// CHECK:           "tts.store"([[VAR_3_]], [[VAR_4_]]) <{static_mask_dims = array<i64>}> : (tensor<256x128x!tt.ptr<bf16, 1>>, tensor<256x128xbf16>) -> ()
 // CHECK:           [[VAR_5_:%.+]] = tts.make_tptr [[PARAM_2_]] to sizes: [256, 128], strides: [1, [[CST_6_]]{{.}}, offsets: [512, [[CST_6_]]144], shape: [0, 0], order: [] : <i32, 1> to tensor<256x128x!tt.ptr<i32, 1>>
-// CHECK:           "tts.store"([[VAR_5_]], [[VAR_2_]]) <{static_dims = array<i64>}> : (tensor<256x128x!tt.ptr<i32, 1>>, tensor<256x128xi32>) -> ()
+// CHECK:           "tts.store"([[VAR_5_]], [[VAR_2_]]) <{static_mask_dims = array<i64>}> : (tensor<256x128x!tt.ptr<i32, 1>>, tensor<256x128xi32>) -> ()
 // CHECK:           tt.return
 // CHECK:         }

--- a/test/Conversion/TritonToStructured/wraparound_side_by_side.mlir
+++ b/test/Conversion/TritonToStructured/wraparound_side_by_side.mlir
@@ -82,8 +82,8 @@ module {
 // CHECK-DAG:       [[VAR_12_:%.+]]:2 = scf.for [[VAR_arg8_:%.+]] = [[CST_0_1_]] to [[CST_2_]] step [[CST_1_]] iter_args([[VAR_arg9_:%.+]] = [[VAR_1_]], [[VAR_arg10_:%.+]] = [[CST_0_]]) -> (index, index)  : i32 {
 // CHECK-DAG:         [[VAR_13_:%.+]] = tts.make_tptr [[PARAM_1_]] to sizes: [4, 4], strides: {{.}}[[VAR_6_]], [[VAR_7_]]{{.}}, offsets: {{.}}[[PARAM_1_]]0, [[CST_0_]]{{.}}, shape: [0, 0], order: [] : <f32, 1> to tensor<4x4x!tt.ptr<f32, 1>>
 // CHECK-DAG:         [[VAR_14_:%.+]] = tts.make_tptr [[PARAM_0_]] to sizes: [4, 4], strides: {{.}}[[VAR_0_]], [[VAR_3_]]{{.}}, offsets: {{.}}[[VAR_arg9_]], [[VAR_4_]]{{.}}, shape: [0, [[VAR_5_]]{{.}}, order: [] : <f32, 1> to tensor<4x4x!tt.ptr<f32, 1>>
-// CHECK:             [[VAR_15_:%.+]] = "tts.load"([[VAR_14_]], [[CST_minus_9_dot_900000_]]) <{operandSegmentSizes = array<i32: 1, 0, 1>, static_dims = array<i64: 2, 4>}> : (tensor<4x4x!tt.ptr<f32, 1>>, f32) -> tensor<4x4xf32>
-// CHECK:             "tts.store"([[VAR_13_]], [[VAR_15_]]) <{static_dims = array<i64>}> : (tensor<4x4x!tt.ptr<f32, 1>>, tensor<4x4xf32>) -> ()
+// CHECK:             [[VAR_15_:%.+]] = "tts.load"([[VAR_14_]], [[CST_minus_9_dot_900000_]]) <{operandSegmentSizes = array<i32: 1, 0, 1>, static_mask_dims = array<i64: 2, 4>}> : (tensor<4x4x!tt.ptr<f32, 1>>, f32) -> tensor<4x4xf32>
+// CHECK:             "tts.store"([[VAR_13_]], [[VAR_15_]]) <{static_mask_dims = array<i64>}> : (tensor<4x4x!tt.ptr<f32, 1>>, tensor<4x4xf32>) -> ()
 // CHECK-DAG:         [[VAR_16_:%.+]] = arith.addi [[VAR_arg9_]], [[VAR_9_]] : index
 // CHECK-DAG:         [[VAR_17_:%.+]] = arith.addi [[VAR_arg10_]], [[VAR_11_]] : index
 // CHECK:             scf.yield [[VAR_16_]], [[VAR_17_]] : index, index

--- a/test/Conversion/TritonToStructured/wraparound_stacked.mlir
+++ b/test/Conversion/TritonToStructured/wraparound_stacked.mlir
@@ -78,8 +78,8 @@ module {
 // CHECK-DAG:       [[VAR_11_:%.+]]:2 = scf.for [[VAR_arg8_:%.+]] = [[CST_0_1_]] to [[CST_2_1_]] step [[CST_1_]] iter_args([[VAR_arg9_:%.+]] = [[VAR_2_]], [[VAR_arg10_:%.+]] = [[CST_0_]]) -> (index, index)  : i32 {
 // CHECK-DAG:         [[VAR_12_:%.+]] = tts.make_tptr [[PARAM_1_]] to sizes: [4, 4], strides: {{.}}[[VAR_6_]], [[VAR_7_]]{{.}}, offsets: {{.}}[[PARAM_1_]]0, [[CST_0_]]{{.}}, shape: [0, 0], order: [] : <f32, 1> to tensor<4x4x!tt.ptr<f32, 1>>
 // CHECK-DAG:         [[VAR_13_:%.+]] = tts.make_tptr [[PARAM_0_]] to sizes: [4, 4], strides: {{.}}[[VAR_1_]], [[VAR_4_]]{{.}}, offsets: {{.}}[[VAR_arg9_]], [[VAR_5_]]{{.}}, shape: {{.}}[[VAR_3_]], 0], order: [] : <f32, 1> to tensor<4x4x!tt.ptr<f32, 1>>
-// CHECK:             [[VAR_14_:%.+]] = "tts.load"([[VAR_13_]], [[CST_minus_9_dot_900000_]]) <{operandSegmentSizes = array<i32: 1, 0, 1>, static_dims = array<i64: 4, 3>}> : (tensor<4x4x!tt.ptr<f32, 1>>, f32) -> tensor<4x4xf32>
-// CHECK:             "tts.store"([[VAR_12_]], [[VAR_14_]]) <{static_dims = array<i64>}> : (tensor<4x4x!tt.ptr<f32, 1>>, tensor<4x4xf32>) -> ()
+// CHECK:             [[VAR_14_:%.+]] = "tts.load"([[VAR_13_]], [[CST_minus_9_dot_900000_]]) <{operandSegmentSizes = array<i32: 1, 0, 1>, static_mask_dims = array<i64: 4, 3>}> : (tensor<4x4x!tt.ptr<f32, 1>>, f32) -> tensor<4x4xf32>
+// CHECK:             "tts.store"([[VAR_12_]], [[VAR_14_]]) <{static_mask_dims = array<i64>}> : (tensor<4x4x!tt.ptr<f32, 1>>, tensor<4x4xf32>) -> ()
 // CHECK-DAG:         [[VAR_15_:%.+]] = arith.addi [[VAR_arg9_]], [[VAR_10_]] : index
 // CHECK-DAG:         [[VAR_16_:%.+]] = arith.addi [[VAR_arg10_]], [[VAR_9_]] : index
 // CHECK:             scf.yield [[VAR_15_]], [[VAR_16_]] : index, index

--- a/test/Conversion/TritonToStructured/wraparound_unsupported_add_offset.mlir
+++ b/test/Conversion/TritonToStructured/wraparound_unsupported_add_offset.mlir
@@ -101,7 +101,7 @@ module {
 // CHECK-DAG:       [[VAR_25_:%.+]]:2 = scf.for [[VAR_arg8_:%.+]] = [[CST_0_1_]] to [[CST_2_]] step [[CST_1_]] iter_args([[VAR_arg9_:%.+]] = [[VAR_15_]], [[VAR_arg10_:%.+]] = [[CST_0_]]) -> (tensor<4x4x!tt.ptr<f32, 1>>, index)  : i32 {
 // CHECK-DAG:         [[VAR_26_:%.+]] = tts.make_tptr [[PARAM_1_]] to sizes: [4, 4], strides: {{.}}[[VAR_17_]], [[VAR_18_]]{{.}}, offsets: {{.}}[[PARAM_1_]]0, [[CST_0_]]{{.}}, shape: [0, 0], order: [] : <f32, 1> to tensor<4x4x!tt.ptr<f32, 1>>
 // CHECK-DAG:         [[LOAD_VAR_arg9_MEM_:%.+]] = tt.load [[VAR_arg9_]], [[VAR_20_]], [[VAR_cst_]] {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<4x4xf32>
-// CHECK:             "tts.store"([[VAR_26_]], [[LOAD_VAR_arg9_MEM_]]) <{static_dims = array<i64>}> : (tensor<4x4x!tt.ptr<f32, 1>>, tensor<4x4xf32>) -> ()
+// CHECK:             "tts.store"([[VAR_26_]], [[LOAD_VAR_arg9_MEM_]]) <{static_mask_dims = array<i64>}> : (tensor<4x4x!tt.ptr<f32, 1>>, tensor<4x4xf32>) -> ()
 // CHECK-DAG:         [[VAR_28_:%.+]] = tt.addptr [[VAR_arg9_]], [[VAR_22_]] : tensor<4x4x!tt.ptr<f32, 1>>, tensor<4x4xi32>
 // CHECK-DAG:         [[VAR_29_:%.+]] = arith.addi [[VAR_arg10_]], [[VAR_24_]] : index
 // CHECK:             scf.yield [[VAR_28_]], [[VAR_29_]] : tensor<4x4x!tt.ptr<f32, 1>>, index

--- a/tools/RegisterTritonSharedDialects.h
+++ b/tools/RegisterTritonSharedDialects.h
@@ -1,4 +1,11 @@
 #pragma once
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/Passes.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "triton-shared/Conversion/StructuredToMemref/Passes.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 
@@ -8,8 +15,9 @@
 #include "triton/Conversion/TritonGPUToLLVM/Passes.h"
 #include "triton/Conversion/TritonToTritonGPU/Passes.h"
 
-#include "triton-shared/Conversion/TritonToLinalg/Passes.h"
+#include "triton-shared/Conversion/StructuredToMemref/Passes.h"
 #include "triton-shared/Conversion/TritonArithToLinalg/Passes.h"
+#include "triton-shared/Conversion/TritonToLinalg/Passes.h"
 #include "triton-shared/Conversion/TritonToStructured/Passes.h"
 #include "triton-shared/Dialect/TritonStructured/IR/TritonStructuredDialect.h"
 #include "triton-shared/Dialect/TritonTilingExt/IR/TritonTilingExtDialect.h"
@@ -29,6 +37,7 @@ inline void registerTritonSharedDialects(mlir::DialectRegistry &registry) {
   mlir::registerAllPasses();
   mlir::registerTritonPasses();
   mlir::registerTritonGPUPasses();
+  mlir::registerLinalgPasses();
   mlir::test::registerTestAliasPass();
   mlir::test::registerTestAlignmentPass();
   mlir::test::registerTestAllocationPass();
@@ -38,11 +47,15 @@ inline void registerTritonSharedDialects(mlir::DialectRegistry &registry) {
   mlir::triton::registerTritonArithToLinalgPasses();
   mlir::triton::registerConvertTritonToTritonGPUPass();
   mlir::triton::registerConvertTritonGPUToLLVMPass();
+  mlir::triton::registerStructuredToMemrefPasses();
 
   // TODO: register Triton & TritonGPU passes
-  registry
-      .insert<mlir::ttx::TritonTilingExtDialect, mlir::tts::TritonStructuredDialect, mlir::triton::TritonDialect,
-              mlir::cf::ControlFlowDialect, mlir::triton::gpu::TritonGPUDialect,
-              mlir::math::MathDialect, mlir::arith::ArithDialect,
-              mlir::scf::SCFDialect, mlir::gpu::GPUDialect>();
+  registry.insert<
+      mlir::ttx::TritonTilingExtDialect, mlir::tts::TritonStructuredDialect,
+      mlir::triton::TritonDialect, mlir::cf::ControlFlowDialect,
+      mlir::triton::gpu::TritonGPUDialect, mlir::math::MathDialect,
+      mlir::arith::ArithDialect, mlir::scf::SCFDialect, mlir::gpu::GPUDialect,
+      mlir::linalg::LinalgDialect, mlir::func::FuncDialect,
+      mlir::tensor::TensorDialect, mlir::memref::MemRefDialect,
+      mlir::bufferization::BufferizationDialect>();
 }


### PR DESCRIPTION
This PR adds the final pass `structured-to-memref` as outlined in the discussion on making the `triton-to-linalg` pass more modular: https://github.com/microsoft/triton-shared/discussions/81

## Details
The pass expects to run after `triton-to-structured` and `triton-arith-to-linalg` and will lower all ops in the TritonStructured dialect to memref:
+ `tts.make_tptr` to `memref.reinterpret_cast`
+ `tts.load` to a combination of `memref.alloc`, `memref.copy`, and `bufferization.to_tensor`
+ `tts.store` to `bufferization.materialize_in_destination`

## Differences
Overall, the final resulting IRs will be cleaner compared to the original monolith `triton-to-linalg` pass with very little changes except for handling of scalar loads and stores.

Since `triton-to-structured` leaves out `tt.addptr`, `tt.load`, and `tt.store` for unstructured pointers and scalars, the pass also handles those that deal with scalars through a combination of `memref.reinterpret_cast` and `memref.extract_strided_metadata` as seen below:

```mlir
  func.func @kernel(%arg0: !tt.ptr<f32, 1> {tt.divisibility = 16 : i32}, %arg1: i32, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32, %arg6: i32) {
    %c8_i32 = arith.constant 8 : i32
    %c0_i32 = arith.constant 0 : i32
    %c1_i32 = arith.constant 1 : i32
    %0 = scf.for %arg7 = %c0_i32 to %c8_i32 step %c1_i32 iter_args(%arg8 = %arg0) -> (!tt.ptr<f32, 1>)  : i32 {
      %1 = arith.sitofp %arg7 : i32 to f32
      tt.store %arg8, %1 {cache = 1 : i32, evict = 1 : i32} : f32
      %2 = tt.addptr %arg8, %c1_i32 : !tt.ptr<f32, 1>, i32
      scf.yield %2 : !tt.ptr<f32, 1>
    }
    return
  }
```

will become

```mlir
  func.func @kernel(%arg0: memref<*xf32> {tt.divisibility = 16 : i32}, %arg1: i32, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32, %arg6: i32) {
    %c1 = arith.constant 1 : index
    %c1_i32 = arith.constant 1 : i32
    %c0_i32 = arith.constant 0 : i32
    %c8_i32 = arith.constant 8 : i32
    %reinterpret_cast = memref.reinterpret_cast %arg0 to offset: [0], sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
    %0 = scf.for %arg7 = %c0_i32 to %c8_i32 step %c1_i32 iter_args(%arg8 = %reinterpret_cast) -> (memref<1xf32, strided<[1], offset: ?>>)  : i32 {
      %1 = arith.sitofp %arg7 : i32 to f32
      affine.store %1, %arg8[0] : memref<1xf32, strided<[1], offset: ?>>
      %base_buffer, %offset, %sizes, %strides = memref.extract_strided_metadata %arg8 : memref<1xf32, strided<[1], offset: ?>> -> memref<f32>, index, index, index
      %2 = arith.addi %offset, %c1 : index
      %reinterpret_cast_0 = memref.reinterpret_cast %base_buffer to offset: [%2], sizes: [1], strides: [1] : memref<f32> to memref<1xf32, strided<[1], offset: ?>>
      scf.yield %reinterpret_cast_0 : memref<1xf32, strided<[1], offset: ?>>
    }
    return
  }
```

## How to use

With this pass, the whole pipeline for lowering triton IR to linalg is:

```
--triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref
```

## Testing

### lit tests
I have added all the existing lit tests from `triton-to-linalg` and manually verified that the outputs make sense.

### CPU backend testing
I have updated our CPU backend to use the new pipeline and verified that they all ran correctly.