### PR TITLE
Introducing Arm SME/SVE2 Optimization pass

### DIFF
--- a/backend/driver.py
+++ b/backend/driver.py
@@ -40,8 +40,8 @@ def _extracted_ty(ty):
         'i64': 'int64_t',
         'u32': 'uint32_t',
         'u64': 'uint64_t',
-        'fp16': 'float16_t',
-        'bf16': 'bfloat16_t',
+        'fp16': 'float',
+        'bf16': 'float',
         'fp32': 'float',
         'f32': 'float',
         'fp64': 'double',
@@ -226,7 +226,7 @@ def compile_module(launcher_src, kernel_placeholder_name):
               # Compile it together.
               subprocess.check_call([
                 "g++", launcher_src_path, asm_src_path,
-                f"-I{py_include_dir}", f"-I{include_dir}" "-mfp16-format=ieee",
+                f"-I{py_include_dir}", f"-I{include_dir}",
                 "-shared", "-fPIC", "-o", so_path
               ])
 

--- a/backend/driver.py
+++ b/backend/driver.py
@@ -2,7 +2,7 @@ import hashlib
 import tempfile
 import sysconfig
 
-import os, subprocess, tempfile
+import os, subprocess, tempfile, platform
 import importlib.util
 import sysconfig
 
@@ -13,9 +13,31 @@ from triton.backends.driver import DriverBase
 
 
 # -------------------- Launcher ----------------------------
+
+def has_hf():
+  resp = os.popen("lscpu").read()
+  if platform.machine() == "x86_64" and "f16c" in resp:
+    
+    return True
+  elif platform.machine() == "aarch64" and "fphp" in resp:
+    return True
+  return False
+
+def has_bf():
+  resp = os.popen("lscpu").read()
+  if platform.machine() == "x86_64" and "avx512_bf16" in resp:
+    print("axv512_bf16")
+    return True
+  #TODO add aarch64 support for bf16
+  return False
+
+
+
+# -------------------- Launcher ----------------------------
 def _ty_to_cpp(ty):
     if ty[0] == '*':
         return "void*"
+      
     return {
         "i1": "int32_t",
         "i8": "int8_t",
@@ -24,12 +46,14 @@ def _ty_to_cpp(ty):
         "i64": "int64_t",
         "u32": "uint32_t",
         "u64": "uint64_t",
-        "fp16": "float",
-        "bf16": "float",
+        "fp16": "float16_t" if has_hf() else "float",
+        "bf16": "bfloat16_t" if has_bf() else "float16_t" if has_hf() else "float",
         "fp32": "float",
         "f32": "float",
         "fp64": "double",
     }[ty]
+    
+    
 
 def _extracted_ty(ty):
     if ty[0] == '*':
@@ -40,15 +64,15 @@ def _extracted_ty(ty):
         'i64': 'int64_t',
         'u32': 'uint32_t',
         'u64': 'uint64_t',
-        'fp16': 'float',
-        'bf16': 'float',
+        "fp16": "float16_t" if has_hf() else "float",
+        "bf16": "bfloat16_t" if has_bf() else "float16_t" if has_hf() else "float",
         'fp32': 'float',
         'f32': 'float',
         'fp64': 'double',
     }[ty]
 
 def _format_of(ty):
-    return {
+    format_dict = {
         "PyObject*": "O",
         "float": "f",
         "double": "d",
@@ -57,7 +81,12 @@ def _format_of(ty):
         "int32_t": "i",
         "uint64_t": "K",
         "int64_t": "L",
-    }[ty]
+    }
+    if has_bf():
+        format_dict["bfloat16"] = "e"
+    if has_hf():
+        format_dict["float16"] = "h"
+    return format_dict[ty]
 
 def _generate_launcher(constants, signature, kernel_name):
     arg_decls = ', '.join(f"{_ty_to_cpp(ty)} arg{i}" for i, ty in signature.items())
@@ -68,6 +97,7 @@ def _generate_launcher(constants, signature, kernel_name):
 #include <Python.h>
 #include "ExecutionEngine/CRunnerUtils.h"
 #include "ExecutionEngine/CRunnerUtils.cpp"
