### PR TITLE
Introduce `--triton-to-linalg-experimental`

### DIFF
--- a/include/triton-shared/Conversion/CMakeLists.txt
+++ b/include/triton-shared/Conversion/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(TritonToLinalg)
+add_subdirectory(TritonToLinalgExperimental)
 add_subdirectory(TritonToStructured)
 add_subdirectory(TritonArithToLinalg)
 add_subdirectory(StructuredToMemref)

--- a/include/triton-shared/Conversion/StructuredToMemref/StructuredToMemref.h
+++ b/include/triton-shared/Conversion/StructuredToMemref/StructuredToMemref.h
@@ -16,6 +16,8 @@ namespace triton {
 void populateStructuredToMemrefConversionPatterns(RewritePatternSet &patterns,
                                                   TypeConverter &typeConverter);
 
+std::unique_ptr<OperationPass<ModuleOp>> createStructuredToMemrefPass();
+
 } // namespace triton
 } // namespace mlir
 

--- a/include/triton-shared/Conversion/TritonArithToLinalg/TritonArithToLinalg.h
+++ b/include/triton-shared/Conversion/TritonArithToLinalg/TritonArithToLinalg.h
@@ -20,6 +20,8 @@ void populateTritonArithToLinalgConversionPatterns(bool pidsToFuncArgs,
                                                    bool assertToCf,
                                                    RewritePatternSet &patterns);
 
+std::unique_ptr<OperationPass<ModuleOp>> createTritonArithToLinalgPass();
+
 } // namespace triton
 } // namespace mlir
 

--- a/include/triton-shared/Conversion/TritonToLinalgExperimental/CMakeLists.txt
+++ b/include/triton-shared/Conversion/TritonToLinalgExperimental/CMakeLists.txt
@@ -1,0 +1,9 @@
+#===------------------------------------------------------------------------===#
+#
+# Copyright (c) Triton Project Contributors.
+#
+#===------------------------------------------------------------------------===#
+
+set(LLVM_TARGET_DEFINITIONS Passes.td)
+mlir_tablegen(Passes.h.inc -gen-pass-decls --name TritonToLinalgExperimental)
+add_public_tablegen_target(TritonToLinalgExperimentalConversionPassIncGen)

--- a/include/triton-shared/Conversion/TritonToLinalgExperimental/Passes.h
+++ b/include/triton-shared/Conversion/TritonToLinalgExperimental/Passes.h
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TRITON_TO_LINALG_EXPERIMENTAL_CONVERSION_PASSES_H
+#define TRITON_TO_LINALG_EXPERIMENTAL_CONVERSION_PASSES_H
+
+#include "triton-shared/Conversion/TritonToLinalgExperimental/TritonToLinalgExperimental.h"
+
+namespace mlir {
+namespace triton {
+
+#define GEN_PASS_REGISTRATION
+#include "triton-shared/Conversion/TritonToLinalgExperimental/Passes.h.inc"
+
+} // namespace triton
+} // namespace mlir
+
+#endif

--- a/include/triton-shared/Conversion/TritonToLinalgExperimental/Passes.td
+++ b/include/triton-shared/Conversion/TritonToLinalgExperimental/Passes.td
@@ -1,0 +1,18 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TRITON_TO_LINALG_EXPERIMENTAL_CONVERSION_PASSES
+#define TRITON_TO_LINALG_EXPERIMENTAL_CONVERSION_PASSES
+
+include "mlir/Pass/PassBase.td"
+
+def TritonToLinalgExperimental : Pass<"triton-to-linalg-experimental", "mlir::ModuleOp"> {
+  let summary = "Convert Triton to Linalg dialect";
+  let constructor = "triton::createTritonToLinalgExperimentalPass()";
+}
+
+#endif

