### PR TITLE
Fixes for nightly build

### DIFF
--- a/backend/compiler.py
+++ b/backend/compiler.py
@@ -1,7 +1,7 @@
 from triton.backends.compiler import BaseBackend
 from triton._C.libtriton import ir, passes
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Tuple
 import hashlib
 import tempfile
 import os
@@ -120,6 +120,7 @@ class CPUOptions:
     cluster_dims: tuple = (1, 1, 1)
     shared: bool = False
     allow_fp8e4nv: bool = False
+    allowed_dot_input_precisions: Tuple[str] = ("ieee", )
 
     def __post_init__(self):
         pass

--- a/backend/driver.py
+++ b/backend/driver.py
@@ -22,6 +22,9 @@ def _ty_to_cpp(ty):
         "i16": "int16_t",
         "i32": "int32_t",
         "i64": "int64_t",
+        "u1": "uint32_t",
+        "u8": "uint8_t",
+        "u16": "uint16_t",
         "u32": "uint32_t",
         "u64": "uint64_t",
         "fp16": "float",
@@ -31,37 +34,32 @@ def _ty_to_cpp(ty):
         "fp64": "double",
     }[ty]
 
-def _extracted_ty(ty):
+def _extracted_type(ty):
     if ty[0] == '*':
         return "PyObject*"
-    return {
-        'i1': 'int32_t',
-        'i32': 'int32_t',
-        'i64': 'int64_t',
-        'u32': 'uint32_t',
-        'u64': 'uint64_t',
-        'fp16': 'float',
-        'bf16': 'float',
-        'fp32': 'float',
-        'f32': 'float',
-        'fp64': 'double',
-    }[ty]
+    return _ty_to_cpp(ty)
 
 def _format_of(ty):
     return {
-        "PyObject*": "O",
-        "float": "f",
-        "double": "d",
-        "long": "l",
-        "uint32_t": "I",
-        "int32_t": "i",
-        "uint64_t": "K",
-        "int64_t": "L",
+      "PyObject*": "O",
+      "float": "f",
+      "double": "d",
+      "long": "l",
+      "int8_t": "b",
+      "int16_t": "h",
+      "int32_t": "i",
+      "int64_t": "l",
+      "uint8_t": "B",
+      "uint16_t": "H",
+      "uint32_t": "I",
+      "uint64_t": "K",
     }[ty]
 
 def _generate_launcher(constants, signature, kernel_name):
     arg_decls = ', '.join(f"{_ty_to_cpp(ty)} arg{i}" for i, ty in signature.items())
