### PR TITLE
[StructuredToMemref] Only use `memref.extract_strided_metadata` in loops

### DIFF
--- a/test/Conversion/StructuredToMemref/addptr_scalar_for.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_scalar_for.mlir
@@ -42,7 +42,6 @@ module {
 // CHECK-DAG:       [[CST_12_:%.+]] = arith.constant 12 : index
 // CHECK-DAG:       [[CST_3_:%.+]] = arith.constant 3 : index
 // CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: [0], sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
 // CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<1024xf32>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_1_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[VAR_0_]] : tensor<1024xf32>) -> tensor<1024xf32>
@@ -50,33 +49,31 @@ module {
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
 // CHECK-DAG:       [[VAR_4_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
-// CHECK:           [[base_buffer_:%.+]], [[offset_:%.+]], [[sizes_:%.+]], [[VAR_strides_:%.+]] = memref.extract_strided_metadata [[VAR_reinterpret_cast_]] : memref<1xf32, strided<[1], offset: ?>> -> memref<f32>, index, index, index
-// CHECK:           [[VAR_5_:%.+]] = arith.addi [[offset_]], [[VAR_4_]] : index
-// CHECK:           [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[base_buffer_]] to offset: {{.}}[[VAR_5_]]{{.}}, sizes: [1], strides: [1] : memref<f32> to memref<1xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_6_:%.+]]:3 = scf.for [[VAR_arg11_:%.+]] = [[CST_0_]] to [[CST_12_]] step [[CST_3_]] iter_args([[VAR_arg12_:%.+]] = [[VAR_reinterpret_cast_0_]], [[VAR_arg13_:%.+]] = [[VAR_1_]], [[VAR_arg14_:%.+]] = [[VAR_3_]]) -> (memref<1xf32, strided<[1], offset: ?>>, tensor<1024xf32>, index) {
-// CHECK-DAG:         [[VAR_reinterpret_cast_2_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_arg14_]]{{.}}, sizes: [1024], strides: [1] : memref<*xf32> to memref<1024xf32, strided<[1], offset: ?>>
+// CHECK:           [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_4_]]{{.}}, sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_5_:%.+]]:3 = scf.for [[VAR_arg11_:%.+]] = [[CST_0_]] to [[CST_12_]] step [[CST_3_]] iter_args([[VAR_arg12_:%.+]] = [[VAR_reinterpret_cast_]], [[VAR_arg13_:%.+]] = [[VAR_1_]], [[VAR_arg14_:%.+]] = [[VAR_3_]]) -> (memref<1xf32, strided<[1], offset: ?>>, tensor<1024xf32>, index) {
+// CHECK-DAG:         [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[PARAM_1_]]4], sizes: [1024], strides: [1] : memref<*xf32> to memref<1024xf32, strided<[1], offset: ?>>
 // CHECK-DAG:         [[RES_:%.+]] = memref.alloc() : memref<1024xf32>
-// CHECK:             memref.copy [[VAR_reinterpret_cast_2_]], [[RES_]] : memref<1024xf32, strided<[1], offset: ?>> to memref<1024xf32>
-// CHECK:             [[VAR_9_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<1024xf32>
-// CHECK:             [[VAR_10_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_9_]] : tensor<1024xf32>) outs([[VAR_9_]] : tensor<1024xf32>) {
+// CHECK:             memref.copy [[VAR_reinterpret_cast_1_]], [[RES_]] : memref<1024xf32, strided<[1], offset: ?>> to memref<1024xf32>
+// CHECK:             [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<1024xf32>
+// CHECK:             [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<1024xf32>) outs([[VAR_8_]] : tensor<1024xf32>) {
 // CHECK:             ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
 // CHECK:               [[VAR_14_:%.+]] = math.exp [[IN_0_]] : f32
 // CHECK:               linalg.yield [[VAR_14_]] : f32
 // CHECK:             } -> tensor<1024xf32>
-// CHECK:             [[VAR_11_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_arg13_]], [[VAR_10_]] : tensor<1024xf32>, tensor<1024xf32>) outs([[VAR_arg13_]] : tensor<1024xf32>) {
+// CHECK:             [[VAR_10_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_arg13_]], [[VAR_9_]] : tensor<1024xf32>, tensor<1024xf32>) outs([[VAR_arg13_]] : tensor<1024xf32>) {
 // CHECK:             ^bb0([[IN_2_:%.+]]: f32, [[IN_3_:%.+]]: f32, [[IN_4_:%.+]]: f32):
 // CHECK:               [[VAR_14_1_:%.+]] = arith.addf [[IN_2_]], [[IN_3_]] : f32
 // CHECK:               linalg.yield [[VAR_14_1_]] : f32
 // CHECK:             } -> tensor<1024xf32>
-// CHECK:             [[base_buffer_3_:%.+]], [[offset_4_:%.+]], [[sizes_5_:%.+]], [[VAR_strides_6_:%.+]] = memref.extract_strided_metadata [[VAR_arg12_]] : memref<1xf32, strided<[1], offset: ?>> -> memref<f32>, index, index, index
-// CHECK:             [[VAR_12_:%.+]] = arith.addi [[offset_4_]], [[VAR_arg11_]] : index
-// CHECK-DAG:         [[VAR_reinterpret_cast_7_:%.+]] = memref.reinterpret_cast [[base_buffer_3_]] to offset: {{.}}[[VAR_12_]]{{.}}, sizes: [1], strides: [1] : memref<f32> to memref<1xf32, strided<[1], offset: ?>>
-// CHECK-DAG:         [[VAR_13_:%.+]] = arith.addi [[VAR_arg14_]], [[VAR_arg11_]] : index
-// CHECK:             scf.yield [[VAR_reinterpret_cast_7_]], [[VAR_11_]], [[VAR_13_]] : memref<1xf32, strided<[1], offset: ?>>, tensor<1024xf32>, index
+// CHECK:             [[base_buffer_:%.+]], [[offset_:%.+]], [[sizes_:%.+]], [[VAR_strides_:%.+]] = memref.extract_strided_metadata [[VAR_arg12_]] : memref<1xf32, strided<[1], offset: ?>> -> memref<f32>, index, index, index
+// CHECK:             [[VAR_11_:%.+]] = arith.addi [[offset_]], [[VAR_arg11_]] : index
+// CHECK-DAG:         [[VAR_reinterpret_cast_2_:%.+]] = memref.reinterpret_cast [[base_buffer_]] to offset: {{.}}[[VAR_11_]]{{.}}, sizes: [1], strides: [1] : memref<f32> to memref<1xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_12_:%.+]] = arith.addi [[VAR_arg14_]], [[VAR_arg11_]] : index
+// CHECK:             scf.yield [[VAR_reinterpret_cast_2_]], [[VAR_10_]], [[VAR_12_]] : memref<1xf32, strided<[1], offset: ?>>, tensor<1024xf32>, index
 // CHECK:           }
-// CHECK:           [[VAR_7_:%.+]] = arith.muli [[PARAM_8_]], [[PARAM_3_]] : i32
-// CHECK:           [[VAR_8_:%.+]] = arith.index_cast [[VAR_7_]] : i32 to index
-// CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_8_]]{{.}}, sizes: [1024], strides: [1] : memref<*xf32> to memref<1024xf32, strided<[1], offset: ?>>
-// CHECK:           bufferization.materialize_in_destination [[VAR_6_]]#1 in writable [[VAR_reinterpret_cast_1_]] : (tensor<1024xf32>, memref<1024xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           [[VAR_6_:%.+]] = arith.muli [[PARAM_8_]], [[PARAM_3_]] : i32
+// CHECK:           [[VAR_7_:%.+]] = arith.index_cast [[VAR_6_]] : i32 to index
+// CHECK:           [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_7_]]{{.}}, sizes: [1024], strides: [1] : memref<*xf32> to memref<1024xf32, strided<[1], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_5_]]#1 in writable [[VAR_reinterpret_cast_0_]] : (tensor<1024xf32>, memref<1024xf32, strided<[1], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/StructuredToMemref/addptr_scalar_for_2d.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_scalar_for_2d.mlir
@@ -62,7 +62,6 @@ module {
 // CHECK-DAG:       [[CST_3_:%.+]] = arith.constant 3 : index
 // CHECK-DAG:       [[CST_128_:%.+]] = arith.constant 128 : index
 // CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: [0], sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
 // CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<128x128xf32>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_1_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[VAR_0_]] : tensor<128x128xf32>) -> tensor<128x128xf32>
@@ -70,36 +69,34 @@ module {
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
 // CHECK-DAG:       [[VAR_4_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
-// CHECK:           [[base_buffer_:%.+]], [[offset_:%.+]], [[sizes_:%.+]], [[VAR_strides_:%.+]] = memref.extract_strided_metadata [[VAR_reinterpret_cast_]] : memref<1xf32, strided<[1], offset: ?>> -> memref<f32>, index, index, index
-// CHECK:           [[VAR_5_:%.+]] = arith.addi [[offset_]], [[VAR_4_]] : index
-// CHECK:           [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[base_buffer_]] to offset: {{.}}[[VAR_5_]]{{.}}, sizes: [1], strides: [1] : memref<f32> to memref<1xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_6_:%.+]]:3 = scf.for [[VAR_arg11_:%.+]] = [[CST_0_]] to [[CST_12_]] step [[CST_3_]] iter_args([[VAR_arg12_:%.+]] = [[VAR_1_]], [[VAR_arg13_:%.+]] = [[VAR_reinterpret_cast_0_]], [[VAR_arg14_:%.+]] = [[VAR_3_]]) -> (tensor<128x128xf32>, memref<1xf32, strided<[1], offset: ?>>, index) {
-// CHECK-DAG:         [[VAR_10_:%.+]] = arith.addi [[VAR_arg14_]], [[CST_128_]] : index
+// CHECK:           [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_4_]]{{.}}, sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_5_:%.+]]:3 = scf.for [[VAR_arg11_:%.+]] = [[CST_0_]] to [[CST_12_]] step [[CST_3_]] iter_args([[VAR_arg12_:%.+]] = [[VAR_1_]], [[VAR_arg13_:%.+]] = [[VAR_reinterpret_cast_]], [[VAR_arg14_:%.+]] = [[VAR_3_]]) -> (tensor<128x128xf32>, memref<1xf32, strided<[1], offset: ?>>, index) {
+// CHECK-DAG:         [[VAR_9_:%.+]] = arith.addi [[VAR_arg14_]], [[CST_128_]] : index
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_reinterpret_cast_2_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_10_]]{{.}}, sizes: [128, 128], strides: [1, 1] : memref<*xf32> to memref<128x128xf32, strided<[1, 1], offset: ?>>
+// CHECK-DAG:         [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_9_]]{{.}}, sizes: [128, 128], strides: [1, 1] : memref<*xf32> to memref<128x128xf32, strided<[1, 1], offset: ?>>
 // CHECK-DAG:         [[RES_:%.+]] = memref.alloc() : memref<128x128xf32>
-// CHECK:             memref.copy [[VAR_reinterpret_cast_2_]], [[RES_]] : memref<128x128xf32, strided<[1, 1], offset: ?>> to memref<128x128xf32>
-// CHECK:             [[VAR_11_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<128x128xf32>
-// CHECK:             [[VAR_12_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_11_]] : tensor<128x128xf32>) outs([[VAR_11_]] : tensor<128x128xf32>) {
+// CHECK:             memref.copy [[VAR_reinterpret_cast_1_]], [[RES_]] : memref<128x128xf32, strided<[1, 1], offset: ?>> to memref<128x128xf32>
+// CHECK:             [[VAR_10_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<128x128xf32>
+// CHECK:             [[VAR_11_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_10_]] : tensor<128x128xf32>) outs([[VAR_10_]] : tensor<128x128xf32>) {
 // CHECK:             ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
 // CHECK:               [[VAR_16_:%.+]] = math.exp [[IN_0_]] : f32
 // CHECK:               linalg.yield [[VAR_16_]] : f32
 // CHECK:             } -> tensor<128x128xf32>
-// CHECK:             [[VAR_13_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_arg12_]], [[VAR_12_]] : tensor<128x128xf32>, tensor<128x128xf32>) outs([[VAR_arg12_]] : tensor<128x128xf32>) {
+// CHECK:             [[VAR_12_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_arg12_]], [[VAR_11_]] : tensor<128x128xf32>, tensor<128x128xf32>) outs([[VAR_arg12_]] : tensor<128x128xf32>) {
 // CHECK:             ^bb0([[IN_2_:%.+]]: f32, [[IN_3_:%.+]]: f32, [[IN_4_:%.+]]: f32):
 // CHECK:               [[VAR_16_1_:%.+]] = arith.addf [[IN_2_]], [[IN_3_]] : f32
 // CHECK:               linalg.yield [[VAR_16_1_]] : f32
 // CHECK:             } -> tensor<128x128xf32>
-// CHECK:             [[base_buffer_3_:%.+]], [[offset_4_:%.+]], [[sizes_5_:%.+]], [[VAR_strides_6_:%.+]] = memref.extract_strided_metadata [[VAR_arg13_]] : memref<1xf32, strided<[1], offset: ?>> -> memref<f32>, index, index, index
-// CHECK:             [[VAR_14_:%.+]] = arith.addi [[offset_4_]], [[VAR_arg11_]] : index
-// CHECK-DAG:         [[VAR_reinterpret_cast_7_:%.+]] = memref.reinterpret_cast [[base_buffer_3_]] to offset: {{.}}[[VAR_14_]]{{.}}, sizes: [1], strides: [1] : memref<f32> to memref<1xf32, strided<[1], offset: ?>>
-// CHECK-DAG:         [[VAR_15_:%.+]] = arith.addi [[VAR_arg14_]], [[VAR_arg11_]] : index
-// CHECK:             scf.yield [[VAR_13_]], [[VAR_reinterpret_cast_7_]], [[VAR_15_]] : tensor<128x128xf32>, memref<1xf32, strided<[1], offset: ?>>, index
+// CHECK:             [[base_buffer_:%.+]], [[offset_:%.+]], [[sizes_:%.+]], [[VAR_strides_:%.+]] = memref.extract_strided_metadata [[VAR_arg13_]] : memref<1xf32, strided<[1], offset: ?>> -> memref<f32>, index, index, index
+// CHECK:             [[VAR_13_:%.+]] = arith.addi [[offset_]], [[VAR_arg11_]] : index
+// CHECK-DAG:         [[VAR_reinterpret_cast_2_:%.+]] = memref.reinterpret_cast [[base_buffer_]] to offset: {{.}}[[VAR_13_]]{{.}}, sizes: [1], strides: [1] : memref<f32> to memref<1xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_14_:%.+]] = arith.addi [[VAR_arg14_]], [[VAR_arg11_]] : index
+// CHECK:             scf.yield [[VAR_12_]], [[VAR_reinterpret_cast_2_]], [[VAR_14_]] : tensor<128x128xf32>, memref<1xf32, strided<[1], offset: ?>>, index
 // CHECK:           }
-// CHECK:           [[VAR_7_:%.+]] = arith.muli [[PARAM_8_]], [[PARAM_3_]] : i32
-// CHECK:           [[VAR_8_:%.+]] = arith.index_cast [[VAR_7_]] : i32 to index
-// CHECK:           [[VAR_9_:%.+]] = arith.addi [[VAR_8_]], [[CST_128_]] : index
-// CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_9_]]{{.}}, sizes: [128, 128], strides: [1, 1] : memref<*xf32> to memref<128x128xf32, strided<[1, 1], offset: ?>>
-// CHECK:           bufferization.materialize_in_destination [[VAR_6_]]#0 in writable [[VAR_reinterpret_cast_1_]] : (tensor<128x128xf32>, memref<128x128xf32, strided<[1, 1], offset: ?>>) -> ()
+// CHECK:           [[VAR_6_:%.+]] = arith.muli [[PARAM_8_]], [[PARAM_3_]] : i32
+// CHECK:           [[VAR_7_:%.+]] = arith.index_cast [[VAR_6_]] : i32 to index
+// CHECK:           [[VAR_8_:%.+]] = arith.addi [[VAR_7_]], [[CST_128_]] : index
+// CHECK:           [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_8_]]{{.}}, sizes: [128, 128], strides: [1, 1] : memref<*xf32> to memref<128x128xf32, strided<[1, 1], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_5_]]#0 in writable [[VAR_reinterpret_cast_0_]] : (tensor<128x128xf32>, memref<128x128xf32, strided<[1, 1], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/StructuredToMemref/addptr_scalar_loopback.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_scalar_loopback.mlir
@@ -16,17 +16,12 @@ module {
 
 // CHECK-LABEL:  func.func @kernel
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: memref<*xbf16>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: [0], sizes: [1], strides: [1] : memref<*xbf16> to memref<1xbf16, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [1], strides: [1] : memref<*xbf16> to memref<1xbf16, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_0_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
-// CHECK:           [[base_buffer_:%.+]], [[offset_:%.+]], [[sizes_:%.+]], [[VAR_strides_:%.+]] = memref.extract_strided_metadata [[VAR_reinterpret_cast_0_]] : memref<1xbf16, strided<[1], offset: ?>> -> memref<bf16>, index, index, index
-// CHECK:           [[VAR_1_:%.+]] = arith.addi [[offset_]], [[VAR_0_]] : index
-// CHECK-DAG:       [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[base_buffer_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [1], strides: [1] : memref<bf16> to memref<1xbf16, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
-// CHECK:           [[base_buffer_2_:%.+]], [[offset_3_:%.+]], [[sizes_4_:%.+]], [[VAR_strides_5_:%.+]] = memref.extract_strided_metadata [[VAR_reinterpret_cast_]] : memref<1xbf16, strided<[1], offset: ?>> -> memref<bf16>, index, index, index
-// CHECK:           [[VAR_3_:%.+]] = arith.addi [[offset_3_]], [[VAR_2_]] : index
-// CHECK-DAG:       [[VAR_reinterpret_cast_6_:%.+]] = memref.reinterpret_cast [[base_buffer_2_]] to offset: {{.}}[[VAR_3_]]{{.}}, sizes: [1], strides: [1] : memref<bf16> to memref<1xbf16, strided<[1], offset: ?>>
-// CHECK-DAG:       [[LOAD_VAR_reinterpret_cast_1_MEM_:%.+]] = affine.load [[VAR_reinterpret_cast_1_]][0] : memref<1xbf16, strided<[1], offset: ?>>
-// CHECK:           affine.store [[LOAD_VAR_reinterpret_cast_1_MEM_]], [[VAR_reinterpret_cast_6_]][0] : memref<1xbf16, strided<[1], offset: ?>>
+// CHECK:           [[VAR_0_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_0_]]{{.}}, sizes: [1], strides: [1] : memref<*xbf16> to memref<1xbf16, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [1], strides: [1] : memref<*xbf16> to memref<1xbf16, strided<[1], offset: ?>>
+// CHECK-DAG:       [[LOAD_VAR_reinterpret_cast_MEM_:%.+]] = affine.load [[VAR_reinterpret_cast_]][0] : memref<1xbf16, strided<[1], offset: ?>>
+// CHECK:           affine.store [[LOAD_VAR_reinterpret_cast_MEM_]], [[VAR_reinterpret_cast_0_]][0] : memref<1xbf16, strided<[1], offset: ?>>
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/StructuredToMemref/convert_argmin_argmax.mlir
+++ b/test/Conversion/StructuredToMemref/convert_argmin_argmax.mlir
@@ -32,7 +32,6 @@ module {
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xi32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
 // CHECK-DAG:       [[CST_minus_1_:%.+]] = arith.constant -1 : i32
 // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0xFF800000 : f32
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: [0], sizes: [1], strides: [1] : memref<*xi32> to memref<1xi32, strided<[1], offset: ?>>
 // CHECK-DAG:       [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[PARAM_2_]] : i32
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
@@ -43,9 +42,9 @@ module {
 // CHECK:             [[VAR_12_:%.+]] = arith.index_cast [[VAR_11_]] : index to i32
 // CHECK:             linalg.yield [[VAR_12_]] : i32
 // CHECK:           } -> tensor<4096xi32>
-// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [4096], strides: [1] : memref<*xf32> to memref<4096xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [4096], strides: [1] : memref<*xf32> to memref<4096xf32, strided<[1], offset: ?>>
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<4096xf32>
-// CHECK:           memref.copy [[VAR_reinterpret_cast_0_]], [[RES_]] : memref<4096xf32, strided<[1], offset: ?>> to memref<4096xf32>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<4096xf32, strided<[1], offset: ?>> to memref<4096xf32>
 // CHECK-DAG:       [[VAR_4_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<4096xf32>
 // CHECK-DAG:       [[VAR_5_:%.+]] = tensor.empty() : tensor<f32>
 // CHECK-NOT: separator of consecutive DAGs
@@ -66,10 +65,8 @@ module {
 // CHECK:             }
 // CHECK-DAG:       [[VAR_extracted_:%.+]] = tensor.extract [[VAR_reduced_]]#1[] : tensor<i32>
 // CHECK-DAG:       [[VAR_9_:%.+]] = arith.index_cast [[PARAM_6_]] : i32 to index
-// CHECK:           [[base_buffer_:%.+]], [[offset_:%.+]], [[sizes_:%.+]], [[VAR_strides_:%.+]] = memref.extract_strided_metadata [[VAR_reinterpret_cast_]] : memref<1xi32, strided<[1], offset: ?>> -> memref<i32>, index, index, index
-// CHECK:           [[VAR_10_:%.+]] = arith.addi [[offset_]], [[VAR_9_]] : index
-// CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[base_buffer_]] to offset: {{.}}[[VAR_10_]]{{.}}, sizes: [1], strides: [1] : memref<i32> to memref<1xi32, strided<[1], offset: ?>>
-// CHECK:           affine.store [[VAR_extracted_]], [[VAR_reinterpret_cast_1_]][0] : memref<1xi32, strided<[1], offset: ?>>
+// CHECK:           [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_9_]]{{.}}, sizes: [1], strides: [1] : memref<*xi32> to memref<1xi32, strided<[1], offset: ?>>
+// CHECK:           affine.store [[VAR_extracted_]], [[VAR_reinterpret_cast_0_]][0] : memref<1xi32, strided<[1], offset: ?>>
 // CHECK:           return
 // CHECK:         }
 
@@ -107,7 +104,6 @@ module {
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xi32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
 // CHECK-DAG:       [[CST_minus_1_:%.+]] = arith.constant -1 : i32
 // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0x7F800000 : f32
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: [0], sizes: [1], strides: [1] : memref<*xi32> to memref<1xi32, strided<[1], offset: ?>>
 // CHECK-DAG:       [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[PARAM_2_]] : i32
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
@@ -118,9 +114,9 @@ module {
 // CHECK:             [[VAR_12_:%.+]] = arith.index_cast [[VAR_11_]] : index to i32
 // CHECK:             linalg.yield [[VAR_12_]] : i32
 // CHECK:           } -> tensor<4096xi32>
-// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [4096], strides: [1] : memref<*xf32> to memref<4096xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [4096], strides: [1] : memref<*xf32> to memref<4096xf32, strided<[1], offset: ?>>
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<4096xf32>
-// CHECK:           memref.copy [[VAR_reinterpret_cast_0_]], [[RES_]] : memref<4096xf32, strided<[1], offset: ?>> to memref<4096xf32>
+// CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<4096xf32, strided<[1], offset: ?>> to memref<4096xf32>
 // CHECK-DAG:       [[VAR_4_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<4096xf32>
 // CHECK-DAG:       [[VAR_5_:%.+]] = tensor.empty() : tensor<f32>
 // CHECK-NOT: separator of consecutive DAGs
@@ -141,9 +137,7 @@ module {
 // CHECK:             }
 // CHECK-DAG:       [[VAR_extracted_:%.+]] = tensor.extract [[VAR_reduced_]]#1[] : tensor<i32>
 // CHECK-DAG:       [[VAR_9_:%.+]] = arith.index_cast [[PARAM_6_]] : i32 to index
-// CHECK:           [[base_buffer_:%.+]], [[offset_:%.+]], [[sizes_:%.+]], [[VAR_strides_:%.+]] = memref.extract_strided_metadata [[VAR_reinterpret_cast_]] : memref<1xi32, strided<[1], offset: ?>> -> memref<i32>, index, index, index
-// CHECK:           [[VAR_10_:%.+]] = arith.addi [[offset_]], [[VAR_9_]] : index
-// CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[base_buffer_]] to offset: {{.}}[[VAR_10_]]{{.}}, sizes: [1], strides: [1] : memref<i32> to memref<1xi32, strided<[1], offset: ?>>
-// CHECK:           affine.store [[VAR_extracted_]], [[VAR_reinterpret_cast_1_]][0] : memref<1xi32, strided<[1], offset: ?>>
+// CHECK:           [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_9_]]{{.}}, sizes: [1], strides: [1] : memref<*xi32> to memref<1xi32, strided<[1], offset: ?>>
+// CHECK:           affine.store [[VAR_extracted_]], [[VAR_reinterpret_cast_0_]][0] : memref<1xi32, strided<[1], offset: ?>>
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/StructuredToMemref/kernel-05-layer-norm-fwd.mlir
+++ b/test/Conversion/StructuredToMemref/kernel-05-layer-norm-fwd.mlir
@@ -96,8 +96,6 @@ module {
 // CHECK-DAG:       [[CST_256_:%.+]] = arith.constant 256 : i32
 // CHECK-DAG:       [[CST_256_1_:%.+]] = arith.constant 256 : index
 // CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_5_]] to offset: [0], sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_4_]] to offset: [0], sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
 // CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<256xf32>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_1_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[VAR_0_]] : tensor<256xf32>) -> tensor<256xf32>
@@ -106,30 +104,30 @@ module {
 // CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
 // CHECK-DAG:       [[VAR_4_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
 // CHECK-DAG:       [[VAR_5_:%.+]] = scf.for [[VAR_arg15_:%.+]] = [[CST_0_]] to [[PARAM_7_]] step [[CST_256_]] iter_args([[VAR_arg16_:%.+]] = [[VAR_1_]]) -> (tensor<256xf32>)  : i32 {
+// CHECK-DAG:         [[VAR_27_:%.+]] = arith.index_cast [[VAR_arg15_]] : i32 to index
+// CHECK:             [[VAR_28_:%.+]] = arith.addi [[VAR_3_]], [[VAR_27_]] : index
+// CHECK-DAG:         [[VAR_reinterpret_cast_5_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_28_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
 // CHECK-DAG:         [[VAR_29_:%.+]] = arith.index_cast [[VAR_arg15_]] : i32 to index
-// CHECK:             [[VAR_30_:%.+]] = arith.addi [[VAR_3_]], [[VAR_29_]] : index
-// CHECK-DAG:         [[VAR_reinterpret_cast_11_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_30_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
-// CHECK-DAG:         [[VAR_31_:%.+]] = arith.index_cast [[VAR_arg15_]] : i32 to index
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_32_:%.+]] = arith.addi [[VAR_31_]], [[CST_256_1_]] : index
-// CHECK-DAG:         [[VAR_33_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
-// CHECK:             [[VAR_34_:%.+]] = arith.minsi [[VAR_32_]], [[VAR_33_]] : index
-// CHECK-DAG:         [[VAR_35_:%.+]] = arith.subi [[VAR_34_]], [[VAR_31_]] : index
+// CHECK-DAG:         [[VAR_30_:%.+]] = arith.addi [[VAR_29_]], [[CST_256_1_]] : index
+// CHECK-DAG:         [[VAR_31_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
+// CHECK:             [[VAR_32_:%.+]] = arith.minsi [[VAR_30_]], [[VAR_31_]] : index
+// CHECK-DAG:         [[VAR_33_:%.+]] = arith.subi [[VAR_32_]], [[VAR_29_]] : index
 // CHECK-DAG:         [[RES_:%.+]] = memref.alloc() : memref<256xf32>
-// CHECK:             [[VAR_36_:%.+]] = arith.cmpi slt, [[VAR_35_]], [[CST_256_1_]] : index
-// CHECK:             scf.if [[VAR_36_]] {
+// CHECK:             [[VAR_34_:%.+]] = arith.cmpi slt, [[VAR_33_]], [[CST_256_1_]] : index
+// CHECK:             scf.if [[VAR_34_]] {
 // CHECK:               linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[RES_]] : memref<256xf32>)
 // CHECK:             }
-// CHECK-DAG:         [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_11_]][0] {{.}}[[VAR_35_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-// CHECK-DAG:         [[VAR_subview_12_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_35_]]{{.}} [1] : memref<256xf32> to memref<?xf32, strided<[1]>>
-// CHECK:             memref.copy [[VAR_subview_]], [[VAR_subview_12_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
-// CHECK:             [[VAR_37_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<256xf32>
-// CHECK:             [[VAR_38_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_arg16_]], [[VAR_37_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_arg16_]] : tensor<256xf32>) {
+// CHECK-DAG:         [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_5_]][0] {{.}}[[VAR_33_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_subview_6_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_33_]]{{.}} [1] : memref<256xf32> to memref<?xf32, strided<[1]>>
+// CHECK:             memref.copy [[VAR_subview_]], [[VAR_subview_]]_6 : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK:             [[VAR_35_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<256xf32>
+// CHECK:             [[VAR_36_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_arg16_]], [[VAR_35_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_arg16_]] : tensor<256xf32>) {
 // CHECK:             ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32, [[IN_2_:%.+]]: f32):
 // CHECK:               [[VAR_39_:%.+]] = arith.addf [[IN_0_]], [[IN_1_]] : f32
 // CHECK:               linalg.yield [[VAR_39_]] : f32
 // CHECK:             } -> tensor<256xf32>
-// CHECK:             scf.yield [[VAR_38_]] : tensor<256xf32>
+// CHECK:             scf.yield [[VAR_36_]] : tensor<256xf32>
 // CHECK:           }
 // CHECK:           [[VAR_6_:%.+]] = bufferization.alloc_tensor() : tensor<f32>
 // CHECK:           [[VAR_inserted_:%.+]] = tensor.insert [[CST_0_dot_000000_]] into [[VAR_6_]][] : tensor<f32>
@@ -155,165 +153,161 @@ module {
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_14_:%.+]] = linalg.fill ins([[VAR_8_]] : f32) outs([[VAR_13_]] : tensor<256xf32>) -> tensor<256xf32>
 // CHECK-DAG:       [[VAR_15_:%.+]] = scf.for [[VAR_arg15_1_:%.+]] = [[CST_0_]] to [[PARAM_7_]] step [[CST_256_]] iter_args([[VAR_arg16_1_:%.+]] = [[VAR_1_]]) -> (tensor<256xf32>)  : i32 {
-// CHECK-DAG:         [[VAR_29_3_:%.+]] = tensor.empty() : tensor<256xi32>
-// CHECK:             [[VAR_30_2_:%.+]] = linalg.fill ins([[VAR_arg15_1_]] : i32) outs([[VAR_29_3_]] : tensor<256xi32>) -> tensor<256xi32>
-// CHECK:             [[VAR_31_1_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_30_2_]], [[VAR_10_]] : tensor<256xi32>, tensor<256xi32>) outs([[VAR_30_2_]] : tensor<256xi32>) {
+// CHECK-DAG:         [[VAR_27_3_:%.+]] = tensor.empty() : tensor<256xi32>
+// CHECK:             [[VAR_28_2_:%.+]] = linalg.fill ins([[VAR_arg15_1_]] : i32) outs([[VAR_27_3_]] : tensor<256xi32>) -> tensor<256xi32>
+// CHECK:             [[VAR_29_1_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_28_2_]], [[VAR_10_]] : tensor<256xi32>, tensor<256xi32>) outs([[VAR_28_2_]] : tensor<256xi32>) {
 // CHECK:             ^bb0([[IN_4_:%.+]]: i32, [[IN_5_:%.+]]: i32, [[IN_6_:%.+]]: i32):
 // CHECK:               [[VAR_47_:%.+]] = arith.addi [[IN_4_]], [[IN_5_]] : i32
 // CHECK:               linalg.yield [[VAR_47_]] : i32
 // CHECK:             } -> tensor<256xi32>
-// CHECK:             [[VAR_32_1_:%.+]] = tensor.empty() : tensor<256xi1>
-// CHECK:             [[VAR_33_1_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_31_1_]], [[VAR_12_]] : tensor<256xi32>, tensor<256xi32>) outs([[VAR_32_1_]] : tensor<256xi1>) {
+// CHECK:             [[VAR_30_1_:%.+]] = tensor.empty() : tensor<256xi1>
+// CHECK:             [[VAR_31_1_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_29_1_]], [[VAR_12_]] : tensor<256xi32>, tensor<256xi32>) outs([[VAR_30_1_]] : tensor<256xi1>) {
 // CHECK:             ^bb0([[IN_7_:%.+]]: i32, [[IN_8_:%.+]]: i32, [[IN_9_:%.+]]: i1):
 // CHECK:               [[VAR_47_1_:%.+]] = arith.cmpi slt, [[IN_7_]], [[IN_8_]] : i32
 // CHECK:               linalg.yield [[VAR_47_1_]] : i1
 // CHECK:             } -> tensor<256xi1>
-// CHECK:             [[VAR_34_1_:%.+]] = arith.index_cast [[VAR_arg15_1_]] : i32 to index
-// CHECK:             [[VAR_35_1_:%.+]] = arith.addi [[VAR_3_]], [[VAR_34_1_]] : index
-// CHECK-DAG:         [[VAR_reinterpret_cast_11_1_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_35_1_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
-// CHECK-DAG:         [[VAR_36_1_:%.+]] = arith.index_cast [[VAR_arg15_1_]] : i32 to index
+// CHECK:             [[VAR_32_1_:%.+]] = arith.index_cast [[VAR_arg15_1_]] : i32 to index
+// CHECK:             [[VAR_33_1_:%.+]] = arith.addi [[VAR_3_]], [[VAR_3_]]2 : index
+// CHECK-DAG:         [[VAR_reinterpret_cast_5_1_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_33_1_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_34_1_:%.+]] = arith.index_cast [[VAR_arg15_1_]] : i32 to index
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_37_1_:%.+]] = arith.addi [[VAR_36_1_]], [[CST_256_1_]] : index
-// CHECK-DAG:         [[VAR_38_1_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
-// CHECK:             [[VAR_39_1_:%.+]] = arith.minsi [[VAR_37_1_]], [[VAR_38_1_]] : index
-// CHECK-DAG:         [[VAR_40_:%.+]] = arith.subi [[VAR_39_1_]], [[VAR_36_1_]] : index
+// CHECK-DAG:         [[VAR_35_1_:%.+]] = arith.addi [[VAR_34_1_]], [[CST_256_1_]] : index
+// CHECK-DAG:         [[VAR_36_1_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
+// CHECK:             [[VAR_37_1_:%.+]] = arith.minsi [[VAR_35_1_]], [[VAR_36_1_]] : index
+// CHECK-DAG:         [[VAR_38_:%.+]] = arith.subi [[VAR_37_1_]], [[VAR_34_1_]] : index
 // CHECK-DAG:         [[RES_1_:%.+]] = memref.alloc() : memref<256xf32>
-// CHECK:             [[VAR_41_:%.+]] = arith.cmpi slt, [[VAR_40_]], [[CST_256_1_]] : index
-// CHECK:             scf.if [[VAR_41_]] {
+// CHECK:             [[VAR_39_:%.+]] = arith.cmpi slt, [[VAR_38_]], [[CST_256_1_]] : index
+// CHECK:             scf.if [[VAR_39_]] {
 // CHECK:               linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[RES_1_]] : memref<256xf32>)
 // CHECK:             }
-// CHECK-DAG:         [[VAR_subview_1_:%.+]] = memref.subview [[VAR_reinterpret_cast_11_1_]][0] {{.}}[[VAR_40_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-// CHECK-DAG:         [[VAR_subview_12_1_:%.+]] = memref.subview [[RES_1_]][0] {{.}}[[VAR_40_]]{{.}} [1] : memref<256xf32> to memref<?xf32, strided<[1]>>
-// CHECK:             memref.copy [[VAR_subview_1_]], [[VAR_subview_12_1_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
-// CHECK:             [[VAR_42_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<256xf32>
-// CHECK:             [[VAR_43_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_42_]], [[VAR_14_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_42_]] : tensor<256xf32>) {
+// CHECK-DAG:         [[VAR_subview_1_:%.+]] = memref.subview [[VAR_reinterpret_cast_5_1_]][0] {{.}}[[VAR_38_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_subview_6_1_:%.+]] = memref.subview [[RES_1_]][0] {{.}}[[VAR_38_]]{{.}} [1] : memref<256xf32> to memref<?xf32, strided<[1]>>
+// CHECK:             memref.copy [[VAR_subview_1_]], [[VAR_subview_1_]]_6 : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK:             [[VAR_40_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<256xf32>
+// CHECK:             [[VAR_41_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_40_]], [[VAR_14_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_40_]] : tensor<256xf32>) {
 // CHECK:             ^bb0([[IN_10_:%.+]]: f32, [[IN_11_:%.+]]: f32, [[IN_12_:%.+]]: f32):
 // CHECK:               [[VAR_47_2_:%.+]] = arith.subf [[IN_10_]], [[IN_11_]] : f32
 // CHECK:               linalg.yield [[VAR_47_2_]] : f32
 // CHECK:             } -> tensor<256xf32>
-// CHECK:             [[VAR_44_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_33_1_]], [[VAR_43_]], [[VAR_1_]] : tensor<256xi1>, tensor<256xf32>, tensor<256xf32>) outs([[VAR_43_]] : tensor<256xf32>) {
+// CHECK:             [[VAR_42_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_31_1_]], [[VAR_41_]], [[VAR_1_]] : tensor<256xi1>, tensor<256xf32>, tensor<256xf32>) outs([[VAR_41_]] : tensor<256xf32>) {
 // CHECK:             ^bb0([[IN_13_:%.+]]: i1, [[IN_14_:%.+]]: f32, [[IN_15_:%.+]]: f32, [[IN_16_:%.+]]: f32):
 // CHECK:               [[VAR_47_3_:%.+]] = arith.select [[IN_13_]], [[IN_14_]], [[IN_15_]] : f32
 // CHECK:               linalg.yield [[VAR_47_3_]] : f32
 // CHECK:             } -> tensor<256xf32>
-// CHECK:             [[VAR_45_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_44_]], [[VAR_44_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_44_]] : tensor<256xf32>) {
+// CHECK:             [[VAR_43_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_42_]], [[VAR_42_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_42_]] : tensor<256xf32>) {
 // CHECK:             ^bb0([[IN_17_:%.+]]: f32, [[IN_18_:%.+]]: f32, [[IN_19_:%.+]]: f32):
 // CHECK:               [[VAR_47_4_:%.+]] = arith.mulf [[IN_17_]], [[IN_18_]] : f32
 // CHECK:               linalg.yield [[VAR_47_4_]] : f32
 // CHECK:             } -> tensor<256xf32>
-// CHECK:             [[VAR_46_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_arg16_1_]], [[VAR_45_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_arg16_1_]] : tensor<256xf32>) {
+// CHECK:             [[VAR_44_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_arg16_1_]], [[VAR_43_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_arg16_1_]] : tensor<256xf32>) {
 // CHECK:             ^bb0([[IN_20_:%.+]]: f32, [[IN_21_:%.+]]: f32, [[IN_22_:%.+]]: f32):
 // CHECK:               [[VAR_47_5_:%.+]] = arith.addf [[IN_20_]], [[IN_21_]] : f32
 // CHECK:               linalg.yield [[VAR_47_5_]] : f32
 // CHECK:             } -> tensor<256xf32>
-// CHECK:             scf.yield [[VAR_46_]] : tensor<256xf32>
+// CHECK:             scf.yield [[VAR_44_]] : tensor<256xf32>
 // CHECK:           }
 // CHECK:           [[VAR_16_:%.+]] = bufferization.alloc_tensor() : tensor<f32>
-// CHECK:           [[VAR_inserted_2_:%.+]] = tensor.insert [[CST_0_dot_000000_]] into [[VAR_16_]][] : tensor<f32>
-// CHECK:           [[VAR_reduced_3_:%.+]] = linalg.reduce ins([[VAR_15_]] : tensor<256xf32>) outs([[VAR_inserted_2_]] : tensor<f32>) dimensions = [0]
+// CHECK:           [[VAR_inserted_1_:%.+]] = tensor.insert [[CST_0_dot_000000_]] into [[VAR_16_]][] : tensor<f32>
+// CHECK:           [[VAR_reduced_2_:%.+]] = linalg.reduce ins([[VAR_15_]] : tensor<256xf32>) outs([[VAR_inserted_1_]] : tensor<f32>) dimensions = [0]
 // CHECK:             ([[IN_20_:%.+]]: f32, [[init_:%.+]]: f32) {
 // CHECK:               [[VAR_29_4_:%.+]] = arith.addf [[IN_20_]], [[init_]] : f32
 // CHECK:               linalg.yield [[VAR_29_4_]] : f32
 // CHECK:             }
-// CHECK:           [[VAR_extracted_4_:%.+]] = tensor.extract [[VAR_reduced_3_]][] : tensor<f32>
-// CHECK:           [[VAR_17_:%.+]] = arith.divf [[VAR_extracted_4_]], [[VAR_7_]] : f32
+// CHECK:           [[VAR_extracted_3_:%.+]] = tensor.extract [[VAR_reduced_2_]][] : tensor<f32>
+// CHECK:           [[VAR_17_:%.+]] = arith.divf [[VAR_extracted_3_]], [[VAR_7_]] : f32
 // CHECK:           [[VAR_18_:%.+]] = arith.addf [[VAR_17_]], [[PARAM_8_]] : f32
 // CHECK:           [[VAR_19_:%.+]] = math.sqrt [[VAR_18_]] : f32
 // CHECK-DAG:       [[VAR_20_:%.+]] = arith.divf [[CST_1_dot_000000_]], [[VAR_19_]] : f32
 // CHECK-DAG:       [[VAR_21_:%.+]] = arith.index_cast [[PARAM_12_]] : i32 to index
-// CHECK:           [[base_buffer_:%.+]], [[offset_:%.+]], [[sizes_:%.+]], [[VAR_strides_:%.+]] = memref.extract_strided_metadata [[VAR_reinterpret_cast_1_]] : memref<1xf32, strided<[1], offset: ?>> -> memref<f32>, index, index, index
-// CHECK:           [[VAR_22_:%.+]] = arith.addi [[offset_]], [[VAR_21_]] : index
-// CHECK:           [[VAR_reinterpret_cast_5_:%.+]] = memref.reinterpret_cast [[base_buffer_]] to offset: {{.}}[[VAR_22_]]{{.}}, sizes: [1], strides: [1] : memref<f32> to memref<1xf32, strided<[1], offset: ?>>
-// CHECK:           affine.store [[VAR_8_]], [[VAR_reinterpret_cast_5_]][0] : memref<1xf32, strided<[1], offset: ?>>
-// CHECK:           [[VAR_23_:%.+]] = arith.index_cast [[PARAM_12_]] : i32 to index
-// CHECK:           [[base_buffer_6_:%.+]], [[offset_7_:%.+]], [[sizes_8_:%.+]], [[VAR_strides_9_:%.+]] = memref.extract_strided_metadata [[VAR_reinterpret_cast_]] : memref<1xf32, strided<[1], offset: ?>> -> memref<f32>, index, index, index
-// CHECK:           [[VAR_24_:%.+]] = arith.addi [[offset_7_]], [[VAR_23_]] : index
-// CHECK:           [[VAR_reinterpret_cast_10_:%.+]] = memref.reinterpret_cast [[base_buffer_6_]] to offset: {{.}}[[VAR_24_]]{{.}}, sizes: [1], strides: [1] : memref<f32> to memref<1xf32, strided<[1], offset: ?>>
-// CHECK:           affine.store [[VAR_20_]], [[VAR_reinterpret_cast_10_]][0] : memref<1xf32, strided<[1], offset: ?>>
-// CHECK:           [[VAR_25_:%.+]] = tensor.empty() : tensor<256xf32>
-// CHECK-DAG:       [[VAR_26_:%.+]] = linalg.fill ins([[VAR_8_]] : f32) outs([[VAR_25_]] : tensor<256xf32>) -> tensor<256xf32>
-// CHECK-DAG:       [[VAR_27_:%.+]] = tensor.empty() : tensor<256xf32>
-// CHECK:           [[VAR_28_:%.+]] = linalg.fill ins([[VAR_20_]] : f32) outs([[VAR_27_]] : tensor<256xf32>) -> tensor<256xf32>
+// CHECK:           [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_4_]] to offset: {{.}}[[VAR_21_]]{{.}}, sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
+// CHECK:           affine.store [[VAR_8_]], [[VAR_reinterpret_cast_]][0] : memref<1xf32, strided<[1], offset: ?>>
+// CHECK:           [[VAR_22_:%.+]] = arith.index_cast [[PARAM_12_]] : i32 to index
+// CHECK:           [[VAR_reinterpret_cast_4_:%.+]] = memref.reinterpret_cast [[PARAM_5_]] to offset: {{.}}[[VAR_22_]]{{.}}, sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
+// CHECK:           affine.store [[VAR_20_]], [[VAR_reinterpret_cast_4_]][0] : memref<1xf32, strided<[1], offset: ?>>
+// CHECK:           [[VAR_23_:%.+]] = tensor.empty() : tensor<256xf32>
+// CHECK-DAG:       [[VAR_24_:%.+]] = linalg.fill ins([[VAR_8_]] : f32) outs([[VAR_23_]] : tensor<256xf32>) -> tensor<256xf32>
+// CHECK-DAG:       [[VAR_25_:%.+]] = tensor.empty() : tensor<256xf32>
+// CHECK:           [[VAR_26_:%.+]] = linalg.fill ins([[VAR_20_]] : f32) outs([[VAR_25_]] : tensor<256xf32>) -> tensor<256xf32>
 // CHECK:           scf.for [[VAR_arg15_1_:%.+]] = [[CST_0_]] to [[PARAM_7_]] step [[CST_256_]]  : i32 {
-// CHECK:             [[VAR_29_5_:%.+]] = arith.index_cast [[VAR_arg15_1_]] : i32 to index
-// CHECK-DAG:         [[VAR_reinterpret_cast_11_2_:%.+]] = memref.reinterpret_cast [[PARAM_2_]] to offset: {{.}}[[VAR_29_5_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
-// CHECK-DAG:         [[VAR_30_3_:%.+]] = arith.index_cast [[VAR_arg15_1_]] : i32 to index
+// CHECK:             [[VAR_27_5_:%.+]] = arith.index_cast [[VAR_arg15_1_]] : i32 to index
+// CHECK-DAG:         [[VAR_reinterpret_cast_5_2_:%.+]] = memref.reinterpret_cast [[PARAM_2_]] to offset: {{.}}[[VAR_27_5_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_28_3_:%.+]] = arith.index_cast [[VAR_arg15_1_]] : i32 to index
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_31_2_:%.+]] = arith.addi [[VAR_30_3_]], [[CST_256_1_]] : index
-// CHECK-DAG:         [[VAR_32_2_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
-// CHECK:             [[VAR_33_2_:%.+]] = arith.minsi [[VAR_31_2_]], [[VAR_32_2_]] : index
-// CHECK-DAG:         [[VAR_34_2_:%.+]] = arith.subi [[VAR_33_2_]], [[VAR_30_3_]] : index
+// CHECK-DAG:         [[VAR_29_2_:%.+]] = arith.addi [[VAR_28_3_]], [[CST_256_1_]] : index
+// CHECK-DAG:         [[VAR_30_2_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
+// CHECK:             [[VAR_31_2_:%.+]] = arith.minsi [[VAR_29_2_]], [[VAR_30_2_]] : index
+// CHECK-DAG:         [[VAR_32_2_:%.+]] = arith.subi [[VAR_31_2_]], [[VAR_28_3_]] : index
 // CHECK-DAG:         [[RES_2_:%.+]] = memref.alloc() : memref<256xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_subview_2_:%.+]] = memref.subview [[VAR_reinterpret_cast_11_2_]][0] {{.}}[[VAR_34_2_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-// CHECK-DAG:         [[VAR_subview_12_2_:%.+]] = memref.subview [[RES_2_]][0] {{.}}[[VAR_34_2_]]{{.}} [1] : memref<256xf32> to memref<?xf32, strided<[1]>>
-// CHECK:             memref.copy [[VAR_subview_2_]], [[VAR_subview_12_2_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
-// CHECK-DAG:         [[VAR_35_2_:%.+]] = bufferization.to_tensor [[RES_2_]] restrict writable : memref<256xf32>
-// CHECK-DAG:         [[VAR_36_2_:%.+]] = arith.index_cast [[VAR_arg15_1_]] : i32 to index
+// CHECK-DAG:         [[VAR_subview_2_:%.+]] = memref.subview [[VAR_reinterpret_cast_5_2_]][0] {{.}}[[VAR_32_2_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_subview_6_2_:%.+]] = memref.subview [[RES_2_]][0] {{.}}[[VAR_32_2_]]{{.}} [1] : memref<256xf32> to memref<?xf32, strided<[1]>>
+// CHECK:             memref.copy [[VAR_subview_2_]], [[VAR_subview_2_]]_6 : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:         [[VAR_33_2_:%.+]] = bufferization.to_tensor [[RES_2_]] restrict writable : memref<256xf32>
+// CHECK-DAG:         [[VAR_34_2_:%.+]] = arith.index_cast [[VAR_arg15_1_]] : i32 to index
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_reinterpret_cast_13_:%.+]] = memref.reinterpret_cast [[PARAM_3_]] to offset: {{.}}[[VAR_36_2_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
-// CHECK-DAG:         [[VAR_37_2_:%.+]] = arith.index_cast [[VAR_arg15_1_]] : i32 to index
+// CHECK-DAG:         [[VAR_reinterpret_cast_7_:%.+]] = memref.reinterpret_cast [[PARAM_3_]] to offset: {{.}}[[VAR_34_2_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_35_2_:%.+]] = arith.index_cast [[VAR_arg15_1_]] : i32 to index
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_38_2_:%.+]] = arith.addi [[VAR_37_2_]], [[CST_256_1_]] : index
-// CHECK-DAG:         [[VAR_39_2_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
-// CHECK:             [[VAR_40_1_:%.+]] = arith.minsi [[VAR_38_2_]], [[VAR_39_2_]] : index
-// CHECK-DAG:         [[VAR_41_1_:%.+]] = arith.subi [[VAR_40_1_]], [[VAR_37_2_]] : index
+// CHECK-DAG:         [[VAR_36_2_:%.+]] = arith.addi [[VAR_35_2_]], [[CST_256_1_]] : index
+// CHECK-DAG:         [[VAR_37_2_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
+// CHECK:             [[VAR_38_1_:%.+]] = arith.minsi [[VAR_36_2_]], [[VAR_37_2_]] : index
+// CHECK-DAG:         [[VAR_39_1_:%.+]] = arith.subi [[VAR_38_1_]], [[VAR_35_2_]] : index
 // CHECK-DAG:         [[RES_3_:%.+]] = memref.alloc() : memref<256xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_subview_15_:%.+]] = memref.subview [[VAR_reinterpret_cast_13_]][0] {{.}}[[VAR_41_1_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-// CHECK-DAG:         [[VAR_subview_16_:%.+]] = memref.subview [[RES_3_]][0] {{.}}[[VAR_41_1_]]{{.}} [1] : memref<256xf32> to memref<?xf32, strided<[1]>>
-// CHECK:             memref.copy [[VAR_subview_15_]], [[VAR_subview_16_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
-// CHECK-DAG:         [[VAR_42_1_:%.+]] = bufferization.to_tensor [[RES_3_]] restrict writable : memref<256xf32>
+// CHECK-DAG:         [[VAR_subview_9_:%.+]] = memref.subview [[VAR_reinterpret_cast_7_]][0] {{.}}[[VAR_39_1_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_subview_10_:%.+]] = memref.subview [[RES_3_]][0] {{.}}[[VAR_39_1_]]{{.}} [1] : memref<256xf32> to memref<?xf32, strided<[1]>>
+// CHECK:             memref.copy [[VAR_subview_9_]], [[VAR_subview_10_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:         [[VAR_40_1_:%.+]] = bufferization.to_tensor [[RES_3_]] restrict writable : memref<256xf32>
+// CHECK-DAG:         [[VAR_41_1_:%.+]] = arith.index_cast [[VAR_arg15_1_]] : i32 to index
+// CHECK:             [[VAR_42_1_:%.+]] = arith.addi [[VAR_3_]], [[VAR_41_1_]] : index
+// CHECK-DAG:         [[VAR_reinterpret_cast_11_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_42_1_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
 // CHECK-DAG:         [[VAR_43_1_:%.+]] = arith.index_cast [[VAR_arg15_1_]] : i32 to index
-// CHECK:             [[VAR_44_1_:%.+]] = arith.addi [[VAR_3_]], [[VAR_43_1_]] : index
-// CHECK-DAG:         [[VAR_reinterpret_cast_17_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_44_1_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
-// CHECK-DAG:         [[VAR_45_1_:%.+]] = arith.index_cast [[VAR_arg15_1_]] : i32 to index
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_46_1_:%.+]] = arith.addi [[VAR_45_1_]], [[CST_256_1_]] : index
-// CHECK-DAG:         [[VAR_47_6_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
-// CHECK:             [[VAR_48_:%.+]] = arith.minsi [[VAR_46_1_]], [[VAR_47_6_]] : index
-// CHECK-DAG:         [[VAR_49_:%.+]] = arith.subi [[VAR_48_]], [[VAR_45_1_]] : index
+// CHECK-DAG:         [[VAR_44_1_:%.+]] = arith.addi [[VAR_43_1_]], [[CST_256_1_]] : index
+// CHECK-DAG:         [[VAR_45_6_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
+// CHECK:             [[VAR_46_:%.+]] = arith.minsi [[VAR_44_1_]], [[VAR_45_6_]] : index
+// CHECK-DAG:         [[VAR_47_:%.+]] = arith.subi [[VAR_46_]], [[VAR_43_1_]] : index
 // CHECK-DAG:         [[RES_4_:%.+]] = memref.alloc() : memref<256xf32>