+#include <stdfloat>
 
 extern "C" {{
   // Pointer type (=Memref) becomes int64_t + MemRef struct

--- a/backend/driver.py
+++ b/backend/driver.py
@@ -17,7 +17,6 @@ from triton.backends.driver import DriverBase
 def has_hf():
   resp = os.popen("lscpu").read()
   if platform.machine() == "x86_64" and "f16c" in resp:
-    
     return True
   elif platform.machine() == "aarch64" and "fphp" in resp:
     return True
@@ -26,9 +25,9 @@ def has_hf():
 def has_bf():
   resp = os.popen("lscpu").read()
   if platform.machine() == "x86_64" and "avx512_bf16" in resp:
-    print("axv512_bf16")
     return True
-  #TODO add aarch64 support for bf16
+  elif platform.machine() == "aarch64" and "bf16" in resp:
+    return True
   return False
 
 

--- a/backend/driver.py
+++ b/backend/driver.py
@@ -40,8 +40,8 @@ def _extracted_ty(ty):
         'i64': 'int64_t',
         'u32': 'uint32_t',
         'u64': 'uint64_t',
-        'fp16': 'float',
-        'bf16': 'float',
+        'fp16': 'float16_t',
+        'bf16': 'bfloat16_t',
         'fp32': 'float',
         'f32': 'float',
         'fp64': 'double',
@@ -226,7 +226,7 @@ def compile_module(launcher_src, kernel_placeholder_name):
               # Compile it together.
               subprocess.check_call([
                 "g++", launcher_src_path, asm_src_path,
-                f"-I{py_include_dir}", f"-I{include_dir}",
+                f"-I{py_include_dir}", f"-I{include_dir}" "-mfp16-format=ieee",
                 "-shared", "-fPIC", "-o", so_path
               ])
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(triton-shared-opt)
+add_subdirectory(triton-sme-opt)

--- a/tools/triton-sme-opt/CMakeLists.txt
+++ b/tools/triton-sme-opt/CMakeLists.txt
@@ -1,0 +1,19 @@
+get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
+get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
+
+add_llvm_executable(triton-sme-opt triton-sme-opt.cpp PARTIAL_SOURCES_INTENDED)
+
+llvm_update_compile_flags(triton-sme-opt)
+target_link_libraries(triton-sme-opt PRIVATE
+
+  ${dialect_libs}
+  ${conversion_libs}
+  # tests
+  TritonTestAnalysis
+  # MLIR core
+  MLIROptLib
+  MLIRPass
+  MLIRTransforms
+)
+
+mlir_check_all_link_libraries(triton-sme-opt)

--- a/tools/triton-sme-opt/triton-sme-opt.cpp
+++ b/tools/triton-sme-opt/triton-sme-opt.cpp
@@ -1,0 +1,142 @@
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/IR/Dialect.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/InitAllDialects.h"
+#include "mlir/InitAllPasses.h"
+#include "mlir/Interfaces/VectorInterfaces.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Tools/mlir-opt/MlirOptMain.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/Passes.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include <iostream>
+#include "mlir/IR/Operation.h"
+#include <llvm/Support/raw_ostream.h>
+
+
+using namespace mlir;
+
+
+namespace {
+struct OuterProductVectorizationPass : public PassWrapper<OuterProductVectorizationPass, OperationPass<func::FuncOp>> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<vector::VectorDialect, func::FuncDialect>();
+  }
+
+  void runOnOperation() override {
+    func::FuncOp funcOp = getOperation();
+    MLIRContext *context = funcOp.getContext();
+    RewritePatternSet patterns(context);
+
+    // Step 4: Lower vector.multi_reduction to vector.contract (+ some helpful patterns)
+    vector::VectorTransformsOptions vectorTransformsOptions;
+    vectorTransformsOptions.setVectorTransformsOptions(vector::VectorContractLowering::OuterProduct);
+    vector::populateVectorTransferDropUnitDimsPatterns(patterns);
+    vector::populateVectorReductionToContractPatterns(patterns);
+
+    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+      return signalPassFailure();
+    }
+
+    // Step 5: Lower vector.contract to vector.outerproduct. Also drop unit dims.
+    patterns.clear();
+    vectorTransformsOptions.setVectorTransformsOptions(vector::VectorContractLowering::OuterProduct);
+    vector::populateVectorTransferDropUnitDimsPatterns(patterns);
+
+    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+      return signalPassFailure();
+    }
+  }
+};
+
+
+  struct MatmulTileConversion: public OpRewritePattern <linalg::MatmulOp> {
+    using OpRewritePattern <linalg::MatmulOp> ::OpRewritePattern;
+
+    LogicalResult matchAndRewrite(linalg::MatmulOp op, PatternRewriter & rewriter) const override {
+
+      SmallVector<int64_t, 3> tileSizes = {4, 4,1}; // Tile sizes for [M, N, K] dimensions tofo
+
+
+      linalg::LinalgTilingOptions tilingOptions = linalg::LinalgTilingOptions().setTileSizes(tileSizes);
+      auto tiledOpResult = tileLinalgOp(rewriter, op, tilingOptions);
+      if (failed(tiledOpResult)) {
+        std::cout << "TILING FAILED" << std::endl;
+        return failure();
+      }
+
+      if (failed(linalg::vectorize(rewriter, cast<linalg::LinalgOp> (tiledOpResult->op.getOperation())))) {
+        return failure();
+      }
+      MLIRContext *context = getContext();
+
+
+      rewriter.replaceOp(op, tiledOpResult->tensorResults);
+      return success();
+
+    }
+  };
+
+  class MatmulTileConversionPass
+    : public PassWrapper <MatmulTileConversionPass, OperationPass <func::FuncOp>> {
+      public: void getDependentDialects(DialectRegistry & registry) const override {
+        registry.insert <linalg::LinalgDialect, func::FuncDialect, scf::SCFDialect, vector::VectorDialect> ();
+      }
+
+      void runOnOperation() override {
+        func::FuncOp funcOp = getOperation();
+        MLIRContext *context = &getContext();
+      
+
+        RewritePatternSet patterns(context);
+        patterns.add<MatmulTileConversion>(context);
+
+        ConversionTarget target( * context);
+        target.addLegalDialect <linalg::LinalgDialect, func::FuncDialect, vector::VectorDialect, affine::AffineDialect, scf::SCFDialect> ();
+
+        if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+          signalPassFailure();
+        }
+      }
+    };
+
+  std::unique_ptr <Pass> createOuterProductVectorizationPass() {
+    return std::make_unique <OuterProductVectorizationPass>();
+  }
+    std::unique_ptr <Pass> createMatmulTileConversionPass() {
+    return std::make_unique <MatmulTileConversionPass>();
+  }
+}
+
+int main(int argc, char ** argv) {
+  mlir::DialectRegistry registry;
+
+  registry.insert<func::FuncDialect, arith::ArithDialect, math::MathDialect,
+    linalg::LinalgDialect, affine::AffineDialect, scf::SCFDialect,
+    tensor::TensorDialect, bufferization::BufferizationDialect,
+    vector::VectorDialect, memref::MemRefDialect, func::FuncDialect>();
+
+
+  registerAllDialects(registry);
+  registerAllPasses();
+
+  MLIRContext context;
+  context.appendDialectRegistry(registry);
+  context.loadAllAvailableDialects();
+
+  PassPipelineRegistration<> pipeline(
+    "sme-converison",
+    "Converts linalg.matmul to a more optimized form",
+    [](OpPassManager & pm) {
+      pm.addPass(createMatmulTileConversionPass());
+      pm.addPass(createOuterProductVectorizationPass());
+    }
+  );
+
+
+  return asMainReturnCode(
+    MlirOptMain(argc, argv, "Optimizer Driver\n", registry)
+  );
+}

