### PR TITLE
Use `add_triton_library` and allow optionally building the CPU backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,6 @@ add_subdirectory(lib)
 add_subdirectory(test)
 add_subdirectory(tools)
 
-if(TRITON_SHARED_BUILD_CPU_BACKEND)
+if (TRITON_SHARED_BUILD_CPU_BACKEND)
     add_triton_plugin(TritonShared ${CMAKE_CURRENT_SOURCE_DIR}/triton_shared.cc LINK_LIBS TritonSharedAnalysis TritonToLinalg TritonTilingExtIR)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,5 @@
+option(TRITON_SHARED_BUILD_CPU_BACKEND "Build triton-shared CPU backend" ON)
+
 set(TRITON_SHARED_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 set(TRITON_SHARED_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 
@@ -7,4 +9,7 @@ add_subdirectory(include)
 add_subdirectory(lib)
 add_subdirectory(test)
 add_subdirectory(tools)
-add_triton_plugin(TritonShared ${CMAKE_CURRENT_SOURCE_DIR}/triton_shared.cc LINK_LIBS TritonSharedAnalysis TritonToLinalg TritonTilingExtIR)
+
+if(TRITON_SHARED_BUILD_CPU_BACKEND)
+    add_triton_plugin(TritonShared ${CMAKE_CURRENT_SOURCE_DIR}/triton_shared.cc LINK_LIBS TritonSharedAnalysis TritonToLinalg TritonTilingExtIR)
+endif()

--- a/backend/compiler.py
+++ b/backend/compiler.py
@@ -144,6 +144,10 @@ class CPUBackend(BaseBackend):
         args.update({k: opts[k] for k in CPUOptions.__dataclass_fields__.keys() if k in opts})
         return CPUOptions(**args)
 
+    def get_codegen_implementation(self):
+        codegen_fns = dict()
+        return codegen_fns
+
     # Our compilation pipeline isn't in python like nvidia or amd, no need to load
     # dialects. See `triton_shared.cc`
     def load_dialects(self, ctx):

--- a/lib/Analysis/CMakeLists.txt
+++ b/lib/Analysis/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_mlir_library(TritonSharedAnalysis
+add_triton_library(TritonSharedAnalysis
   MaskAnalysis.cpp
   OpFoldResultUtils.cpp
   PtrAnalysis.cpp

--- a/lib/AnalysisStructured/CMakeLists.txt
+++ b/lib/AnalysisStructured/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_mlir_library(TritonSharedAnalysisStructured
+add_triton_library(TritonSharedAnalysisStructured
   PtrAnalysis.cpp
 
   DEPENDS

--- a/lib/Conversion/StructuredToMemref/CMakeLists.txt
+++ b/lib/Conversion/StructuredToMemref/CMakeLists.txt
@@ -1,14 +1,12 @@
-add_mlir_conversion_library(StructuredToMemref
+add_triton_library(StructuredToMemref
   StructuredToMemref.cpp
   StructuredToMemrefPass.cpp
 
   DEPENDS
   StructuredToMemrefConversionPassIncGen
 
-  LINK_COMPONENTS
-  Core
-
   LINK_LIBS PUBLIC
+  MLIRSCFTransforms
   MLIRArithDialect
   MLIRDialectUtils
   MLIRIR

--- a/lib/Conversion/StructuredToMemref/StructuredToMemrefPass.cpp
+++ b/lib/Conversion/StructuredToMemref/StructuredToMemrefPass.cpp
@@ -63,7 +63,7 @@ public:
   LoopTypeConverter(MLIRContext *context) {
     // The order of type conversion is important: later ones are tried earlier.
     addConversion([](Type type) { return type; });
-    addConversion([&](triton::PointerType ptrType) {
+    addConversion([context](triton::PointerType ptrType) {
       SmallVector<int64_t> strides{1};
       auto layout =
           StridedLayoutAttr::get(context, ShapedType::kDynamic, strides);
@@ -110,6 +110,7 @@ public:
 
     if (failed(convertArgsToMemrefType())) {
       signalPassFailure();
+      return;
     }
 
     auto moduleOp = getOperation();

--- a/lib/Conversion/TritonArithToLinalg/CMakeLists.txt
+++ b/lib/Conversion/TritonArithToLinalg/CMakeLists.txt
@@ -1,14 +1,12 @@
-add_mlir_conversion_library(TritonArithToLinalg
+add_triton_library(TritonArithToLinalg
   TritonArithToLinalg.cpp
   TritonArithToLinalgPass.cpp
 
   DEPENDS
   TritonArithToLinalgConversionPassIncGen
 
-  LINK_COMPONENTS
-  Core
-
   LINK_LIBS PUBLIC
+  MLIRLinalgTransforms
   MLIRArithDialect
   MLIRDialectUtils
   MLIRIR

--- a/lib/Conversion/TritonToLinalg/CMakeLists.txt
+++ b/lib/Conversion/TritonToLinalg/CMakeLists.txt
@@ -4,15 +4,12 @@
 #
 #===------------------------------------------------------------------------===#
 
-add_mlir_conversion_library(TritonToLinalg
+add_triton_library(TritonToLinalg
   TritonToLinalg.cpp
   TritonToLinalgPass.cpp
 
   DEPENDS
   TritonToLinalgConversionPassIncGen
-
-  LINK_COMPONENTS
-  Core
 
   LINK_LIBS PUBLIC
   TritonTilingExtIR

--- a/lib/Conversion/TritonToLinalgExperimental/CMakeLists.txt
+++ b/lib/Conversion/TritonToLinalgExperimental/CMakeLists.txt
@@ -4,14 +4,11 @@
 #
 #===------------------------------------------------------------------------===#
 
-add_mlir_conversion_library(TritonToLinalgExperimental
+add_triton_library(TritonToLinalgExperimental
   TritonToLinalgExperimentalPass.cpp
 
   DEPENDS
   TritonToLinalgExperimentalConversionPassIncGen
-
-  LINK_COMPONENTS
-  Core
 
   LINK_LIBS PUBLIC
   TritonTilingExtIR

--- a/lib/Conversion/TritonToStructured/CMakeLists.txt
+++ b/lib/Conversion/TritonToStructured/CMakeLists.txt
@@ -1,12 +1,9 @@
-add_mlir_conversion_library(TritonToStructured
+add_triton_library(TritonToStructured
   TritonToStructuredPass.cpp
 
   DEPENDS
   TritonStructuredTableGen
   TritonToStructuredConversionPassIncGen
-
-  LINK_COMPONENTS
-  Core
 
   LINK_LIBS PUBLIC
   MLIRArithDialect

--- a/lib/Dialect/TritonStructured/IR/CMakeLists.txt
+++ b/lib/Dialect/TritonStructured/IR/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_mlir_dialect_library(TritonStructuredIR
+add_triton_library(TritonStructuredIR
   TritonStructuredOps.cpp
   TritonStructuredDialect.cpp
 

--- a/lib/Dialect/TritonTilingExt/IR/CMakeLists.txt
+++ b/lib/Dialect/TritonTilingExt/IR/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_mlir_dialect_library(TritonTilingExtIR
+add_triton_library(TritonTilingExtIR
   BufferizableOpInterfaceImpl.cpp
   CumSum.cpp
   TritonTilingExtDialect.cpp


### PR DESCRIPTION
+ Use `add_triton_library` for all triton-shared passes and libs to be consistent with triton. This also helps potential issues when integrating with other backends because `add_mlir_library` exports the targets (and therefore their dependencies) by default, but triton does not export `TritonIR` and other passes.
+ Allow optionally build the cpu backend, this is to account for cases where another backend just wants to use `triton-shared` as a middle-layer and does not need the CPU backend to be installed.
+ Fix lambda capturing the context pointer by reference.
+ Add `get_codegen_implementation` to the CPUBackend, this was added recently in triton upstream.