-// CHECK:             [[VAR_50_:%.+]] = arith.cmpi slt, [[VAR_49_]], [[CST_256_1_]] : index
-// CHECK:             scf.if [[VAR_50_]] {
+// CHECK:             [[VAR_48_:%.+]] = arith.cmpi slt, [[VAR_47_]], [[CST_256_1_]] : index
+// CHECK:             scf.if [[VAR_48_]] {
 // CHECK:               linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[RES_4_]] : memref<256xf32>)
 // CHECK:             }
-// CHECK-DAG:         [[VAR_subview_19_:%.+]] = memref.subview [[VAR_reinterpret_cast_17_]][0] {{.}}[[VAR_49_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-// CHECK-DAG:         [[VAR_subview_20_:%.+]] = memref.subview [[RES_4_]][0] {{.}}[[VAR_49_]]{{.}} [1] : memref<256xf32> to memref<?xf32, strided<[1]>>
-// CHECK:             memref.copy [[VAR_subview_19_]], [[VAR_subview_20_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
-// CHECK:             [[VAR_51_:%.+]] = bufferization.to_tensor [[RES_4_]] restrict writable : memref<256xf32>
-// CHECK:             [[VAR_52_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_51_]], [[VAR_26_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_51_]] : tensor<256xf32>) {
+// CHECK-DAG:         [[VAR_subview_13_:%.+]] = memref.subview [[VAR_reinterpret_cast_11_]][0] {{.}}[[VAR_47_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_subview_14_:%.+]] = memref.subview [[RES_4_]][0] {{.}}[[VAR_47_]]{{.}} [1] : memref<256xf32> to memref<?xf32, strided<[1]>>
+// CHECK:             memref.copy [[VAR_subview_13_]], [[VAR_subview_14_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK:             [[VAR_49_:%.+]] = bufferization.to_tensor [[RES_4_]] restrict writable : memref<256xf32>
+// CHECK:             [[VAR_50_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_49_]], [[VAR_24_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_49_]] : tensor<256xf32>) {
 // CHECK:             ^bb0([[IN_23_:%.+]]: f32, [[IN_24_:%.+]]: f32, [[IN_25_:%.+]]: f32):
 // CHECK:               [[VAR_63_:%.+]] = arith.subf [[IN_23_]], [[IN_24_]] : f32
 // CHECK:               linalg.yield [[VAR_63_]] : f32
 // CHECK:             } -> tensor<256xf32>