--- a/tools/triton-sme-opt/triton-sme-opt.cpp
+++ b/tools/triton-sme-opt/triton-sme-opt.cpp
@@ -243,9 +243,7 @@ struct OuterProductVectorizationPass
   std::unique_ptr<Pass> createOuterProductVectorizationPass() {
     return std::make_unique<OuterProductVectorizationPass>();
   }
-  std::unique_ptr<Pass> createPrefetchPass() {
-    return std::make_unique<PrefetchingPass>();
-  }
+
   std::unique_ptr<Pass> createMatmulTileConversionPass(bool enableSME) {
     return std::make_unique<MatmulTileConversionPass>(enableSME);
   }

--- a/tools/triton-sme-opt/triton-sme-opt.cpp
+++ b/tools/triton-sme-opt/triton-sme-opt.cpp
@@ -1,49 +1,237 @@
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/Dialect/Vector/TransformOps/VectorTransformOps.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/Operation.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/InitAllDialects.h"
 #include "mlir/InitAllPasses.h"
 #include "mlir/Interfaces/VectorInterfaces.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Tools/mlir-opt/MlirOptMain.h"
+#include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
-#include "mlir/Transforms/DialectConversion.h"
+#include <fstream>
 #include <iostream>
-#include "mlir/IR/Operation.h"
 #include <llvm/Support/raw_ostream.h>
-
+#include "mlir/Dialect/Vector/Transforms/LoweringPatterns.h"
+#include "mlir/Dialect/Bufferization/Transforms/Bufferize.h"
+#include "mlir/Dialect/Linalg/TransformOps/LinalgTransformOps.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Pass/Pass.h"
 
 using namespace mlir;
 
+namespace matmul_conversion {
 
-namespace {
-struct OuterProductVectorizationPass : public PassWrapper<OuterProductVectorizationPass, OperationPass<func::FuncOp>> {
+
+
+
+
+
+
+struct RestrictToTensorOpsPass
+    : public PassWrapper<RestrictToTensorOpsPass, OperationPass<func::FuncOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(RestrictToTensorOpsPass)
+
+  void runOnOperation() override {
+    func::FuncOp funcOp = getOperation();
+    MLIRContext *context = &getContext();
+
+    funcOp.walk([&](bufferization::ToTensorOp op) {
+      OpBuilder builder(op);
+      Location loc = op.getLoc();
+      Value alloc = op.getMemref();
+      Type tensorType = op.getType();
+
+      Value tensor = builder.create<bufferization::ToTensorOp>(
+          loc, tensorType, alloc, true /* restrict */, true /* writable */);
+      op.replaceAllUsesWith(tensor);
+      op.erase();
+    });
+  }
+};
+struct OneShotBufferizationPass : public PassWrapper<OneShotBufferizationPass, OperationPass<ModuleOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(OneShotBufferizationPass)
+
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<bufferization::BufferizationDialect>();
+  }
+
+  void runOnOperation() override {
+    ModuleOp moduleOp = getOperation();
+    MLIRContext *context = &getContext();
+
+    // Set up OneShotBufferizationOptions.
+    bufferization::OneShotBufferizationOptions options;
+    //  auto options = mlir::bufferization::OneShotBufferizationOptions();
+    options.allowReturnAllocsFromLoops = true;
+    options.allowUnknownOps = true;
+    options.bufferizeFunctionBoundaries = true;
+    options.unknownTypeConverterFn =
+        [](mlir::Value value, mlir::Attribute memorySpace,
+           const mlir::bufferization::BufferizationOptions &options) {
+          return mlir::bufferization::getMemRefTypeWithStaticIdentityLayout(
+              value.getType().cast<mlir::TensorType>(), memorySpace);
+        };
+    options.setFunctionBoundaryTypeConversion(
+        mlir::bufferization::LayoutMapOption::IdentityLayoutMap);
+    // options.getMemorySpaceFn = [](mlir::TensorType t) {
+    //   if (auto rt = t.dyn_cast<mlir::RankedTensorType>())
+    //     return rt.getEncoding();
+    //   return mlir::Attribute();
+    // };
+
+    // Run One-Shot Bufferize.
+    if (failed(bufferization::runOneShotBufferize(moduleOp, options))) {
+      return signalPassFailure();
+    }
+  }
+};
+
+
+
+struct MatmulTileConversion : public OpRewritePattern<linalg::MatmulOp> {
+  explicit MatmulTileConversion(MLIRContext *context, bool enableSME)
+      : OpRewritePattern<linalg::MatmulOp>(context), enableSME(enableSME) {}
+
+  LogicalResult matchAndRewrite(linalg::MatmulOp op,
+                                PatternRewriter &rewriter) const override {
+    linalg::LinalgTilingOptions tilingOptions;
+
+    tilingOptions.setTileSizeComputationFunction(
+        [&](OpBuilder &b, Operation *) {
+          SmallVector<Value, 4> sizes;
+          sizes.reserve(3);
+
+          Location loc = op.getLoc();
+          Value vscale = b.create<vector::VectorScaleOp>(loc, b.getIndexType());
+
+          if (enableSME) {
+            Value tileM = b.create<arith::ConstantIndexOp>(loc, 4);
+            Value tileMScaled = b.create<arith::MulIOp>(loc, tileM, vscale);
+            sizes.push_back(tileMScaled);
+          } else {
+            Value tileM = b.create<arith::ConstantIndexOp>(loc, 2);
+            sizes.push_back(tileM);
+          }
+          Value tileN = b.create<arith::ConstantIndexOp>(loc, 4);
+          Value tileNScaled = b.create<arith::MulIOp>(loc, tileN, vscale);
+          sizes.push_back(tileNScaled);
+          Value tileK = b.create<arith::ConstantIndexOp>(loc, 2);
+          sizes.push_back(tileK);
+
+          return sizes;
+        });
+    std::cout << enableSME << std::endl;
+
+    auto tiledOpResult = tileLinalgOp(rewriter, op, tilingOptions);
+    if (failed(tiledOpResult)) {
+      std::cout << "TILING FAILED" << std::endl;
+      return failure();
+    }
+
+    SmallVector<int64_t, 4> inputVectorSizes = {enableSME ? 4 : 2, 4, 2};
+    SmallVector<bool, 4> inputScalableVecDims = {enableSME, true, false};
+
+    if (failed(linalg::vectorize(
+            rewriter, cast<linalg::LinalgOp>(tiledOpResult->op.getOperation()),
+            inputVectorSizes, inputScalableVecDims))) {
+      std::cout << "Vectorization FAILED" << std::endl;
+      return failure();
+    }
+
+    MLIRContext *context = getContext();
+    rewriter.replaceOp(op, tiledOpResult->tensorResults);
+
+    return success();
+  }
+
+
+private:
+  bool enableSME;
+};
+
+struct MatmulTileConversionPass
+    : public PassWrapper<MatmulTileConversionPass,
+                          OperationPass<func::FuncOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(MatmulTileConversionPass)
+
+  explicit MatmulTileConversionPass(bool enableSME) : enableSME(enableSME) {}
+
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<linalg::LinalgDialect, func::FuncDialect, scf::SCFDialect,
+                    vector::VectorDialect>();
+  }
+
+  void runOnOperation() override {
+    func::FuncOp funcOp = getOperation();
+    MLIRContext *context = &getContext();
+
+    RewritePatternSet patterns(context);
+    patterns.add<MatmulTileConversion>(context, enableSME);
+
+    ConversionTarget target(*context);
+    target.addLegalDialect<linalg::LinalgDialect, func::FuncDialect,
+                           vector::VectorDialect, affine::AffineDialect,
+                           scf::SCFDialect>();
+
+    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+      signalPassFailure();
+    }
+  }
+
+private:
+  bool enableSME;
+};
+
+struct OuterProductVectorizationPass
+    : public PassWrapper<OuterProductVectorizationPass,
+                          OperationPass<func::FuncOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(OuterProductVectorizationPass)
+
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<vector::VectorDialect, func::FuncDialect>();
   }
 
   void runOnOperation() override {
-    func::FuncOp funcOp = getOperation();
+   func::FuncOp funcOp = getOperation();
     MLIRContext *context = funcOp.getContext();
     RewritePatternSet patterns(context);
+    ConversionTarget target(*context);
+      // Apply patterns for lowering masked transfers
+    transform::ApplyLowerMaskedTransfersPatternsOp lowerMaskedTransfersPatterns;
+    lowerMaskedTransfersPatterns.populatePatterns(patterns);
 
-    // Step 4: Lower vector.multi_reduction to vector.contract (+ some helpful patterns)
-    vector::VectorTransformsOptions vectorTransformsOptions;
-    vectorTransformsOptions.setVectorTransformsOptions(vector::VectorContractLowering::OuterProduct);
-    vector::populateVectorTransferDropUnitDimsPatterns(patterns);
-    vector::populateVectorReductionToContractPatterns(patterns);
+    // Apply patterns for transfer permutation
+    transform::ApplyTransferPermutationPatternsOp transferPermutationPatterns;
+    transferPermutationPatterns.populatePatterns(patterns);
 
-    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
-      return signalPassFailure();
-    }
+    // Apply patterns for reduction to contract
+    transform::ApplyVectorReductionToContractPatternsOp reductionToContractPatterns;
+    reductionToContractPatterns.populatePatterns(patterns);
+    transform::ApplyLowerMasksPatternsOp lowerMasksPatterns;
+    lowerMasksPatterns.populatePatterns(patterns);
 