--- a/include/triton-shared/Conversion/TritonToLinalgExperimental/TritonToLinalgExperimental.h
+++ b/include/triton-shared/Conversion/TritonToLinalgExperimental/TritonToLinalgExperimental.h
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TRITON_CONVERSION_TRITONTOLINALG_TRITONTOLINALGEXPERIMENTAL_H
+#define TRITON_CONVERSION_TRITONTOLINALG_TRITONTOLINALGEXPERIMENTAL_H
+
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+namespace triton {
+
+std::unique_ptr<OperationPass<ModuleOp>> createTritonToLinalgExperimentalPass();
+
+} // namespace triton
+} // namespace mlir
+
+#endif // TRITON_CONVERSION_TRITONTOLINALG_TRITONTOLINALGEXPERIMENTAL_H

--- a/lib/Conversion/CMakeLists.txt
+++ b/lib/Conversion/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(TritonToLinalg)
+add_subdirectory(TritonToLinalgExperimental)
 add_subdirectory(TritonToStructured)
 add_subdirectory(TritonArithToLinalg)
 add_subdirectory(StructuredToMemref)

--- a/lib/Conversion/StructuredToMemref/StructuredToMemrefPass.cpp
+++ b/lib/Conversion/StructuredToMemref/StructuredToMemrefPass.cpp
@@ -150,3 +150,8 @@ public:
   }
 };
 } // namespace
+
+std::unique_ptr<OperationPass<ModuleOp>>
+triton::createStructuredToMemrefPass() {
+  return std::make_unique<StructuredToMemrefPass>();
+}

--- a/lib/Conversion/TritonArithToLinalg/TritonArithToLinalgPass.cpp
+++ b/lib/Conversion/TritonArithToLinalg/TritonArithToLinalgPass.cpp
@@ -15,8 +15,6 @@
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
-#include "mlir/Transforms/Passes.h"
-#include "triton/Dialect/Triton/IR/Types.h"
 
 #include "llvm/Support/Debug.h"
 
@@ -194,4 +192,10 @@ public:
     }
   }
 };
+
 } // namespace
+
+std::unique_ptr<OperationPass<ModuleOp>>
+triton::createTritonArithToLinalgPass() {
+  return std::make_unique<TritonArithToLinalgPass>();
+}

--- a/lib/Conversion/TritonToLinalgExperimental/CMakeLists.txt
+++ b/lib/Conversion/TritonToLinalgExperimental/CMakeLists.txt
@@ -1,0 +1,30 @@
+#===------------------------------------------------------------------------===#
+#
+# Copyright (c) Triton Project Contributors.
+#
+#===------------------------------------------------------------------------===#
+
+add_mlir_conversion_library(TritonToLinalgExperimental
+  TritonToLinalgExperimentalPass.cpp
+
+  DEPENDS
+  TritonToLinalgExperimentalConversionPassIncGen
+
+  LINK_COMPONENTS
+  Core
+
+  LINK_LIBS PUBLIC
+  TritonTilingExtIR
+  MLIRArithDialect
+  MLIRDialectUtils
+  MLIRIR
+  MLIRMathDialect
+  MLIRPass
+  MLIRTensorDialect
+  MLIRTransforms
+  MLIRSupport
+  TritonAnalysis
+  TritonIR
+  TritonTransforms
+  TritonSharedAnalysis
+)

--- a/lib/Conversion/TritonToLinalgExperimental/TritonToLinalgExperimentalPass.cpp
+++ b/lib/Conversion/TritonToLinalgExperimental/TritonToLinalgExperimentalPass.cpp
@@ -9,6 +9,7 @@
 #include "triton-shared/Conversion/TritonArithToLinalg/TritonArithToLinalg.h"
 #include "triton-shared/Conversion/TritonToLinalgExperimental/TritonToLinalgExperimental.h"
 #include "triton-shared/Conversion/TritonToStructured/TritonToStructured.h"