-// CHECK:             [[VAR_53_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_52_]], [[VAR_28_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_52_]] : tensor<256xf32>) {
+// CHECK:             [[VAR_51_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_50_]], [[VAR_26_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_50_]] : tensor<256xf32>) {
 // CHECK:             ^bb0([[IN_26_:%.+]]: f32, [[IN_27_:%.+]]: f32, [[IN_28_:%.+]]: f32):
 // CHECK:               [[VAR_63_1_:%.+]] = arith.mulf [[IN_26_]], [[IN_27_]] : f32
 // CHECK:               linalg.yield [[VAR_63_1_]] : f32
 // CHECK:             } -> tensor<256xf32>
-// CHECK:             [[VAR_54_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_53_]], [[VAR_35_2_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_53_]] : tensor<256xf32>) {
+// CHECK:             [[VAR_52_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_51_]], [[VAR_33_2_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_51_]] : tensor<256xf32>) {
 // CHECK:             ^bb0([[IN_29_:%.+]]: f32, [[IN_30_:%.+]]: f32, [[IN_31_:%.+]]: f32):
 // CHECK:               [[VAR_63_2_:%.+]] = arith.mulf [[IN_29_]], [[IN_30_]] : f32
 // CHECK:               linalg.yield [[VAR_63_2_]] : f32
 // CHECK:             } -> tensor<256xf32>
