### PR TITLE
Add permission for creating issue in nightly jobs

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -23,6 +23,8 @@ jobs:
         # check the user provided input if it contains `true` instead of using the value directly.
         force-failure: ${{ contains(inputs.force-failure, 'true') }}
   report-failure:
+    permissions:
+      issues: write
     runs-on: ubuntu-latest
     needs: [call-workflow]
     # Always report failure if the workflow is triggered by a schedule.


### PR DESCRIPTION
Nightly jobs cannot create issues due to missing write permissions:

```
GraphQL: Resource not accessible by integration (createIssue)
```