+#include "triton-shared/Dialect/TritonStructured/IR/TritonStructuredDialect.h"
 #include "triton-shared/Dialect/TritonTilingExt/IR/TritonTilingExtDialect.h"
 
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
@@ -36,7 +37,8 @@ public:
         .insert<func::FuncDialect, arith::ArithDialect, math::MathDialect,
                 linalg::LinalgDialect, affine::AffineDialect, scf::SCFDialect,
                 tensor::TensorDialect, bufferization::BufferizationDialect,
-                memref::MemRefDialect, ttx::TritonTilingExtDialect>();
+                memref::MemRefDialect, ttx::TritonTilingExtDialect,
+                tts::TritonStructuredDialect>();
   }
 
   void runOnOperation() override {

--- a/lib/Conversion/TritonToLinalgExperimental/TritonToLinalgExperimentalPass.cpp
+++ b/lib/Conversion/TritonToLinalgExperimental/TritonToLinalgExperimentalPass.cpp
@@ -1,0 +1,63 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+//===----------------------------------------------------------------------===//
+
+#include "triton-shared/Conversion/StructuredToMemref/StructuredToMemref.h"
+#include "triton-shared/Conversion/TritonArithToLinalg/TritonArithToLinalg.h"
+#include "triton-shared/Conversion/TritonToLinalgExperimental/TritonToLinalgExperimental.h"
+#include "triton-shared/Conversion/TritonToStructured/TritonToStructured.h"
+#include "triton-shared/Dialect/TritonTilingExt/IR/TritonTilingExtDialect.h"
+
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Transforms/Passes.h"
+
+using namespace mlir;
+using namespace triton;
+
+#define GEN_PASS_CLASSES
+#include "triton-shared/Conversion/TritonToLinalgExperimental/Passes.h.inc"
+
+namespace {
+
+class TritonToLinalgExperimentalPass
+    : public TritonToLinalgExperimentalBase<TritonToLinalgExperimentalPass> {
+
+public:
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry
+        .insert<func::FuncDialect, arith::ArithDialect, math::MathDialect,
+                linalg::LinalgDialect, affine::AffineDialect, scf::SCFDialect,
+                tensor::TensorDialect, bufferization::BufferizationDialect,
+                memref::MemRefDialect, ttx::TritonTilingExtDialect>();
+  }
+
+  void runOnOperation() override {
+    auto moduleOp = getOperation();
+    PassManager pm(&getContext(), moduleOp.getOperationName());
+    pm.addPass(createTritonToStructuredPass());
+
+    // Erase dead code and fold constants created during lowering
+    pm.addPass(createCanonicalizerPass());
+
+    pm.addPass(createTritonArithToLinalgPass());
+    pm.addPass(createStructuredToMemrefPass());
+
+    if (failed(runPipeline(pm, getOperation()))) {
+      signalPassFailure();
+    }
+  }
+};
+} // namespace
+
+std::unique_ptr<OperationPass<ModuleOp>>
+triton::createTritonToLinalgExperimentalPass() {
+  return std::make_unique<TritonToLinalgExperimentalPass>();
+}

