### PR TITLE
Test against latest triton in nightly builds

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -17,6 +17,7 @@ jobs:
     uses: ./.github/workflows/test-plugin.yml
     with:
         triton-shared-ref: 'main'
+        triton-ref: 'main'
         # The `inputs` variable is not available when the workflow is automatically triggered by a schedule.
         # In such case, `inputs.force-failure` is an empty string which breaks the workflow. As a workaround,
         # check the user provided input if it contains `true` instead of using the value directly.

--- a/.github/workflows/test-plugin.yml
+++ b/.github/workflows/test-plugin.yml
@@ -46,8 +46,8 @@ jobs:
       if: ${{ inputs.triton-ref }}
       working-directory: triton_shared/triton
       run: |
-        git fetch
-        git checkout ${{ inputs.triton-ref }}
+        git submodule update --recursive --remote
+        # git checkout ${{ inputs.triton-ref }}
         git log
 
     - name: Clear Triton Cache

--- a/.github/workflows/test-plugin.yml
+++ b/.github/workflows/test-plugin.yml
@@ -46,8 +46,8 @@ jobs:
       if: ${{ inputs.triton-ref }}
       working-directory: triton_shared/triton
       run: |
-        git submodule update --recursive --remote
-        # git checkout ${{ inputs.triton-ref }}
+        # git fetch
+        git checkout ${{ inputs.triton-ref }}
         git log
 
     - name: Clear Triton Cache

--- a/.github/workflows/test-plugin.yml
+++ b/.github/workflows/test-plugin.yml
@@ -42,13 +42,12 @@ jobs:
         # Also checkout triton submodule
         submodules: recursive
 
-    - name: Checkout triton at commit ${{ inputs.triton-ref }}
+    - name: Checkout triton at ${{ inputs.triton-ref }}
       if: ${{ inputs.triton-ref }}
       working-directory: triton_shared/triton
       run: |
-        # git fetch
         git checkout ${{ inputs.triton-ref }}
-        git log
+        git log -1
 
     - name: Clear Triton Cache
       run: |

--- a/.github/workflows/test-plugin.yml
+++ b/.github/workflows/test-plugin.yml
@@ -3,6 +3,9 @@ name: Triton-Shared Plugin Testing
 on:
   workflow_call:
     inputs:
+      triton-ref:
+        required: false
+        type: string
       triton-shared-ref:
         required: true
         type: string
@@ -11,6 +14,9 @@ on:
         type: boolean
   workflow_dispatch:
     inputs:
+      triton-ref:
+        required: false
+        type: string
       triton-shared-ref:
         required: true
         type: string
@@ -33,7 +39,14 @@ jobs:
       with:
         ref: ${{ inputs.triton-shared-ref }}
         path: triton_shared
+        # Also checkout triton submodule
         submodules: recursive
+
+    - name: Checkout triton at commit
+      if: ${{ inputs.triton-ref }}
+      working-directory: triton_shared/triton
+      run: |
+        git checkout ${{ inputs.triton-ref }}
 
     - name: Clear Triton Cache
       run: |

--- a/.github/workflows/test-plugin.yml
+++ b/.github/workflows/test-plugin.yml
@@ -42,11 +42,13 @@ jobs:
         # Also checkout triton submodule
         submodules: recursive
 
-    - name: Checkout triton at commit
+    - name: Checkout triton at commit ${{ inputs.triton-ref }}
       if: ${{ inputs.triton-ref }}
       working-directory: triton_shared/triton
       run: |
+        git fetch
         git checkout ${{ inputs.triton-ref }}
+        git log
 
     - name: Clear Triton Cache
       run: |


### PR DESCRIPTION
After the recent updates, we no longer run the nightly builds with latest triton. This PR adds back the option to specify the triton commit to test with. For nightly runs, we always test the latest.