-    // Step 5: Lower vector.contract to vector.outerproduct. Also drop unit dims.
-    patterns.clear();
-    vectorTransformsOptions.setVectorTransformsOptions(vector::VectorContractLowering::OuterProduct);
-    vector::populateVectorTransferDropUnitDimsPatterns(patterns);
+    // Apply patterns for rank-reducing subview
+    transform::ApplyRankReducingSubviewPatternsOp rankReducingSubviewPatterns;
+    rankReducingSubviewPatterns.populatePatterns(patterns);
+    
+    vector::populateVectorContractLoweringPatterns(
+        patterns, vector::VectorTransformsOptions().setVectorTransformsOptions(
+                      vector::VectorContractLowering::OuterProduct));
+    target.addIllegalOp<vector::ContractionOp>();  
 
     if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
       return signalPassFailure();
@@ -51,95 +239,34 @@ struct OuterProductVectorizationPass : public PassWrapper<OuterProductVectorizat
   }
 };
 
-    struct MatmulTileConversion : public OpRewritePattern<linalg::MatmulOp> {
-      using OpRewritePattern<linalg::MatmulOp>::OpRewritePattern;
 
-      LogicalResult matchAndRewrite(linalg::MatmulOp op,
-                                    PatternRewriter &rewriter) const override {
-        linalg::LinalgTilingOptions tilingOptions;
-
-        tilingOptions.setTileSizeComputationFunction([&](OpBuilder &b,
-                                                        Operation *) {
-          SmallVector<mlir::Value, 4> sizes;
-          sizes.reserve(3);
-
-          Location loc = op.getLoc();
-          Value vscale = b.create<vector::VectorScaleOp>(loc, b.getIndexType());
-          Value tileM = b.create<arith::ConstantIndexOp>(loc, 4);
-          Value tileMScaled = b.create<arith::MulIOp>(loc, tileM, vscale);
-          sizes.push_back(tileMScaled);
-          Value tileN = b.create<arith::ConstantIndexOp>(loc, 4);
-          Value tileNScaled = b.create<arith::MulIOp>(loc, tileN, vscale);
-          sizes.push_back(tileNScaled);
-          Value tileK = b.create<arith::ConstantIndexOp>(loc, 1);
-          sizes.push_back(tileK);
-
-          return sizes;
-        });
-
-        auto tiledOpResult = tileLinalgOp(rewriter, op, tilingOptions);
-        if (failed(tiledOpResult)) {
-          std::cout << "TILING FAILED" << std::endl;
-          return failure();
-        }
-
-        // Specify vector sizes and scalable dimensions for each dimension
-        SmallVector<int64_t, 4> inputVectorSizes = {4, 4, 1};
-        SmallVector<bool, 4> inputScalableVecDims = {true, true, false};
-
-        if (failed(linalg::vectorize(rewriter,
-                                    cast<linalg::LinalgOp>(
-                                        tiledOpResult->op.getOperation()),
-                                    inputVectorSizes, inputScalableVecDims))) {
-          std::cout << "Vectorization FAILED" << std::endl;
-          return failure();
-        }
-
-        MLIRContext *context = getContext();
-        rewriter.replaceOp(op, tiledOpResult->tensorResults);
-
-        return success();
-      }
-    };
-  class MatmulTileConversionPass
-    : public PassWrapper <MatmulTileConversionPass, OperationPass <func::FuncOp>> {
-      public: void getDependentDialects(DialectRegistry & registry) const override {
-        registry.insert <linalg::LinalgDialect, func::FuncDialect, scf::SCFDialect, vector::VectorDialect> ();
-      }
-
-      void runOnOperation() override {
-        func::FuncOp funcOp = getOperation();
-        MLIRContext *context = &getContext();
-      
-
-        RewritePatternSet patterns(context);
-        patterns.add<MatmulTileConversion>(context);
-
-        ConversionTarget target( * context);
-        target.addLegalDialect <linalg::LinalgDialect, func::FuncDialect, vector::VectorDialect, affine::AffineDialect, scf::SCFDialect> ();
-
-        if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
-          signalPassFailure();
-        }
-      }
-    };
-
-  std::unique_ptr <Pass> createOuterProductVectorizationPass() {
-    return std::make_unique <OuterProductVectorizationPass>();
+  std::unique_ptr<Pass> createOuterProductVectorizationPass() {
+    return std::make_unique<OuterProductVectorizationPass>();
   }
-    std::unique_ptr <Pass> createMatmulTileConversionPass() {
-    return std::make_unique <MatmulTileConversionPass>();
+  std::unique_ptr<Pass> createPrefetchPass() {
+    return std::make_unique<PrefetchingPass>();
   }
-}
+  std::unique_ptr<Pass> createMatmulTileConversionPass(bool enableSME) {
+    return std::make_unique<MatmulTileConversionPass>(enableSME);
+  }
 
-int main(int argc, char ** argv) {
-  mlir::DialectRegistry registry;
+  std::unique_ptr<Pass> createRestrictToTensorOpsPass() {
+    return std::make_unique<RestrictToTensorOpsPass>();
+  }
+
+  std::unique_ptr<Pass> createOneShotBufferizationPass() {
+    return std::make_unique<OneShotBufferizationPass>();
+  }
+} // namespace matmul_conversion
+
+int main(int argc, char **argv) {
+ DialectRegistry registry;
 
   registry.insert<func::FuncDialect, arith::ArithDialect, math::MathDialect,
-    linalg::LinalgDialect, affine::AffineDialect, scf::SCFDialect,
-    tensor::TensorDialect, bufferization::BufferizationDialect,
-    vector::VectorDialect, memref::MemRefDialect, func::FuncDialect>();
-
+                  linalg::LinalgDialect, affine::AffineDialect, scf::SCFDialect,
+                  tensor::TensorDialect, bufferization::BufferizationDialect,
+                  vector::VectorDialect, memref::MemRefDialect,
+                  func::FuncDialect, arm_sme::ArmSMEDialect>();
 
   registerAllDialects(registry);
   registerAllPasses();
@@ -148,17 +275,36 @@ int main(int argc, char ** argv) {
   context.appendDialectRegistry(registry);
   context.loadAllAvailableDialects();
 
-  PassPipelineRegistration<> pipeline(
-    "sme-converison",
-    "Converts linalg.matmul to a more optimized form",
-    [](OpPassManager & pm) {
-      pm.addPass(createMatmulTileConversionPass());
-      pm.addPass(createOuterProductVectorizationPass());
-    }
-  );
+
+  PassPipelineRegistration<> smeConversionPipeline(
+      "sme-conversion",
+      "Converts linalg.matmul to a more optimized form using SME",
+      [](OpPassManager &pm) {
+        pm.addPass(matmul_conversion::createMatmulTileConversionPass(true));
+        pm.addPass(matmul_conversion::createRestrictToTensorOpsPass());
+        pm.addPass(matmul_conversion::createOneShotBufferizationPass());
+        pm.addPass(matmul_conversion::createOuterProductVectorizationPass());
+      });
+
+  PassPipelineRegistration<> sveConversionPipeline(
+      "sve-conversion",
+      "Converts linalg.matmul to a more optimized form using SME",
+      [](OpPassManager &pm) {
+        pm.addPass(matmul_conversion::createMatmulTileConversionPass(false));
+        pm.addPass(matmul_conversion::createRestrictToTensorOpsPass());
+        pm.addPass(matmul_conversion::createOneShotBufferizationPass());
+        pm.addPass(matmul_conversion::createOuterProductVectorizationPass());
+      });
+
+  PassPipelineRegistration<> prefConversionPipeline(
+      "prefetch",
+      "Converts linalg.matmul to a more optimized form using SME",
+      [](OpPassManager &pm) {
+        pm.addPass(matmul_conversion::createPrefetchPass());
+      });
+
 
 
   return asMainReturnCode(
-    MlirOptMain(argc, argv, "Optimizer Driver\n", registry)
-  );
+      MlirOptMain(argc, argv, "Optimizer Driver\n", registry));
 }


### PR DESCRIPTION
Since this is an optimization pass to existing ttshare output, I decided to make it its own binary, currently gets past optimization phase and fails on  _ttsharedir_to_llir which is to be expected since it needs different mlir-opt flags. These flags have also just been recently updated. 

Also trying to introduce bf16/f16 support as well as make the current optimization passes only apply to hardware that can support it. 

There are more plans for optimization than just the tile and outerproduct approach as seen here but the current build does produce valid MLIR. Based this off the  [example](https://github.com/llvm/llvm-project/blob/main/mlir/test/Integration/Dialect/Linalg/CPU/ArmSME/matmul.mlir) shown here. 

As of now only SVE2  can tested on real hardware which I don't have access to. SME will have to be emulated.
Not yet anywhere ready in a state to be merged but feedback would be appreciated.


## Instructions to build
Same as normal however to see the optimized MLIR, 
Usage
```bash
#dependent on cmake/python/arch details
export TRITON_SME_PATH="$(pwd)/python/build/cmake.linux-aarch64-cpython-3.11/third_party/triton_shared/tools/triton-sme-opt/triton-sme-opt"
 cd ./third_party/triton_shared/python/examples
rm -rf ~/.triton/cache
python3 test_matmul.py
```
this is should cause the test to not compile and fail but the optimized MLIR should be printed in blue test
to turn this off just set 
```bash
export TRITON_SME_PATH=""
```
Below is the optimized MLIR produced from test_matmul.py

```llvm
#map = affine_map<(d0, d1) -> (-d0 + 32, d1)>
#map1 = affine_map<(d0, d1) -> (-d0 + 64, d1)>
#map2 = affine_map<(d0, d1) -> (d0, 0, d1)>
#map3 = affine_map<(d0, d1) -> (0, d1, d0)>
#map4 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
#map5 = affine_map<(d0, d1, d2) -> (d0, d1)>
#map6 = affine_map<(d0, d1) -> (d0, d1)>
module {
  func.func @matmul_kernel_0d1d2d34567c89c1011c(%arg0: memref<*xf16> {tt.divisibility = 16 : i32}, %arg1: memref<*xf16> {tt.divisibility = 16 : i32}, %arg2: memref<*xf16> {tt.divisibility = 16 : i32}, %arg3: i32, %arg4: i32, %arg5: i32, %arg6: i32, %arg7: i32, %arg8: i32, %arg9: i32, %arg10: i32, %arg11: i32, %arg12: i32, %arg13: i32, %arg14: i32) {
    %cst = arith.constant dense<false> : vector<1x[4]xi1>
    %c4 = arith.constant 4 : index
    %c8_i32 = arith.constant 8 : i32
    %c32_i32 = arith.constant 32 : i32
    %c64_i32 = arith.constant 64 : i32
    %c16_i32 = arith.constant 16 : i32
    %cst_0 = arith.constant 0.000000e+00 : f32
    %c0_i32 = arith.constant 0 : i32
    %c1_i32 = arith.constant 1 : i32
    %c31_i32 = arith.constant 31 : i32
    %c63_i32 = arith.constant 63 : i32
    %c15_i32 = arith.constant 15 : i32
    %c0 = arith.constant 0 : index
    %c1 = arith.constant 1 : index
    %c16 = arith.constant 16 : index
    %cst_1 = arith.constant 0.000000e+00 : f16
    %c32 = arith.constant 32 : index
    %c64 = arith.constant 64 : index
    %alloc = memref.alloc() {alignment = 64 : i64} : memref<32x64xf32>
    linalg.fill ins(%cst_0 : f32) outs(%alloc : memref<32x64xf32>)
    %0 = bufferization.to_tensor %alloc : memref<32x64xf32>
    %1 = arith.addi %arg3, %c31_i32 : i32
    %2 = arith.divsi %1, %c32_i32 : i32
    %3 = arith.addi %arg4, %c63_i32 : i32
    %4 = arith.divsi %3, %c64_i32 : i32
    %5 = arith.muli %4, %c8_i32 : i32
    %6 = arith.divsi %arg12, %5 : i32
    %7 = arith.muli %6, %c8_i32 : i32
    %8 = arith.subi %2, %7 : i32
    %9 = arith.minsi %8, %c8_i32 : i32
    %10 = arith.remsi %arg12, %9 : i32
    %11 = arith.addi %7, %10 : i32
    %12 = arith.remsi %arg12, %5 : i32
    %13 = arith.divsi %12, %9 : i32
    %14 = arith.muli %11, %c32_i32 : i32
    %15 = arith.index_cast %14 : i32 to index
    %16 = arith.muli %13, %c64_i32 : i32
    %17 = arith.index_cast %16 : i32 to index
    %18 = arith.index_cast %arg3 : i32 to index
    %19 = arith.index_cast %arg6 : i32 to index
    %20 = arith.muli %15, %19 : index
    %21 = arith.muli %18, %19 : index
    %22 = arith.index_cast %arg7 : i32 to index
    %23 = arith.index_cast %arg4 : i32 to index
    %24 = arith.addi %arg5, %c15_i32 : i32
    %25 = arith.divsi %24, %c16_i32 : i32
    %26 = arith.muli %arg7, %c16_i32 : i32
    %27 = arith.index_cast %26 : i32 to index
    %28:3 = scf.for %arg15 = %c0_i32 to %25 step %c1_i32 iter_args(%arg16 = %0, %arg17 = %20, %arg18 = %c0) -> (tensor<32x64xf32>, index, index)  : i32 {
      %41 = bufferization.to_memref %arg16 : memref<32x64xf32>
      %42 = arith.addi %arg18, %17 : index
      %43 = arith.remsi %42, %23 : index
      %44 = arith.subi %42, %43 : index
      %45 = arith.addi %43, %c64 : index
      %46 = arith.minsi %45, %23 : index
      %47 = arith.subi %46, %43 : index
      %reinterpret_cast_4 = memref.reinterpret_cast %arg1 to offset: [%42], sizes: [%c16, %47], strides: [%22, %c1] : memref<*xf16> to memref<16x?xf16, strided<[?, ?], offset: ?>>
      %48 = arith.subi %c64, %47 : index
      %reinterpret_cast_5 = memref.reinterpret_cast %arg1 to offset: [%44], sizes: [%c16, %48], strides: [%22, %c1] : memref<*xf16> to memref<16x?xf16, strided<[?, ?], offset: ?>>
      %49 = arith.remsi %arg17, %19 : index
      %50 = arith.addi %21, %49 : index
      %51 = arith.subi %50, %arg17 : index
      %52 = arith.divsi %51, %19 : index
      %reinterpret_cast_6 = memref.reinterpret_cast %arg0 to offset: [%arg17], sizes: [%52, %c16], strides: [%19, %c1] : memref<*xf16> to memref<?x16xf16, strided<[?, ?], offset: ?>>
      %53 = arith.subi %c32, %52 : index
      %reinterpret_cast_7 = memref.reinterpret_cast %arg0 to offset: [%49], sizes: [%53, %c16], strides: [%19, %c1] : memref<*xf16> to memref<?x16xf16, strided<[?, ?], offset: ?>>
      %54 = arith.muli %arg15, %c16_i32 : i32
      %55 = arith.subi %arg5, %54 : i32
      %56 = arith.index_cast %55 : i32 to index
      %57 = arith.minsi %56, %c16 : index
      %alloc_8 = memref.alloc() : memref<32x16xf16>
      %58 = arith.cmpi slt, %57, %c16 : index
      scf.if %58 {
        linalg.fill ins(%cst_1 : f16) outs(%alloc_8 : memref<32x16xf16>)
      }
      %59 = arith.minsi %52, %c32 : index
      %60 = arith.subi %c32, %59 : index
      %subview_9 = memref.subview %reinterpret_cast_6[0, 0] [%59, %57] [1, 1] : memref<?x16xf16, strided<[?, ?], offset: ?>> to memref<?x?xf16, strided<[?, ?], offset: ?>>
      %subview_10 = memref.subview %reinterpret_cast_7[0, 0] [%60, %57] [1, 1] : memref<?x16xf16, strided<[?, ?], offset: ?>> to memref<?x?xf16, strided<[?, ?], offset: ?>>
      %subview_11 = memref.subview %alloc_8[0, 0] [%59, %57] [1, 1] : memref<32x16xf16> to memref<?x?xf16, strided<[16, 1]>>
      %subview_12 = memref.subview %alloc_8[%59, 0] [%60, %57] [1, 1] : memref<32x16xf16> to memref<?x?xf16, strided<[16, 1], offset: ?>>
      memref.copy %subview_9, %subview_11 : memref<?x?xf16, strided<[?, ?], offset: ?>> to memref<?x?xf16, strided<[16, 1]>>
      memref.copy %subview_10, %subview_12 : memref<?x?xf16, strided<[?, ?], offset: ?>> to memref<?x?xf16, strided<[16, 1], offset: ?>>
      %alloc_13 = memref.alloc() : memref<16x64xf16>
      %61 = arith.cmpi slt, %57, %c16 : index
      scf.if %61 {
        linalg.fill ins(%cst_1 : f16) outs(%alloc_13 : memref<16x64xf16>)
      }
      %62 = arith.minsi %47, %c64 : index
      %63 = arith.subi %c64, %62 : index
      %subview_14 = memref.subview %reinterpret_cast_4[0, 0] [%57, %62] [1, 1] : memref<16x?xf16, strided<[?, ?], offset: ?>> to memref<?x?xf16, strided<[?, ?], offset: ?>>
      %subview_15 = memref.subview %reinterpret_cast_5[0, 0] [%57, %63] [1, 1] : memref<16x?xf16, strided<[?, ?], offset: ?>> to memref<?x?xf16, strided<[?, ?], offset: ?>>
      %subview_16 = memref.subview %alloc_13[0, 0] [%57, %62] [1, 1] : memref<16x64xf16> to memref<?x?xf16, strided<[64, 1]>>
      %subview_17 = memref.subview %alloc_13[0, %62] [%57, %63] [1, 1] : memref<16x64xf16> to memref<?x?xf16, strided<[64, 1], offset: ?>>
      memref.copy %subview_14, %subview_16 : memref<?x?xf16, strided<[?, ?], offset: ?>> to memref<?x?xf16, strided<[64, 1]>>
      memref.copy %subview_15, %subview_17 : memref<?x?xf16, strided<[?, ?], offset: ?>> to memref<?x?xf16, strided<[64, 1], offset: ?>>
      %64 = vector.vscale
      %65 = arith.muli %64, %c4 : index
      %66 = arith.muli %64, %c4 : index
      %67 = scf.for %arg19 = %c0 to %c32 step %65 iter_args(%arg20 = %0) -> (tensor<32x64xf32>) {
        %72 = scf.for %arg21 = %c0 to %c64 step %66 iter_args(%arg22 = %arg20) -> (tensor<32x64xf32>) {
          %73 = scf.for %arg23 = %c0 to %c16 step %c1 iter_args(%arg24 = %arg22) -> (tensor<32x64xf32>) {
            %74 = bufferization.to_memref %arg24 : memref<32x64xf32>
            %75 = bufferization.to_memref %arg24 : memref<32x64xf32>
            %76 = affine.min #map(%arg19, %65)
            %77 = affine.min #map1(%arg21, %66)
            %78 = affine.min #map(%arg19, %65)
            %79 = affine.min #map1(%arg21, %66)
            %subview_19 = memref.subview %alloc_8[%arg19, %arg23] [%76, 1] [1, 1] : memref<32x16xf16> to memref<?x1xf16, strided<[16, 1], offset: ?>>
            %80 = bufferization.to_tensor %subview_19 : memref<?x1xf16, strided<[16, 1], offset: ?>>
            %subview_20 = memref.subview %alloc_13[%arg23, %arg21] [1, %77] [1, 1] : memref<16x64xf16> to memref<1x?xf16, strided<[64, 1], offset: ?>>
            %81 = bufferization.to_tensor %subview_20 : memref<1x?xf16, strided<[64, 1], offset: ?>>
            %subview_21 = memref.subview %75[%arg19, %arg21] [%78, %79] [1, 1] : memref<32x64xf32> to memref<?x?xf32, strided<[64, 1], offset: ?>>
            %82 = bufferization.to_tensor %subview_21 : memref<?x?xf32, strided<[64, 1], offset: ?>>
            %83 = vector.create_mask %76, %c1 : vector<[4]x1xi1>
            %84 = vector.transfer_read %80[%c0, %c0], %cst_1, %83 {in_bounds = [true, true, true], permutation_map = #map2} : tensor<?x1xf16>, vector<[4]x[4]x1xf16>
            %85 = vector.create_mask %77 : vector<[4]xi1>
            %86 = vector.insert %85, %cst [0] : vector<[4]xi1> into vector<1x[4]xi1>
            %87 = vector.transfer_read %81[%c0, %c0], %cst_1, %86 {in_bounds = [true, true, true], permutation_map = #map3} : tensor<1x?xf16>, vector<[4]x[4]x1xf16>
            %88 = vector.create_mask %76, %77 : vector<[4]x[4]xi1>
            %89 = vector.transfer_read %82[%c0, %c0], %cst_0, %88 {in_bounds = [true, true]} : tensor<?x?xf32>, vector<[4]x[4]xf32>
            %90 = arith.extf %84 : vector<[4]x[4]x1xf16> to vector<[4]x[4]x1xf32>
            %91 = arith.extf %87 : vector<[4]x[4]x1xf16> to vector<[4]x[4]x1xf32>
            %92 = vector.create_mask %76, %77, %c1 : vector<[4]x[4]x1xi1>
            %93 = vector.mask %92 { vector.contract {indexing_maps = [#map4, #map4, #map5], iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>} %90, %91, %89 : vector<[4]x[4]x1xf32>, vector<[4]x[4]x1xf32> into vector<[4]x[4]xf32> } : vector<[4]x[4]x1xi1> -> vector<[4]x[4]xf32>
            %94 = vector.transfer_write %93, %82[%c0, %c0], %88 {in_bounds = [true, true]} : vector<[4]x[4]xf32>, tensor<?x?xf32>
            %95 = bufferization.to_memref %94 : memref<?x?xf32>
            %alloc_22 = memref.alloc() {alignment = 64 : i64} : memref<32x64xf32>
            memref.copy %74, %alloc_22 : memref<32x64xf32> to memref<32x64xf32>
            %subview_23 = memref.subview %alloc_22[%arg19, %arg21] [%78, %79] [1, 1] : memref<32x64xf32> to memref<?x?xf32, strided<[64, 1], offset: ?>>
            memref.copy %95, %subview_23 : memref<?x?xf32> to memref<?x?xf32, strided<[64, 1], offset: ?>>
            %96 = bufferization.to_tensor %alloc_22 : memref<32x64xf32>
            scf.yield %96 : tensor<32x64xf32>
          }
          scf.yield %73 : tensor<32x64xf32>
        }
        scf.yield %72 : tensor<32x64xf32>
      }
      %68 = bufferization.to_memref %67 : memref<32x64xf32>
      %alloc_18 = memref.alloc() {alignment = 64 : i64} : memref<32x64xf32>
      linalg.generic {indexing_maps = [#map6, #map6, #map6], iterator_types = ["parallel", "parallel"]} ins(%68, %41 : memref<32x64xf32>, memref<32x64xf32>) outs(%alloc_18 : memref<32x64xf32>) {
      ^bb0(%in: f32, %in_19: f32, %out: f32):
        %72 = arith.addf %in, %in_19 : f32
        linalg.yield %72 : f32
      }
      %69 = bufferization.to_tensor %alloc_18 : memref<32x64xf32>
      %70 = arith.addi %arg17, %c16 : index
      %71 = arith.addi %arg18, %27 : index
      scf.yield %69, %70, %71 : tensor<32x64xf32>, index, index
    }
    %29 = bufferization.to_memref %28#0 : memref<32x64xf32>
    %30 = arith.index_cast %arg8 : i32 to index
    %31 = arith.muli %15, %30 : index
    %32 = arith.addi %31, %17 : index
    %reinterpret_cast = memref.reinterpret_cast %arg2 to offset: [%32], sizes: [32, 64], strides: [%30, 1] : memref<*xf16> to memref<32x64xf16, strided<[?, 1], offset: ?>>
    %alloc_2 = memref.alloc() {alignment = 64 : i64} : memref<32x64xf16>
    linalg.generic {indexing_maps = [#map6, #map6], iterator_types = ["parallel", "parallel"]} ins(%29 : memref<32x64xf32>) outs(%alloc_2 : memref<32x64xf16>) {
    ^bb0(%in: f32, %out: f16):
      %41 = arith.truncf %in : f32 to f16
      linalg.yield %41 : f16
    }
    %33 = arith.addi %15, %c32 : index
    %34 = arith.minsi %33, %18 : index
    %35 = arith.subi %34, %15 : index
    %36 = arith.addi %17, %c64 : index
    %37 = arith.minsi %36, %23 : index
    %38 = arith.subi %37, %17 : index
    %39 = arith.minsi %35, %c32 : index
    %40 = arith.minsi %38, %c64 : index
    %subview = memref.subview %alloc_2[0, 0] [%39, %40] [1, 1] : memref<32x64xf16> to memref<?x?xf16, strided<[64, 1]>>
    %subview_3 = memref.subview %reinterpret_cast[0, 0] [%39, %40] [1, 1] : memref<32x64xf16, strided<[?, 1], offset: ?>> to memref<?x?xf16, strided<[?, 1], offset: ?>>
    memref.copy %subview, %subview_3 : memref<?x?xf16, strided<[64, 1]>> to memref<?x?xf16, strided<[?, 1], offset: ?>>
    return
  }
}
```