-    format = "iiiOOO" + ''.join([_format_of(_extracted_ty(ty)) for ty in signature.values()])
+    args_format = ''.join([_format_of(_extracted_type(ty)) for ty in signature.values()])
+    format = "iiiOOOO" + args_format
+    args_list = ', ' + ', '.join(f"&_arg{i}" for i, ty in signature.items()) if len(signature) > 0 else ''
     return f"""
 #include <assert.h>
 #include <stdbool.h>
@@ -134,15 +132,37 @@ static PyObject* launch(PyObject* self, PyObject* args) {{
   int gridX, gridY, gridZ;
   PyObject *launch_enter_hook = NULL;
   PyObject *launch_exit_hook = NULL;
-  PyObject *metadata = NULL;
-  {' '.join([f"{_extracted_ty(ty)} _arg{i}; " for i, ty in signature.items()])}
-  if(!PyArg_ParseTuple(args, \"{format}\", &gridX, &gridY, &gridZ, &launch_enter_hook, &launch_exit_hook, &metadata
-                       {', ' + ', '.join(f"&_arg{i}" for i, ty in signature.items()) if len(signature) > 0 else ''})) {{
+  PyObject *kernel_metadata = NULL;
+  PyObject *launch_metadata = NULL;
+  {' '.join([f"{_extracted_type(ty)} _arg{i}; " for i, ty in signature.items()])}
+  if(!PyArg_ParseTuple(args, \"{format}\", &gridX, &gridY, &gridZ,
+                                           &kernel_metadata, &launch_metadata,
+                                           &launch_enter_hook, &launch_exit_hook {args_list})) {{
     return NULL;
   }}
 
-  if (launch_enter_hook != Py_None && !PyObject_CallObject(launch_enter_hook, args)) {{
+  // extract kernel metadata
+  int num_warps     = PyLong_AsLong(PyObject_GetAttrString(kernel_metadata, "num_warps"));
+  int num_ctas      = PyLong_AsLong(PyObject_GetAttrString(kernel_metadata, "num_ctas"));
+  int shared_memory = PyLong_AsLong(PyObject_GetAttrString(kernel_metadata, "shared"));
+
+  // extract cluster dims
+  PyObject *clusterDim =  PyObject_GetAttrString(kernel_metadata, "cluster_dims");
+  if (!PyTuple_Check(kernel_metadata)) {{
+    PyErr_SetString(PyExc_TypeError, "kernel_metadata.cluster_dims must be a tuple");
     return NULL;
+  }}
+  int clusterDimX   = PyLong_AsLong(PyTuple_GetItem(clusterDim, 0));
+  int clusterDimY   = PyLong_AsLong(PyTuple_GetItem(clusterDim, 1));
+  int clusterDimZ   = PyLong_AsLong(PyTuple_GetItem(clusterDim, 2));
+
+  // extract launch metadata
+  if (launch_enter_hook != Py_None){{
+    PyObject* args = Py_BuildValue("(O)", launch_metadata);
+    PyObject* ret = PyObject_CallObject(launch_enter_hook, args);
+    Py_DECREF(args);
+    if (!ret)
+      return NULL;
   }}
 
   // raise exception asap
@@ -152,8 +172,12 @@ static PyObject* launch(PyObject* self, PyObject* args) {{
   if (PyErr_Occurred()) {{
     return NULL;
   }}
-  if (launch_exit_hook != Py_None && !PyObject_CallObject(launch_exit_hook, args)) {{
-    return NULL;
+  if(launch_exit_hook != Py_None){{
+    PyObject* args = Py_BuildValue("(O)", launch_metadata);
+    PyObject* ret = PyObject_CallObject(launch_exit_hook, args);
+    Py_DECREF(args);
+    if (!ret)
+      return NULL;
   }}
 
   // return None
@@ -200,15 +224,15 @@ def compile_module(launcher_src, kernel_placeholder_name):
     include_dir = os.path.join(cpu_backend_path, "include")
 
     def launch(
-        gridX, gridY, gridZ, num_warps, num_ctas, clusterDim0, clusterDim1, clusterDim2,
-        shared, stream, cu_function, launch_enter_hook, launch_exit_hook, metadata,
-        *args):
+        gridX, gridY, gridZ, stream, cu_function,
+        kernel_metadata, launch_metadata,
+        launch_enter_hook, launch_exit_hook, *args):
         # Unlike CUDA/HIP, we cannot easily pass function pointer across different pybind libraries.
         # Let's compile a kernel every time.
         # The cu_function parameter actually contains our assembly source code.
         # See CPUUtils.load_binary method.
         asm_src = cu_function
-        src = launcher_src.replace(kernel_placeholder_name, metadata.name)
+        src = launcher_src.replace(kernel_placeholder_name, kernel_metadata.name)
 
         key = hashlib.md5(src.encode("utf-8")).hexdigest()
         cache = get_cache_manager(key)
@@ -237,7 +261,10 @@ def compile_module(launcher_src, kernel_placeholder_name):
         spec = importlib.util.spec_from_file_location(name, cache_path)
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)
-        return mod.launch(gridX, gridY, gridZ, launch_enter_hook, launch_exit_hook, metadata, *args)
+        return mod.launch(gridX, gridY, gridZ,
+                          kernel_metadata, launch_metadata,
+                          launch_enter_hook, launch_exit_hook,
+                          *args)
 
     return launch
 
@@ -245,10 +272,13 @@ def compile_module(launcher_src, kernel_placeholder_name):
 class CPULauncher(object):
 
     def __init__(self, src, metadata):
-        constants = src.constants if hasattr(src, "constants") else dict()
-
         kernel_placeholder_name = "KERNEL_NAME_PLACEHOLDER"
-        launcher_src = _generate_launcher(constants, src.signature, kernel_placeholder_name)
+
+        constants = src.constants if hasattr(src, "constants") else dict()
+        cst_key = lambda i: src.fn.arg_names.index(i) if isinstance(i, str) else i
+        constants = {cst_key(key): value for key, value in constants.items()}
+        signature = {cst_key(key): value for key, value in src.signature.items()}
+        launcher_src = _generate_launcher(constants, signature, kernel_placeholder_name)
         # Later KERNEL_NAME_PLACEHOLDER will be used to assign the kernel name
         # in the following launch function.
         self.launch = compile_module(launcher_src, kernel_placeholder_name)

--- a/backend/driver.py
+++ b/backend/driver.py
@@ -141,6 +141,10 @@ static PyObject* launch(PyObject* self, PyObject* args) {{
     return NULL;
   }}
 
+  // [CPULauncher-specific]: We don't need the metadata below but just put them
+  // here anyway to be consistent with others.
+  // This will make updating the driver easier in the future.
+
   // extract kernel metadata
   int num_warps     = PyLong_AsLong(PyObject_GetAttrString(kernel_metadata, "num_warps"));
   int num_ctas      = PyLong_AsLong(PyObject_GetAttrString(kernel_metadata, "num_ctas"));

--- a/test/Conversion/StructuredToMemref/dot.mlir
+++ b/test/Conversion/StructuredToMemref/dot.mlir
@@ -43,7 +43,7 @@ module {
     %50 = tt.splat %arg2 : !tt.ptr<bf16> -> tensor<128x256x!tt.ptr<bf16>>
     %51 = tt.addptr %50, %26 : tensor<128x256x!tt.ptr<bf16>>, tensor<128x256xi32>
     %52 = tt.load %51 {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<128x256xbf16>
-    %60 = tt.dot %32, %43, %52 {allowTF32 = false, maxNumImpreciseAcc = 0 : i32} : tensor<128x64xbf16> * tensor<64x256xbf16> -> tensor<128x256xbf16>
+    %60 = tt.dot %32, %43, %52 {inputPrecision = 2 : i32, maxNumImpreciseAcc = 0 : i32} : tensor<128x64xbf16> * tensor<64x256xbf16> -> tensor<128x256xbf16>
     tt.store %51, %60 : tensor<128x256xbf16>
     tt.return
   }

--- a/test/Conversion/StructuredToMemref/kernel-03-matrix-multiplication.mlir
+++ b/test/Conversion/StructuredToMemref/kernel-03-matrix-multiplication.mlir
@@ -68,7 +68,7 @@ module {
     %53:3 = scf.for %arg12 = %c0_i32 to %6 step %c1_i32 iter_args(%arg13 = %48, %arg14 = %36, %arg15 = %47) -> (tensor<128x256xf32>, tensor<128x64x!tt.ptr<bf16>>, tensor<64x256x!tt.ptr<bf16>>)  : i32 {
       %71 = tt.load %arg14 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128x64xbf16>
       %72 = tt.load %arg15 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<64x256xbf16>
-      %73 = tt.dot %71, %72, %48 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<128x64xbf16> * tensor<64x256xbf16> -> tensor<128x256xf32>
+      %73 = tt.dot %71, %72, %48 {inputPrecision = 0 : i32, maxNumImpreciseAcc = 0 : i32} : tensor<128x64xbf16> * tensor<64x256xbf16> -> tensor<128x256xf32>
       %74 = arith.addf %arg13, %73 : tensor<128x256xf32>
       %75 = tt.addptr %arg14, %50 : tensor<128x64x!tt.ptr<bf16>>, tensor<128x64xi32>
       %76 = tt.addptr %arg15, %52 : tensor<64x256x!tt.ptr<bf16>>, tensor<64x256xi32>

--- a/test/Conversion/StructuredToMemref/use_dot_opc.mlir
+++ b/test/Conversion/StructuredToMemref/use_dot_opc.mlir
@@ -43,7 +43,7 @@ module {
     %51 = tt.addptr %50, %26 : tensor<128x256x!tt.ptr<bf16>>, tensor<128x256xi32>
     %cf0 = arith.constant 0.0 : bf16
     %71 = tt.splat %cf0 : bf16 -> tensor<128x256xbf16>
-    %60 = tt.dot %32, %42, %71 {allowTF32 = false, maxNumImpreciseAcc = 0 : i32} : tensor<128x64xbf16> * tensor<64x256xbf16> -> tensor<128x256xbf16>
+    %60 = tt.dot %32, %42, %71 {inputPrecision = 2 : i32, maxNumImpreciseAcc = 0 : i32} : tensor<128x64xbf16> * tensor<64x256xbf16> -> tensor<128x256xbf16>
     tt.store %51, %60 : tensor<128x256xbf16>
     tt.store %51, %71 : tensor<128x256xbf16>
     tt.return

--- a/test/Conversion/TritonArithToLinalg/dot.mlir
+++ b/test/Conversion/TritonArithToLinalg/dot.mlir
@@ -43,7 +43,7 @@ module {
     %50 = tt.splat %arg2 : !tt.ptr<bf16> -> tensor<128x256x!tt.ptr<bf16>>
     %51 = tt.addptr %50, %26 : tensor<128x256x!tt.ptr<bf16>>, tensor<128x256xi32>
     %52 = tt.load %51 {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<128x256xbf16>
-    %60 = tt.dot %32, %43, %52 {allowTF32 = false, maxNumImpreciseAcc = 0 : i32} : tensor<128x64xbf16> * tensor<64x256xbf16> -> tensor<128x256xbf16>
+    %60 = tt.dot %32, %43, %52 {inputPrecision = 2 : i32, maxNumImpreciseAcc = 0 : i32} : tensor<128x64xbf16> * tensor<64x256xbf16> -> tensor<128x256xbf16>
     tt.store %51, %60 : tensor<128x256xbf16>
     tt.return
   }

--- a/test/Conversion/TritonToLinalg/dot.mlir
+++ b/test/Conversion/TritonToLinalg/dot.mlir
@@ -43,7 +43,7 @@ module {
     %50 = tt.splat %arg2 : !tt.ptr<bf16> -> tensor<128x256x!tt.ptr<bf16>>
     %51 = tt.addptr %50, %26 : tensor<128x256x!tt.ptr<bf16>>, tensor<128x256xi32>
     %52 = tt.load %51 {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<128x256xbf16>
-    %60 = tt.dot %32, %43, %52 {allowTF32 = false, maxNumImpreciseAcc = 0 : i32} : tensor<128x64xbf16> * tensor<64x256xbf16> -> tensor<128x256xbf16>
+    %60 = tt.dot %32, %43, %52 {inputPrecision = 2 : i32, maxNumImpreciseAcc = 0 : i32} : tensor<128x64xbf16> * tensor<64x256xbf16> -> tensor<128x256xbf16>
     tt.store %51, %60 : tensor<128x256xbf16>
     tt.return
   }

--- a/test/Conversion/TritonToLinalg/kernel-03-matrix-multiplication.mlir
+++ b/test/Conversion/TritonToLinalg/kernel-03-matrix-multiplication.mlir
@@ -68,7 +68,7 @@ module {
     %53:3 = scf.for %arg12 = %c0_i32 to %6 step %c1_i32 iter_args(%arg13 = %48, %arg14 = %36, %arg15 = %47) -> (tensor<128x256xf32>, tensor<128x64x!tt.ptr<bf16>>, tensor<64x256x!tt.ptr<bf16>>)  : i32 {
       %71 = tt.load %arg14 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128x64xbf16>
       %72 = tt.load %arg15 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<64x256xbf16>
-      %73 = tt.dot %71, %72, %48 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<128x64xbf16> * tensor<64x256xbf16> -> tensor<128x256xf32>
+      %73 = tt.dot %71, %72, %48 {inputPrecision = 0 : i32, maxNumImpreciseAcc = 0 : i32} : tensor<128x64xbf16> * tensor<64x256xbf16> -> tensor<128x256xf32>
       %74 = arith.addf %arg13, %73 : tensor<128x256xf32>
       %75 = tt.addptr %arg14, %50 : tensor<128x64x!tt.ptr<bf16>>, tensor<128x64xi32>
       %76 = tt.addptr %arg15, %52 : tensor<64x256x!tt.ptr<bf16>>, tensor<64x256xi32>

--- a/test/Conversion/TritonToLinalg/use_dot_opc.mlir
+++ b/test/Conversion/TritonToLinalg/use_dot_opc.mlir
@@ -43,7 +43,7 @@ module {
     %51 = tt.addptr %50, %26 : tensor<128x256x!tt.ptr<bf16>>, tensor<128x256xi32>
     %cf0 = arith.constant 0.0 : bf16
     %71 = tt.splat %cf0 : bf16 -> tensor<128x256xbf16>
-    %60 = tt.dot %32, %42, %71 {allowTF32 = false, maxNumImpreciseAcc = 0 : i32} : tensor<128x64xbf16> * tensor<64x256xbf16> -> tensor<128x256xbf16>
+    %60 = tt.dot %32, %42, %71 {inputPrecision = 2 : i32, maxNumImpreciseAcc = 0 : i32} : tensor<128x64xbf16> * tensor<64x256xbf16> -> tensor<128x256xbf16>
     tt.store %51, %60 : tensor<128x256xbf16>
     tt.store %51, %71 : tensor<128x256xbf16>
     tt.return

--- a/test/Conversion/TritonToStructured/dot.mlir
+++ b/test/Conversion/TritonToStructured/dot.mlir
@@ -44,7 +44,7 @@ module {
     %50 = tt.splat %arg2 : !tt.ptr<bf16> -> tensor<128x256x!tt.ptr<bf16>>
     %51 = tt.addptr %50, %26 : tensor<128x256x!tt.ptr<bf16>>, tensor<128x256xi32>
     %52 = tt.load %51 {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<128x256xbf16>
-    %60 = tt.dot %32, %43, %52 {allowTF32 = false, maxNumImpreciseAcc = 0 : i32} : tensor<128x64xbf16> * tensor<64x256xbf16> -> tensor<128x256xbf16>
+    %60 = tt.dot %32, %43, %52 {inputPrecision = 2 : i32, maxNumImpreciseAcc = 0 : i32} : tensor<128x64xbf16> * tensor<64x256xbf16> -> tensor<128x256xbf16>
     tt.store %51, %60 : tensor<128x256xbf16>
     tt.return
   }
@@ -60,7 +60,7 @@ module {
 // CHECK-DAG:       [[VAR_4_:%.+]] = tt.trans [[VAR_3_]] {order = array<i32: 1, 0>} : tensor<256x64xbf16> -> tensor<64x256xbf16>
 // CHECK-DAG:       [[VAR_5_:%.+]] = tts.make_tptr [[PARAM_2_]] to sizes: [128, 256], strides: {{.}}[[CST_256_]], 1], offsets: [0, 0], shape: [0, 0], order: [] : <bf16, 1> to tensor<128x256x!tt.ptr<bf16, 1>>
 // CHECK:           [[VAR_6_:%.+]] = "tts.load"([[VAR_5_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<128x256x!tt.ptr<bf16, 1>>) -> tensor<128x256xbf16>
-// CHECK:           [[VAR_7_:%.+]] = tt.dot [[VAR_1_]], [[VAR_4_]], [[VAR_6_]] {allowTF32 = false, maxNumImpreciseAcc = 0 : i32} : tensor<128x64xbf16> * tensor<64x256xbf16> -> tensor<128x256xbf16>
+// CHECK:           [[VAR_7_:%.+]] = tt.dot [[VAR_1_]], [[VAR_4_]], [[VAR_6_]] {inputPrecision = 2 : i32, maxNumImpreciseAcc = 0 : i32} : tensor<128x64xbf16> * tensor<64x256xbf16> -> tensor<128x256xbf16>
 // CHECK:           "tts.store"([[VAR_5_]], [[VAR_7_]]) <{static_mask_dims = array<i64>}> : (tensor<128x256x!tt.ptr<bf16, 1>>, tensor<128x256xbf16>) -> ()
 // CHECK:           tt.return
 // CHECK:         }

--- a/test/Conversion/TritonToStructured/kernel-03-matrix-multiplication.mlir
+++ b/test/Conversion/TritonToStructured/kernel-03-matrix-multiplication.mlir
@@ -68,7 +68,7 @@ module {
     %53:3 = scf.for %arg12 = %c0_i32 to %6 step %c1_i32 iter_args(%arg13 = %48, %arg14 = %36, %arg15 = %47) -> (tensor<128x256xf32>, tensor<128x64x!tt.ptr<bf16>>, tensor<64x256x!tt.ptr<bf16>>)  : i32 {
       %71 = tt.load %arg14 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128x64xbf16>
       %72 = tt.load %arg15 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<64x256xbf16>
-      %73 = tt.dot %71, %72, %48 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<128x64xbf16> * tensor<64x256xbf16> -> tensor<128x256xf32>
+      %73 = tt.dot %71, %72, %48 {inputPrecision = 0 : i32, maxNumImpreciseAcc = 0 : i32} : tensor<128x64xbf16> * tensor<64x256xbf16> -> tensor<128x256xf32>
       %74 = arith.addf %arg13, %73 : tensor<128x256xf32>
       %75 = tt.addptr %arg14, %50 : tensor<128x64x!tt.ptr<bf16>>, tensor<128x64xi32>
       %76 = tt.addptr %arg15, %52 : tensor<64x256x!tt.ptr<bf16>>, tensor<64x256xi32>
@@ -158,7 +158,7 @@ module {
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:         [[VAR_54_:%.+]] = "tts.load"([[VAR_53_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<128x64x!tt.ptr<bf16, 1>>) -> tensor<128x64xbf16>
 // CHECK-DAG:         [[VAR_55_:%.+]] = "tts.load"([[VAR_52_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<64x256x!tt.ptr<bf16, 1>>) -> tensor<64x256xbf16>
-// CHECK:             [[VAR_56_:%.+]] = tt.dot [[VAR_54_]], [[VAR_55_]], [[VAR_cst_]] {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<128x64xbf16> * tensor<64x256xbf16> -> tensor<128x256xf32>
+// CHECK:             [[VAR_56_:%.+]] = tt.dot [[VAR_54_]], [[VAR_55_]], [[VAR_cst_]] {inputPrecision = 0 : i32, maxNumImpreciseAcc = 0 : i32} : tensor<128x64xbf16> * tensor<64x256xbf16> -> tensor<128x256xf32>
 // CHECK-DAG:         [[VAR_57_:%.+]] = arith.addf [[VAR_arg13_]], [[VAR_56_]] : tensor<128x256xf32>
 // CHECK-DAG:         [[VAR_58_:%.+]] = arith.addi [[VAR_arg14_]], [[VAR_30_]] : index
 // CHECK-DAG:         [[VAR_59_:%.+]] = arith.addi [[VAR_arg15_]], [[VAR_32_]] : index

--- a/test/Conversion/TritonToStructured/use_dot_opc.mlir
+++ b/test/Conversion/TritonToStructured/use_dot_opc.mlir
@@ -44,7 +44,7 @@ module {
     %51 = tt.addptr %50, %26 : tensor<128x256x!tt.ptr<bf16>>, tensor<128x256xi32>
     %cf0 = arith.constant 0.0 : bf16
     %71 = tt.splat %cf0 : bf16 -> tensor<128x256xbf16>
-    %60 = tt.dot %32, %42, %71 {allowTF32 = false, maxNumImpreciseAcc = 0 : i32} : tensor<128x64xbf16> * tensor<64x256xbf16> -> tensor<128x256xbf16>
+    %60 = tt.dot %32, %42, %71 {inputPrecision = 2 : i32, maxNumImpreciseAcc = 0 : i32} : tensor<128x64xbf16> * tensor<64x256xbf16> -> tensor<128x256xbf16>
     tt.store %51, %60 : tensor<128x256xbf16>
     tt.store %51, %71 : tensor<128x256xbf16>
     tt.return
@@ -61,7 +61,7 @@ module {
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_3_:%.+]] = "tts.load"([[VAR_2_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<64x256x!tt.ptr<bf16, 1>>) -> tensor<64x256xbf16>
 // CHECK-DAG:       [[VAR_4_:%.+]] = tts.make_tptr [[PARAM_2_]] to sizes: [128, 256], strides: {{.}}[[CST_256_]], 1], offsets: [0, 0], shape: [0, 0], order: [] : <bf16, 1> to tensor<128x256x!tt.ptr<bf16, 1>>
-// CHECK:           [[VAR_5_:%.+]] = tt.dot [[VAR_1_]], [[VAR_3_]], [[VAR_cst_]] {allowTF32 = false, maxNumImpreciseAcc = 0 : i32} : tensor<128x64xbf16> * tensor<64x256xbf16> -> tensor<128x256xbf16>
+// CHECK:           [[VAR_5_:%.+]] = tt.dot [[VAR_1_]], [[VAR_3_]], [[VAR_cst_]] {inputPrecision = 2 : i32, maxNumImpreciseAcc = 0 : i32} : tensor<128x64xbf16> * tensor<64x256xbf16> -> tensor<128x256xbf16>
 // CHECK:           "tts.store"([[VAR_4_]], [[VAR_5_]]) <{static_mask_dims = array<i64>}> : (tensor<128x256x!tt.ptr<bf16, 1>>, tensor<128x256xbf16>) -> ()
 // CHECK:           "tts.store"([[VAR_4_]], [[VAR_cst_]]) <{static_mask_dims = array<i64>}> : (tensor<128x256x!tt.ptr<bf16, 1>>, tensor<128x256xbf16>) -> ()
 // CHECK:           tt.return


### PR DESCRIPTION
- Fix CPU backend launcher hook since upstream has updated theirs.
- `allowTF32` in tt.dot is changed to `inputPrecision`

Fixes #122 