-// CHECK:             [[VAR_55_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_54_]], [[VAR_42_1_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_54_]] : tensor<256xf32>) {
+// CHECK:             [[VAR_53_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_52_]], [[VAR_40_1_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_52_]] : tensor<256xf32>) {
 // CHECK:             ^bb0([[IN_32_:%.+]]: f32, [[IN_33_:%.+]]: f32, [[IN_34_:%.+]]: f32):
 // CHECK:               [[VAR_63_3_:%.+]] = arith.addf [[IN_32_]], [[IN_33_]] : f32
 // CHECK:               linalg.yield [[VAR_63_3_]] : f32
 // CHECK:             } -> tensor<256xf32>
-// CHECK:             [[VAR_56_:%.+]] = arith.index_cast [[VAR_arg15_1_]] : i32 to index
-// CHECK:             [[VAR_57_:%.+]] = arith.addi [[VAR_4_]], [[VAR_56_]] : index
-// CHECK-DAG:         [[VAR_reinterpret_cast_21_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_57_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
-// CHECK-DAG:         [[VAR_58_:%.+]] = arith.index_cast [[VAR_arg15_1_]] : i32 to index
+// CHECK:             [[VAR_54_:%.+]] = arith.index_cast [[VAR_arg15_1_]] : i32 to index
+// CHECK:             [[VAR_55_:%.+]] = arith.addi [[VAR_4_]], [[VAR_54_]] : index
+// CHECK-DAG:         [[VAR_reinterpret_cast_15_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_55_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_56_:%.+]] = arith.index_cast [[VAR_arg15_1_]] : i32 to index
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_59_:%.+]] = arith.addi [[VAR_58_]], [[CST_256_1_]] : index
-// CHECK-DAG:         [[VAR_60_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
-// CHECK:             [[VAR_61_:%.+]] = arith.minsi [[VAR_59_]], [[VAR_60_]] : index
-// CHECK:             [[VAR_62_:%.+]] = arith.subi [[VAR_61_]], [[VAR_58_]] : index
-// CHECK-DAG:         [[VAR_extracted_slice_:%.+]] = tensor.extract_slice [[VAR_55_]][0] {{.}}[[VAR_62_]]{{.}} [1] : tensor<256xf32> to tensor<?xf32>
-// CHECK-DAG:         [[VAR_subview_22_:%.+]] = memref.subview [[VAR_reinterpret_cast_21_]][0] {{.}}[[VAR_62_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-// CHECK:             bufferization.materialize_in_destination [[VAR_extracted_slice_]] in writable [[VAR_subview_22_]] : (tensor<?xf32>, memref<?xf32, strided<[1], offset: ?>>) -> ()
+// CHECK-DAG:         [[VAR_57_:%.+]] = arith.addi [[VAR_56_]], [[CST_256_1_]] : index
+// CHECK-DAG:         [[VAR_58_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
+// CHECK:             [[VAR_59_:%.+]] = arith.minsi [[VAR_57_]], [[VAR_58_]] : index
+// CHECK:             [[VAR_60_:%.+]] = arith.subi [[VAR_59_]], [[VAR_56_]] : index
+// CHECK-DAG:         [[VAR_extracted_slice_:%.+]] = tensor.extract_slice [[VAR_53_]][0] {{.}}[[VAR_60_]]{{.}} [1] : tensor<256xf32> to tensor<?xf32>
+// CHECK-DAG:         [[VAR_subview_16_:%.+]] = memref.subview [[VAR_reinterpret_cast_15_]][0] {{.}}[[VAR_60_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK:             bufferization.materialize_in_destination [[VAR_extracted_slice_]] in writable [[VAR_subview_16_]] : (tensor<?xf32>, memref<?xf32, strided<[1], offset: ?>>) -> ()
 // CHECK:           }
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/StructuredToMemref/scalar_store_loop_iterargs.mlir
+++ b/test/Conversion/StructuredToMemref/scalar_store_loop_iterargs.mlir
@@ -24,26 +24,24 @@ module {
 // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : i32
 // CHECK-DAG:       [[CST_5_:%.+]] = arith.constant 5 : i32
 // CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : i32
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: [0], sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
 // CHECK-DAG:       [[VAR_0_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
 // CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
-// CHECK:           [[base_buffer_:%.+]], [[offset_:%.+]], [[sizes_:%.+]], [[VAR_strides_:%.+]] = memref.extract_strided_metadata [[VAR_reinterpret_cast_]] : memref<1xf32, strided<[1], offset: ?>> -> memref<f32>, index, index, index
-// CHECK:           [[VAR_2_:%.+]] = arith.addi [[offset_]], [[VAR_1_]] : index
-// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[base_buffer_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [1], strides: [1] : memref<f32> to memref<1xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_3_:%.+]] = arith.sitofp [[PARAM_7_]] : i32 to f32
-// CHECK-DAG:       [[VAR_4_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
-// CHECK:           [[VAR_5_:%.+]]:3 = scf.for [[VAR_arg10_:%.+]] = [[CST_0_]] to [[CST_5_]] step [[CST_1_]] iter_args([[VAR_arg11_:%.+]] = [[VAR_reinterpret_cast_0_]], [[VAR_arg12_:%.+]] = [[VAR_0_]], [[VAR_arg13_:%.+]] = [[VAR_4_]]) -> (memref<1xf32, strided<[1], offset: ?>>, index, index)  : i32 {
-// CHECK:             affine.store [[VAR_3_]], [[VAR_arg11_]][0] : memref<1xf32, strided<[1], offset: ?>>
-// CHECK:             [[VAR_6_:%.+]] = arith.index_cast [[VAR_arg10_]] : i32 to index
-// CHECK:             [[base_buffer_1_:%.+]], [[offset_2_:%.+]], [[sizes_3_:%.+]], [[VAR_strides_4_:%.+]] = memref.extract_strided_metadata [[VAR_arg11_]] : memref<1xf32, strided<[1], offset: ?>> -> memref<f32>, index, index, index
-// CHECK:             [[VAR_7_:%.+]] = arith.addi [[offset_2_]], [[VAR_6_]] : index
-// CHECK-DAG:         [[VAR_reinterpret_cast_5_:%.+]] = memref.reinterpret_cast [[base_buffer_1_]] to offset: {{.}}[[VAR_7_]]{{.}}, sizes: [1], strides: [1] : memref<f32> to memref<1xf32, strided<[1], offset: ?>>
-// CHECK-DAG:         [[VAR_8_:%.+]] = arith.index_cast [[VAR_arg10_]] : i32 to index
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_9_:%.+]] = arith.addi [[VAR_arg12_]], [[VAR_8_]] : index
-// CHECK-DAG:         [[VAR_10_:%.+]] = arith.index_cast [[VAR_arg10_]] : i32 to index
-// CHECK:             [[VAR_11_:%.+]] = arith.addi [[VAR_arg13_]], [[VAR_10_]] : index
-// CHECK:             scf.yield [[VAR_reinterpret_cast_5_]], [[VAR_9_]], [[VAR_11_]] : memref<1xf32, strided<[1], offset: ?>>, index, index
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.sitofp [[PARAM_7_]] : i32 to f32
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
+// CHECK:           [[VAR_4_:%.+]]:3 = scf.for [[VAR_arg10_:%.+]] = [[CST_0_]] to [[CST_5_]] step [[CST_1_]] iter_args([[VAR_arg11_:%.+]] = [[VAR_reinterpret_cast_]], [[VAR_arg12_:%.+]] = [[VAR_0_]], [[VAR_arg13_:%.+]] = [[VAR_3_]]) -> (memref<1xf32, strided<[1], offset: ?>>, index, index)  : i32 {
+// CHECK:             affine.store [[VAR_2_]], [[VAR_arg11_]][0] : memref<1xf32, strided<[1], offset: ?>>
+// CHECK:             [[VAR_5_:%.+]] = arith.index_cast [[VAR_arg10_]] : i32 to index
+// CHECK:             [[base_buffer_:%.+]], [[offset_:%.+]], [[sizes_:%.+]], [[VAR_strides_:%.+]] = memref.extract_strided_metadata [[VAR_arg11_]] : memref<1xf32, strided<[1], offset: ?>> -> memref<f32>, index, index, index
+// CHECK:             [[VAR_6_:%.+]] = arith.addi [[offset_]], [[VAR_5_]] : index
+// CHECK-DAG:         [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[base_buffer_]] to offset: {{.}}[[VAR_6_]]{{.}}, sizes: [1], strides: [1] : memref<f32> to memref<1xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_7_:%.+]] = arith.index_cast [[VAR_arg10_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_8_:%.+]] = arith.addi [[VAR_arg12_]], [[VAR_7_]] : index
+// CHECK-DAG:         [[VAR_9_:%.+]] = arith.index_cast [[VAR_arg10_]] : i32 to index
+// CHECK:             [[VAR_10_:%.+]] = arith.addi [[VAR_arg13_]], [[VAR_9_]] : index
+// CHECK:             scf.yield [[VAR_reinterpret_cast_0_]], [[VAR_8_]], [[VAR_10_]] : memref<1xf32, strided<[1], offset: ?>>, index, index
 // CHECK:           }
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/StructuredToMemref/scalar_store_nested_loop.mlir
+++ b/test/Conversion/StructuredToMemref/scalar_store_nested_loop.mlir
@@ -28,22 +28,19 @@ module {
 // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : i32
 // CHECK-DAG:       [[CST_8_:%.+]] = arith.constant 8 : i32
 // CHECK-DAG:       [[CST_2_:%.+]] = arith.constant 2 : i32
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
 // CHECK-DAG:       [[VAR_0_:%.+]] = arith.index_cast [[PARAM_4_]] : i32 to index
-// CHECK:           [[base_buffer_:%.+]], [[offset_:%.+]], [[sizes_:%.+]], [[VAR_strides_:%.+]] = memref.extract_strided_metadata [[VAR_reinterpret_cast_]] : memref<1xf32, strided<[1], offset: ?>> -> memref<f32>, index, index, index
-// CHECK:           [[VAR_1_:%.+]] = arith.addi [[offset_]], [[VAR_0_]] : index
-// CHECK:           [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[base_buffer_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [1], strides: [1] : memref<f32> to memref<1xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_2_:%.+]] = scf.for [[VAR_arg7_:%.+]] = [[CST_0_]] to [[CST_8_]] step [[CST_1_1_]] iter_args([[VAR_arg8_:%.+]] = [[VAR_reinterpret_cast_0_]]) -> (memref<1xf32, strided<[1], offset: ?>>)  : i32 {
-// CHECK-DAG:         [[VAR_3_:%.+]] = scf.for [[VAR_arg9_:%.+]] = [[CST_0_]] to [[CST_2_]] step [[CST_1_1_]] iter_args([[VAR_arg10_:%.+]] = [[VAR_arg8_]]) -> (memref<1xf32, strided<[1], offset: ?>>)  : i32 {
-// CHECK-DAG:           [[VAR_4_:%.+]] = arith.muli [[VAR_arg7_]], [[VAR_arg9_]] : i32
-// CHECK:               [[VAR_5_:%.+]] = arith.sitofp [[VAR_4_]] : i32 to f32
-// CHECK:               affine.store [[VAR_5_]], [[VAR_arg10_]][0] : memref<1xf32, strided<[1], offset: ?>>
-// CHECK:               [[base_buffer_1_:%.+]], [[offset_2_:%.+]], [[sizes_3_:%.+]], [[VAR_strides_4_:%.+]] = memref.extract_strided_metadata [[VAR_arg10_]] : memref<1xf32, strided<[1], offset: ?>> -> memref<f32>, index, index, index
-// CHECK:               [[VAR_6_:%.+]] = arith.addi [[offset_2_]], [[CST_1_]] : index
-// CHECK:               [[VAR_reinterpret_cast_5_:%.+]] = memref.reinterpret_cast [[base_buffer_1_]] to offset: {{.}}[[VAR_6_]]{{.}}, sizes: [1], strides: [1] : memref<f32> to memref<1xf32, strided<[1], offset: ?>>
-// CHECK:               scf.yield [[VAR_reinterpret_cast_5_]] : memref<1xf32, strided<[1], offset: ?>>
+// CHECK:           [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_0_]]{{.}}, sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_1_:%.+]] = scf.for [[VAR_arg7_:%.+]] = [[CST_0_]] to [[CST_8_]] step [[CST_1_1_]] iter_args([[VAR_arg8_:%.+]] = [[VAR_reinterpret_cast_]]) -> (memref<1xf32, strided<[1], offset: ?>>)  : i32 {
+// CHECK-DAG:         [[VAR_2_:%.+]] = scf.for [[VAR_arg9_:%.+]] = [[CST_0_]] to [[CST_2_]] step [[CST_1_1_]] iter_args([[VAR_arg10_:%.+]] = [[VAR_arg8_]]) -> (memref<1xf32, strided<[1], offset: ?>>)  : i32 {
+// CHECK-DAG:           [[VAR_3_:%.+]] = arith.muli [[VAR_arg7_]], [[VAR_arg9_]] : i32
+// CHECK:               [[VAR_4_:%.+]] = arith.sitofp [[VAR_3_]] : i32 to f32
+// CHECK:               affine.store [[VAR_4_]], [[VAR_arg10_]][0] : memref<1xf32, strided<[1], offset: ?>>
+// CHECK:               [[base_buffer_:%.+]], [[offset_:%.+]], [[sizes_:%.+]], [[VAR_strides_:%.+]] = memref.extract_strided_metadata [[VAR_arg10_]] : memref<1xf32, strided<[1], offset: ?>> -> memref<f32>, index, index, index
+// CHECK:               [[VAR_5_:%.+]] = arith.addi [[offset_]], [[CST_1_]] : index
+// CHECK:               [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[base_buffer_]] to offset: {{.}}[[VAR_5_]]{{.}}, sizes: [1], strides: [1] : memref<f32> to memref<1xf32, strided<[1], offset: ?>>
+// CHECK:               scf.yield [[VAR_reinterpret_cast_0_]] : memref<1xf32, strided<[1], offset: ?>>
 // CHECK:             }
-// CHECK:             scf.yield [[VAR_3_]] : memref<1xf32, strided<[1], offset: ?>>
+// CHECK:             scf.yield [[VAR_2_]] : memref<1xf32, strided<[1], offset: ?>>
 // CHECK:           }
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/StructuredToMemref/scalar_store_no_iterargs.mlir
+++ b/test/Conversion/StructuredToMemref/scalar_store_no_iterargs.mlir
@@ -20,18 +20,13 @@ module {
 // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : i32
 // CHECK-DAG:       [[CST_5_:%.+]] = arith.constant 5 : i32
 // CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : i32
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: [0], sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
 // CHECK-DAG:       [[VAR_0_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
-// CHECK:           [[base_buffer_:%.+]], [[offset_:%.+]], [[sizes_:%.+]], [[VAR_strides_:%.+]] = memref.extract_strided_metadata [[VAR_reinterpret_cast_]] : memref<1xf32, strided<[1], offset: ?>> -> memref<f32>, index, index, index
-// CHECK:           [[VAR_1_:%.+]] = arith.addi [[offset_]], [[VAR_0_]] : index
-// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[base_buffer_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [1], strides: [1] : memref<f32> to memref<1xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_2_:%.+]] = arith.sitofp [[PARAM_7_]] : i32 to f32
+// CHECK-DAG:       [[VAR_1_:%.+]] = arith.sitofp [[PARAM_7_]] : i32 to f32
 // CHECK:           scf.for [[I_0_:%.+]] = [[CST_0_]] to [[CST_5_]] step [[CST_1_]]  : i32 {
-// CHECK:             [[VAR_3_:%.+]] = arith.index_cast [[I_0_]] : i32 to index
-// CHECK:             [[base_buffer_1_:%.+]], [[offset_2_:%.+]], [[sizes_3_:%.+]], [[VAR_strides_4_:%.+]] = memref.extract_strided_metadata [[VAR_reinterpret_cast_0_]] : memref<1xf32, strided<[1], offset: ?>> -> memref<f32>, index, index, index
-// CHECK:             [[VAR_4_:%.+]] = arith.addi [[offset_2_]], [[VAR_3_]] : index
-// CHECK:             [[VAR_reinterpret_cast_5_:%.+]] = memref.reinterpret_cast [[base_buffer_1_]] to offset: {{.}}[[VAR_4_]]{{.}}, sizes: [1], strides: [1] : memref<f32> to memref<1xf32, strided<[1], offset: ?>>
-// CHECK:             affine.store [[VAR_2_]], [[VAR_reinterpret_cast_5_]][0] : memref<1xf32, strided<[1], offset: ?>>
+// CHECK:             [[VAR_2_:%.+]] = arith.index_cast [[I_0_]] : i32 to index
+// CHECK:             [[VAR_3_:%.+]] = arith.addi [[VAR_0_]], [[VAR_2_]] : index
+// CHECK:             [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_3_]]{{.}}, sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
+// CHECK:             affine.store [[VAR_1_]], [[VAR_reinterpret_cast_]][0] : memref<1xf32, strided<[1], offset: ?>>
 // CHECK:           }
 // CHECK:           return
 // CHECK:         }


### PR DESCRIPTION
## Intro
We currently lower a sequence of `tt.addptr` for scalars using `memref.extract_strided_metadata` and `memref.reinterpret_cast`. To improve codegen in certain cases, this PR changes the lowering to just using `memref.reinterpret_cast` for `tt.addptr` outside of loops. For `tt.addptr` inside loops, `memref.extract_strided_metadata` is still used to avoid having to carry the pointer offset in the loops' iter args.
 
## Background
In `triton-to-linalg-experimental`, when lowering `%new_ptr = tt.addptr %base_ptr %add_offset` for scalars, `%base_ptr` is lowered to a `memref` using a `memref.reinterpret_cast` op with a certain offset `%curr_offset`. If `%ptr` comes from the function arguments, we assume that the `%curr_offset` is `0`. Then `%new_ptr` is lowered to another `memref` using `memref.reinterpret_cast` with offset `%curr_offset` + `%add_offset`.

With this approach, each `memref.reinterpret_cast` that's lowered from a `tt.addptr` has to know the current offset of `%base_ptr` and perform a pointer addition to get the new offset.

`memref.extract_strided_metadata` can be used to extract the offset from a memref. Then the pointer addition can be done by a simple `arith.addi`.

Doing so is particularly helpful when lowering `tt.addptr` in loops, because we don't have to carry the buffer offsets as induction variables -- the offsets can be retrieved just by calling `memref.extract_strided_metadata`.


## Improvements
With the current approach, the generated code might not be optimal and prevents certain optimizations through canonicalization from kicking in:

```
%0 = memref.reinterpret_cast %arg0 with offset 0

%base, %offset, %size, %stride = memref.extract_strided_metadata %0 : memref<1xf32>, index, index, index

%new_offset = arith.addi %offset %add_offset
%1 = memref.reinterpret_cast %base with offset %new_offset
```

this can actually be simplified to:

```
%1 = memref.reinterpret_cast %base with offset %add_offset
```

When lowering `tt.addptr` not in any loops, to get the current offset the buffer, we can look at the defining op of the buffer which must be a `memref.reinterpret_cast`. So, in the example, we will end up with the following code:

```
%0 = memref.reinterpret_cast %arg0 with offset 0
%new_offset = arith.addi %offset %add_offset
%1 = memref.reinterpret_cast %base with offset %new_offset
```

After canonicalization, we will get:

```
%1 = memref.reinterpret_cast %base with offset %add_offset
```