--- a/test/Conversion/StructuredToMemref/addptr_2d_example.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_2d_example.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 module {
   tt.func @kernel(
     %arg0 : !tt.ptr<bf16>,

--- a/test/Conversion/StructuredToMemref/addptr_add_value.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_add_value.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 module {
   tt.func @kernel(
   %arg0 : !tt.ptr<bf16>,

--- a/test/Conversion/StructuredToMemref/addptr_dim1.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_dim1.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 
 module {
   tt.func @kernel(

--- a/test/Conversion/StructuredToMemref/addptr_for_accumulation.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_for_accumulation.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 module {
   tt.func @kernel(
     %arg0 : !tt.ptr<bf16>,

--- a/test/Conversion/StructuredToMemref/addptr_for_expand_ptr.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_for_expand_ptr.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 module {
   tt.func @kernel(
     %arg0 : !tt.ptr<bf16>

--- a/test/Conversion/StructuredToMemref/addptr_for_more_init_args.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_for_more_init_args.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 module {
   tt.func @kernel(
     %arg0 : !tt.ptr<bf16>,

--- a/test/Conversion/StructuredToMemref/addptr_for_used_after_update.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_for_used_after_update.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 module {
   tt.func @kernel(
     %arg0 : !tt.ptr<bf16>

--- a/test/Conversion/StructuredToMemref/addptr_for_used_before_update.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_for_used_before_update.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 module {
   tt.func @kernel(
     %arg0 : !tt.ptr<bf16>

--- a/test/Conversion/StructuredToMemref/addptr_loopback.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_loopback.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 module {
   tt.func @kernel(
   %arg0 : !tt.ptr<bf16>,

--- a/test/Conversion/StructuredToMemref/addptr_mul_const_const.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_mul_const_const.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 module {
   tt.func @kernel(
     %arg0 : !tt.ptr<bf16>,

--- a/test/Conversion/StructuredToMemref/addptr_mul_value_const.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_mul_value_const.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 module {
   tt.func @kernel(
     %arg0 : !tt.ptr<bf16>,

--- a/test/Conversion/StructuredToMemref/addptr_nested.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_nested.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 module {
   tt.func @kernel(
     %arg0 : !tt.ptr<bf16>,

--- a/test/Conversion/StructuredToMemref/addptr_reshape_broadcast.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_reshape_broadcast.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 // TODO: expand this example to 3D
 module {
   tt.func @kernel(

--- a/test/Conversion/StructuredToMemref/addptr_scalar_broadcast.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_scalar_broadcast.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 module {
   tt.func @kernel (%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: i32, %arg3: i32, %arg4: i32) {
     %0 = tt.get_program_id x : i32

--- a/test/Conversion/StructuredToMemref/addptr_scalar_for.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_scalar_for.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 module {
   tt.func @kernel (%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: i32, %arg3: i32, %arg4: i32) {
     %0 = tt.get_program_id x : i32

--- a/test/Conversion/StructuredToMemref/addptr_scalar_for_2d.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_scalar_for_2d.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 module {
   tt.func @kernel (%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: i32, %arg3: i32, %arg4: i32) {
     %0 = tt.get_program_id x : i32

--- a/test/Conversion/StructuredToMemref/addptr_scalar_loopback.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_scalar_loopback.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 
 module {
   tt.func @kernel(

--- a/test/Conversion/StructuredToMemref/addptr_scalar_nested.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_scalar_nested.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 module {
   tt.func @kernel (%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: i32, %arg3: i32, %arg4: i32) {
     %0 = tt.get_program_id x : i32

--- a/test/Conversion/StructuredToMemref/addptr_scalar_splat.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_scalar_splat.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 module {
   tt.func @kernel (%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: i32, %arg3: i32, %arg4: i32) {
     %0 = tt.get_program_id x : i32

--- a/test/Conversion/StructuredToMemref/addptr_scalar_splat_2d.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_scalar_splat_2d.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 module {
   tt.func @kernel (%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: i32, %arg3: i32, %arg4: i32) {
     %0 = tt.get_program_id x : i32

--- a/test/Conversion/StructuredToMemref/arith_not_ptr_arith.mlir
+++ b/test/Conversion/StructuredToMemref/arith_not_ptr_arith.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 module {
   tt.func @kernel(
     %a : !tt.ptr<i32>,

--- a/test/Conversion/StructuredToMemref/bitcast.mlir
+++ b/test/Conversion/StructuredToMemref/bitcast.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 
 module {
   tt.func @kernel(%a : !tt.ptr<i32>, %b : !tt.ptr<f32>) -> () {

--- a/test/Conversion/StructuredToMemref/block_ptr_advance.mlir
+++ b/test/Conversion/StructuredToMemref/block_ptr_advance.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 
 module {
   tt.func public @matmul_kernel_with_block_pointers_01234567891011(%arg0: !tt.ptr<bf16>, %arg1: !tt.ptr<bf16>, %arg2: !tt.ptr<bf16>, %arg3: i32, %arg4: i32, %arg5: i32, %arg6: i32, %arg7: i32, %arg8: i32, %arg9: i32, %arg10: i32, %arg11: i32, %arg12: i32, %arg13: i32) {

--- a/test/Conversion/StructuredToMemref/convert_1d_elemwise_arith_binary.mlir
+++ b/test/Conversion/StructuredToMemref/convert_1d_elemwise_arith_binary.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 module {
   tt.func @kernel(
     %a : !tt.ptr<f32>,

--- a/test/Conversion/StructuredToMemref/convert_1d_elemwise_arith_ternary.mlir
+++ b/test/Conversion/StructuredToMemref/convert_1d_elemwise_arith_ternary.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 module {
   tt.func @kernel(
     %a : !tt.ptr<i1>,

--- a/test/Conversion/StructuredToMemref/convert_1d_elemwise_arith_unary.mlir
+++ b/test/Conversion/StructuredToMemref/convert_1d_elemwise_arith_unary.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 module {
   tt.func @kernel(
     %f32ptr : !tt.ptr<f32>,

--- a/test/Conversion/StructuredToMemref/convert_2d_elemwise_arith_binary.mlir
+++ b/test/Conversion/StructuredToMemref/convert_2d_elemwise_arith_binary.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 module {
   tt.func @kernel(
     %a : !tt.ptr<f32>,

--- a/test/Conversion/StructuredToMemref/convert_2d_elemwise_arith_ternary.mlir
+++ b/test/Conversion/StructuredToMemref/convert_2d_elemwise_arith_ternary.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 module {
     tt.func @kernel(
                         %a : !tt.ptr<i1>,

--- a/test/Conversion/StructuredToMemref/convert_2d_elemwise_arith_unary.mlir
+++ b/test/Conversion/StructuredToMemref/convert_2d_elemwise_arith_unary.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 module {
   tt.func @kernel(
     %f32ptr : !tt.ptr<f32>,

--- a/test/Conversion/StructuredToMemref/convert_addi_reduce.mlir
+++ b/test/Conversion/StructuredToMemref/convert_addi_reduce.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref  %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental  %s | FileCheck %s
 
 module {
   tt.func public @addi(%arg0: !tt.ptr<i32>) {

--- a/test/Conversion/StructuredToMemref/convert_argmin_argmax.mlir
+++ b/test/Conversion/StructuredToMemref/convert_argmin_argmax.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref  %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental  %s | FileCheck %s
 
 module {
   tt.func public @argmax_012(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<i32>, %arg2: i32) {

--- a/test/Conversion/StructuredToMemref/convert_argmin_argmax_2d.mlir
+++ b/test/Conversion/StructuredToMemref/convert_argmin_argmax_2d.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref  %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental  %s | FileCheck %s
 
 // @triton.jit
 // def test(

--- a/test/Conversion/StructuredToMemref/convert_extern_elementwise.mlir
+++ b/test/Conversion/StructuredToMemref/convert_extern_elementwise.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref  %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental  %s | FileCheck %s
 
 module {
   tt.func public @atan2_kernel_0123(%arg0: !tt.ptr<f32, 1>, %arg1: !tt.ptr<f32, 1>, %arg2: !tt.ptr<f32, 1>, %arg3: i32) attributes {noinline = false} {

--- a/test/Conversion/StructuredToMemref/convert_minmax.mlir
+++ b/test/Conversion/StructuredToMemref/convert_minmax.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref  %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental  %s | FileCheck %s
 module {
   tt.func public @minmax_olt(%arg0: !tt.ptr<f32>, %arg1: f32, %arg2: f32) {
     %0 = arith.cmpf olt, %arg1, %arg2 : f32

--- a/test/Conversion/StructuredToMemref/convert_minmax_fp_reduce.mlir
+++ b/test/Conversion/StructuredToMemref/convert_minmax_fp_reduce.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref  %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental  %s | FileCheck %s
 
 module {
   tt.func public @maxnumf(%arg0: !tt.ptr<f32>) {

--- a/test/Conversion/StructuredToMemref/convert_minmax_reduce.mlir
+++ b/test/Conversion/StructuredToMemref/convert_minmax_reduce.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref  %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental  %s | FileCheck %s
 module {
   tt.func public @minmax_sgt(%arg0: !tt.ptr<i32>) {
     %cst_0 = arith.constant dense<0> : tensor<4096xi32>

--- a/test/Conversion/StructuredToMemref/convert_splat_float.mlir
+++ b/test/Conversion/StructuredToMemref/convert_splat_float.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 module {
     tt.func @kernel(%fin : f32,
                     %bin : bf16,

--- a/test/Conversion/StructuredToMemref/convert_tensor_reshape.mlir
+++ b/test/Conversion/StructuredToMemref/convert_tensor_reshape.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 module {
   tt.func public @bcast_kernel_01(%arg0: !tt.ptr<f32, 1>, %arg1: !tt.ptr<f32, 1>) attributes {noinline = false} {
     %c32_i32 = arith.constant 32 : i32

--- a/test/Conversion/StructuredToMemref/cumsum.mlir
+++ b/test/Conversion/StructuredToMemref/cumsum.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 
 // @triton.jit
 // def test_cumsum_op(

--- a/test/Conversion/StructuredToMemref/dot.mlir
+++ b/test/Conversion/StructuredToMemref/dot.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 module {
   tt.func @kernel(
     %arg0 : !tt.ptr<bf16>,

--- a/test/Conversion/StructuredToMemref/get_num_programs.mlir
+++ b/test/Conversion/StructuredToMemref/get_num_programs.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 
 module {
   tt.func public @num_programs(%arg0: !tt.ptr<i32>) {

--- a/test/Conversion/StructuredToMemref/kernel-01-vector-add.mlir
+++ b/test/Conversion/StructuredToMemref/kernel-01-vector-add.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 
 module {
   tt.func public @add_kernel_01234(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: !tt.ptr<f32>, %arg3: i32) {

--- a/test/Conversion/StructuredToMemref/kernel-02-fused-softmax.mlir
+++ b/test/Conversion/StructuredToMemref/kernel-02-fused-softmax.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 
 module {
   tt.func public @softmax_kernel_012345(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: i32, %arg3: i32, %arg4: i32) {

--- a/test/Conversion/StructuredToMemref/kernel-03-matrix-multiplication.mlir
+++ b/test/Conversion/StructuredToMemref/kernel-03-matrix-multiplication.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 
 module {
   tt.func public @matmul_kernel_0123456789101112131415(%arg0: !tt.ptr<bf16>, %arg1: !tt.ptr<bf16>, %arg2: !tt.ptr<bf16>, %arg3: i32, %arg4: i32, %arg5: i32, %arg6: i32, %arg7: i32, %arg8: i32, %arg9: i32, %arg10: i32, %arg11: i32) {

--- a/test/Conversion/StructuredToMemref/kernel-05-layer-norm-dwdb.mlir
+++ b/test/Conversion/StructuredToMemref/kernel-05-layer-norm-dwdb.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 
 module {
   tt.func public @_layer_norm_bwd_dwdb_0123456(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: !tt.ptr<f32>, %arg3: !tt.ptr<f32>, %arg4: i32, %arg5: i32) {

--- a/test/Conversion/StructuredToMemref/kernel-05-layer-norm-fwd.mlir
+++ b/test/Conversion/StructuredToMemref/kernel-05-layer-norm-fwd.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 
 module {
   tt.func public @_layer_norm_fwd_fused_0123456789(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: !tt.ptr<f32>, %arg3: !tt.ptr<f32>, %arg4: !tt.ptr<f32>, %arg5: !tt.ptr<f32>, %arg6: i32, %arg7: i32, %arg8: f32) {

--- a/test/Conversion/StructuredToMemref/masked_ldst_1d.mlir
+++ b/test/Conversion/StructuredToMemref/masked_ldst_1d.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 module {
   tt.func @kernel(
   %arg0 : !tt.ptr<bf16>,

--- a/test/Conversion/StructuredToMemref/masked_ldst_2d.mlir
+++ b/test/Conversion/StructuredToMemref/masked_ldst_2d.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 module {
   tt.func @kernel(
   %arg0 : !tt.ptr<bf16>,

--- a/test/Conversion/StructuredToMemref/masked_ldst_sitofp_other.mlir
+++ b/test/Conversion/StructuredToMemref/masked_ldst_sitofp_other.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 module {
   tt.func @kernel(
   %arg0 : !tt.ptr<bf16>,

--- a/test/Conversion/StructuredToMemref/reducemax_32_256_bf16.mlir
+++ b/test/Conversion/StructuredToMemref/reducemax_32_256_bf16.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 module {
     tt.func @kernel(%afloat : !tt.ptr<bf16>,
         %res : tensor<256x16x!tt.ptr<bf16>>

--- a/test/Conversion/StructuredToMemref/reducesum_512_256_bf16_axis0.mlir
+++ b/test/Conversion/StructuredToMemref/reducesum_512_256_bf16_axis0.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 module {
     tt.func @kernel(%afloat : !tt.ptr<bf16>,
         %res : !tt.ptr<bf16>

--- a/test/Conversion/StructuredToMemref/reducesum_512_256_bf16_axis1.mlir
+++ b/test/Conversion/StructuredToMemref/reducesum_512_256_bf16_axis1.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 module {
     tt.func @kernel(%afloat : !tt.ptr<bf16>,
         %res : !tt.ptr<bf16>

--- a/test/Conversion/StructuredToMemref/reducesum_512_256_f32_axis0.mlir
+++ b/test/Conversion/StructuredToMemref/reducesum_512_256_f32_axis0.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 module {
     tt.func @kernel(%afloat : !tt.ptr<f32>,
         %res : !tt.ptr<f32>

--- a/test/Conversion/StructuredToMemref/reducesum_512_256_f32_axis1.mlir
+++ b/test/Conversion/StructuredToMemref/reducesum_512_256_f32_axis1.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 module {
     tt.func @kernel(%afloat : !tt.ptr<f32>,
         %res : !tt.ptr<f32>

--- a/test/Conversion/StructuredToMemref/reducesum_middle_dim.mlir
+++ b/test/Conversion/StructuredToMemref/reducesum_middle_dim.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 module {
     tt.func @kernel(%afloat : !tt.ptr<bf16>,
         %res : !tt.ptr<bf16>,

--- a/test/Conversion/StructuredToMemref/reducesum_scalar.mlir
+++ b/test/Conversion/StructuredToMemref/reducesum_scalar.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 module {
   tt.func @kernel(%afloat : !tt.ptr<bf16>, %res : !tt.ptr<bf16>)
   {

--- a/test/Conversion/StructuredToMemref/scalar_store_loop_iterargs.mlir
+++ b/test/Conversion/StructuredToMemref/scalar_store_loop_iterargs.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --triton-to-linalg-experimental %s | FileCheck %s
 
 module {
   func.func @reduce_kernel_2d_0d1d2de3de(%arg0: !tt.ptr<f32, 1> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32, 1> {tt.divisibility = 16 : i32}, %arg2: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 16 : i32}, %arg3: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 16 : i32}, %arg4: i32, %arg5: i32, %arg6: i32, %arg7: i32, %arg8: i32, %arg9: i32) {

--- a/test/Conversion/StructuredToMemref/triton_assert.mlir
+++ b/test/Conversion/StructuredToMemref/triton_assert.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 tt.func public @assert_lol(%arg0: i32) {
   %c0_i32 = arith.constant 0 : i32
   %0 = arith.cmpi sgt, %arg0, %c0_i32 : i32

--- a/test/Conversion/StructuredToMemref/unsupported_extern_elementwise.mlir
+++ b/test/Conversion/StructuredToMemref/unsupported_extern_elementwise.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 
 module {
   tt.func public @rand(%arg0: !tt.ptr<i32, 1>, %arg1: !tt.ptr<i32, 1>) attributes {noinline = false} {

--- a/test/Conversion/StructuredToMemref/use_dot_opc.mlir
+++ b/test/Conversion/StructuredToMemref/use_dot_opc.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 module {
   tt.func @kernel(
     %arg0 : !tt.ptr<bf16>,

--- a/test/Conversion/StructuredToMemref/use_end_chain.mlir
+++ b/test/Conversion/StructuredToMemref/use_end_chain.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 module {
   tt.func @kernel(
   %arg0 : !tt.ptr<bf16>,

--- a/test/Conversion/StructuredToMemref/use_mid_chain.mlir
+++ b/test/Conversion/StructuredToMemref/use_mid_chain.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 module {
   tt.func @kernel(
   %arg0 : !tt.ptr<bf16>,

--- a/test/Conversion/StructuredToMemref/wraparound_side_by_side.mlir
+++ b/test/Conversion/StructuredToMemref/wraparound_side_by_side.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 
 module {
   tt.func public @wrap_side_by_side_masked_loop_01234567(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32, %arg6: i32, %arg7: i32) {

--- a/test/Conversion/StructuredToMemref/wraparound_stacked.mlir
+++ b/test/Conversion/StructuredToMemref/wraparound_stacked.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 
 module {
   tt.func public @wrap_stacked_masked_loop_01234567(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32, %arg6: i32, %arg7: i32) {

--- a/test/Conversion/StructuredToMemref/wraparound_unsupported_add_offset.mlir
+++ b/test/Conversion/StructuredToMemref/wraparound_unsupported_add_offset.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-structured --canonicalize --triton-arith-to-linalg --structured-to-memref %s | FileCheck %s
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 // XFAIL: *
 // We currently do not support this kind of modulo pattern:
 // (a + arrange(0, K)) % M

--- a/tools/RegisterTritonSharedDialects.h
+++ b/tools/RegisterTritonSharedDialects.h
@@ -17,6 +17,7 @@
 #include "triton-shared/Conversion/StructuredToMemref/Passes.h"
 #include "triton-shared/Conversion/TritonArithToLinalg/Passes.h"
 #include "triton-shared/Conversion/TritonToLinalg/Passes.h"
+#include "triton-shared/Conversion/TritonToLinalgExperimental/Passes.h"
 #include "triton-shared/Conversion/TritonToStructured/Passes.h"
 #include "triton-shared/Dialect/TritonStructured/IR/TritonStructuredDialect.h"
 #include "triton-shared/Dialect/TritonTilingExt/IR/TritonTilingExtDialect.h"
@@ -42,6 +43,7 @@ inline void registerTritonSharedDialects(mlir::DialectRegistry &registry) {
   mlir::test::registerTestAllocationPass();
   mlir::test::registerTestMembarPass();
   mlir::triton::registerTritonToLinalgPass();
+  mlir::triton::registerTritonToLinalgExperimentalPass();
   mlir::triton::registerTritonToStructuredPass();
   mlir::triton::registerTritonArithToLinalgPasses();
   mlir::triton::registerConvertTritonToTritonGPUPass();


### PR DESCRIPTION
This pass is a combination of the following passes:

+ `--triton-to-structured`
+ `--canonicalize`
+ `--triton-arith-to-linalg`
+ `--structured-to-memref`

Once stabilized, we intend to deprecate the old `--triton-to-linalg` pass in favour of this new pass. We expect this to happen May 1st, 2024. At that point, we will rename the old `--triton-to-linalg` pass to `--triton-to-linalg-legacy` and will stop future updates for it.