### PR TITLE
Fix missing build dependencies for `triton-to-linalg-experimental`

### DIFF
--- a/backend/compiler.py
+++ b/backend/compiler.py
@@ -32,7 +32,7 @@ def _ttir_to_ttsharedir(mod):
         dst_path = os.path.join(tmpdir, "ttshared.mlir")
         Path(src_path).write_text(ttir_code)
         triton_shared_opt_path = _get_triton_shared_opt_path()
-        subprocess.check_call([triton_shared_opt_path, src_path, "--triton-to-structured", "--canonicalize", "--triton-arith-to-linalg", "--cse", "--structured-to-memref", "-o", dst_path])
+        subprocess.check_call([triton_shared_opt_path, src_path, "--triton-to-linalg-experimental", "-o", dst_path])
         return Path(dst_path).read_text()
 
 

--- a/lib/Conversion/TritonToLinalgExperimental/CMakeLists.txt
+++ b/lib/Conversion/TritonToLinalgExperimental/CMakeLists.txt
@@ -24,4 +24,8 @@ add_triton_library(TritonToLinalgExperimental
   TritonIR
   TritonTransforms
   TritonSharedAnalysis
+
+  TritonArithToLinalg
+  StructuredToMemref
+  TritonToStructured
 )

--- a/lib/Conversion/TritonToLinalgExperimental/TritonToLinalgExperimentalPass.cpp
+++ b/lib/Conversion/TritonToLinalgExperimental/TritonToLinalgExperimentalPass.cpp
@@ -47,10 +47,14 @@ public:
     pm.addPass(createTritonToStructuredPass());
 
     // Erase dead code and fold constants created during lowering
+    pm.addPass(createCSEPass());
     pm.addPass(createCanonicalizerPass());
 
     pm.addPass(createTritonArithToLinalgPass());
     pm.addPass(createStructuredToMemrefPass());
+
+    pm.addPass(createCSEPass());
+    pm.addPass(createCanonicalizerPass());
 
     if (failed(runPipeline(pm, getOperation()))) {
       signalPassFailure();

--- a/test/Conversion/StructuredToMemref/addptr_2d_example.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_2d_example.mlir
@@ -44,7 +44,7 @@ module {
     tt.return
   }
 }
-// mlir2FileCheck.py
+
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0, d1) -> (d0, d1)>
 // CHECK-LABEL:  func.func @kernel
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: memref<*xbf16>, [[PARAM_2_:%.+]]: memref<*xbf16>, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32) {
@@ -55,19 +55,16 @@ module {
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<4x256xbf16>
 // CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<4x256xbf16, strided<[1, ?], offset: ?>> to memref<4x256xbf16>
 // CHECK-DAG:       [[VAR_1_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<4x256xbf16>
-// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [4, 256], strides: [1, [[CST_5_]]{{.}} : memref<*xbf16> to memref<4x256xbf16, strided<[1, ?], offset: ?>>
+// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_0_]]{{.}}, sizes: [4, 256], strides: [1, [[CST_5_]]{{.}} : memref<*xbf16> to memref<4x256xbf16, strided<[1, ?], offset: ?>>
 // CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc() : memref<4x256xbf16>
 // CHECK:           memref.copy [[VAR_reinterpret_cast_0_]], [[RES_1_]] : memref<4x256xbf16, strided<[1, ?], offset: ?>> to memref<4x256xbf16>
-// CHECK:           [[VAR_3_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<4x256xbf16>
-// CHECK:           [[VAR_4_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_1_]], [[VAR_3_]] : tensor<4x256xbf16>, tensor<4x256xbf16>) outs([[VAR_1_]] : tensor<4x256xbf16>) {
+// CHECK:           [[VAR_2_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<4x256xbf16>
+// CHECK:           [[VAR_3_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_1_]], [[VAR_2_]] : tensor<4x256xbf16>, tensor<4x256xbf16>) outs([[VAR_1_]] : tensor<4x256xbf16>) {
 // CHECK:           ^bb0([[IN_0_:%.+]]: bf16, [[IN_1_:%.+]]: bf16, [[IN_2_:%.+]]: bf16):
-// CHECK:             [[VAR_6_:%.+]] = arith.addf [[IN_0_]], [[IN_1_]] : bf16
-// CHECK:             linalg.yield [[VAR_6_]] : bf16
+// CHECK:             [[VAR_4_:%.+]] = arith.addf [[IN_0_]], [[IN_1_]] : bf16
+// CHECK:             linalg.yield [[VAR_4_]] : bf16
 // CHECK:           } -> tensor<4x256xbf16>
-// CHECK:           [[VAR_5_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
-// CHECK:           [[VAR_reinterpret_cast_2_:%.+]] = memref.reinterpret_cast [[PARAM_2_]] to offset: {{.}}[[VAR_5_]]{{.}}, sizes: [4, 256], strides: [1, [[CST_5_]]{{.}} : memref<*xbf16> to memref<4x256xbf16, strided<[1, ?], offset: ?>>
-// CHECK:           bufferization.materialize_in_destination [[VAR_4_]] in writable [[VAR_reinterpret_cast_2_]] : (tensor<4x256xbf16>, memref<4x256xbf16, strided<[1, ?], offset: ?>>) -> ()
+// CHECK:           [[VAR_reinterpret_cast_2_:%.+]] = memref.reinterpret_cast [[PARAM_2_]] to offset: {{.}}[[VAR_0_]]{{.}}, sizes: [4, 256], strides: [1, [[CST_5_]]{{.}} : memref<*xbf16> to memref<4x256xbf16, strided<[1, ?], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_3_]] in writable [[VAR_reinterpret_cast_2_]] : (tensor<4x256xbf16>, memref<4x256xbf16, strided<[1, ?], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/StructuredToMemref/addptr_add_value.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_add_value.mlir
@@ -46,7 +46,7 @@ module {
   tt.return
   }
 }
-// mlir2FileCheck.py
+
 // CHECK-LABEL:  func.func @kernel
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: memref<*xbf16>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32) {
 // CHECK-DAG:       [[CST_6_:%.+]] = arith.constant 6 : index
@@ -56,14 +56,10 @@ module {
 // CHECK:           [[VAR_2_:%.+]] = arith.addi [[VAR_0_]], [[VAR_1_]] : index
 // CHECK:           [[VAR_3_:%.+]] = arith.addi [[VAR_2_]], [[CST_10_]] : index
 // CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_3_]]{{.}}, sizes: [4, 256], strides: [1, [[CST_6_]]{{.}} : memref<*xbf16> to memref<4x256xbf16, strided<[1, ?], offset: ?>>
-// CHECK-DAG:       [[VAR_4_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
-// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
-// CHECK:           [[VAR_6_:%.+]] = arith.addi [[VAR_4_]], [[VAR_5_]] : index
-// CHECK:           [[VAR_7_:%.+]] = arith.addi [[VAR_6_]], [[CST_10_]] : index
-// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_7_]]{{.}}, sizes: [4, 256], strides: [1, [[CST_6_]]{{.}} : memref<*xbf16> to memref<4x256xbf16, strided<[1, ?], offset: ?>>
+// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_3_]]{{.}}, sizes: [4, 256], strides: [1, [[CST_6_]]{{.}} : memref<*xbf16> to memref<4x256xbf16, strided<[1, ?], offset: ?>>
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<4x256xbf16>
 // CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<4x256xbf16, strided<[1, ?], offset: ?>> to memref<4x256xbf16>
-// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<4x256xbf16>
-// CHECK:           bufferization.materialize_in_destination [[VAR_8_]] in writable [[VAR_reinterpret_cast_0_]] : (tensor<4x256xbf16>, memref<4x256xbf16, strided<[1, ?], offset: ?>>) -> ()
+// CHECK:           [[VAR_4_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<4x256xbf16>
+// CHECK:           bufferization.materialize_in_destination [[VAR_4_]] in writable [[VAR_reinterpret_cast_0_]] : (tensor<4x256xbf16>, memref<4x256xbf16, strided<[1, ?], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/StructuredToMemref/addptr_for_accumulation.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_for_accumulation.mlir
@@ -58,7 +58,7 @@ module {
     tt.return
   }
 }
-// mlir2FileCheck.py
+
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0, d1) -> (d0, d1)>
 // CHECK-LABEL:  func.func @kernel
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: memref<*xbf16>, [[PARAM_2_:%.+]]: memref<*xbf16>, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32, [[PARAM_10_:%.+]]: i32) {
@@ -72,24 +72,21 @@ module {
 // CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_0_]]{{.}}, sizes: [4, 256], strides: [1, [[CST_5_]]{{.}} : memref<*xbf16> to memref<4x256xbf16, strided<[1, ?], offset: ?>>
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<4x256xbf16>
 // CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<4x256xbf16, strided<[1, ?], offset: ?>> to memref<4x256xbf16>
-// CHECK-DAG:       [[VAR_1_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<4x256xbf16>
-// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_3_:%.+]]:2 = scf.for [[VAR_arg11_:%.+]] = [[CST_0_]] to [[CST_12_]] step [[CST_3_]] iter_args([[VAR_arg12_:%.+]] = [[VAR_1_]], [[VAR_arg13_:%.+]] = [[VAR_2_]]) -> (tensor<4x256xbf16>, index) {
+// CHECK:           [[VAR_1_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<4x256xbf16>
+// CHECK-DAG:       [[VAR_2_:%.+]]:2 = scf.for [[VAR_arg11_:%.+]] = [[CST_0_]] to [[CST_12_]] step [[CST_3_]] iter_args([[VAR_arg12_:%.+]] = [[VAR_1_]], [[VAR_arg13_:%.+]] = [[VAR_0_]]) -> (tensor<4x256xbf16>, index) {
 // CHECK-DAG:         [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_arg13_]]{{.}}, sizes: [4, 256], strides: {{.}}[[CST_1_]], [[CST_5_]]{{.}} : memref<*xbf16> to memref<4x256xbf16, strided<[?, ?], offset: ?>>
 // CHECK-DAG:         [[RES_1_:%.+]] = memref.alloc() : memref<4x256xbf16>
 // CHECK:             memref.copy [[VAR_reinterpret_cast_1_]], [[RES_1_]] : memref<4x256xbf16, strided<[?, ?], offset: ?>> to memref<4x256xbf16>
-// CHECK:             [[VAR_5_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<4x256xbf16>
-// CHECK:             [[VAR_6_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_arg12_]], [[VAR_5_]] : tensor<4x256xbf16>, tensor<4x256xbf16>) outs([[VAR_arg12_]] : tensor<4x256xbf16>) {
+// CHECK:             [[VAR_3_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<4x256xbf16>
+// CHECK:             [[VAR_4_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_arg12_]], [[VAR_3_]] : tensor<4x256xbf16>, tensor<4x256xbf16>) outs([[VAR_arg12_]] : tensor<4x256xbf16>) {
 // CHECK:             ^bb0([[IN_0_:%.+]]: bf16, [[IN_1_:%.+]]: bf16, [[IN_2_:%.+]]: bf16):
-// CHECK:               [[VAR_8_:%.+]] = arith.addf [[IN_0_]], [[IN_1_]] : bf16
-// CHECK:               linalg.yield [[VAR_8_]] : bf16
+// CHECK:               [[VAR_6_:%.+]] = arith.addf [[IN_0_]], [[IN_1_]] : bf16
+// CHECK:               linalg.yield [[VAR_6_]] : bf16
 // CHECK:             } -> tensor<4x256xbf16>
-// CHECK:             [[VAR_7_:%.+]] = arith.addi [[VAR_arg13_]], [[CST_3_]] : index
-// CHECK:             scf.yield [[VAR_6_]], [[VAR_7_]] : tensor<4x256xbf16>, index
+// CHECK:             [[VAR_5_:%.+]] = arith.addi [[VAR_arg13_]], [[CST_3_]] : index
+// CHECK:             scf.yield [[VAR_4_]], [[VAR_5_]] : tensor<4x256xbf16>, index
 // CHECK:           }
-// CHECK:           [[VAR_4_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
-// CHECK:           [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_2_]] to offset: {{.}}[[VAR_4_]]{{.}}, sizes: [4, 256], strides: [1, [[CST_5_]]{{.}} : memref<*xbf16> to memref<4x256xbf16, strided<[1, ?], offset: ?>>
-// CHECK:           bufferization.materialize_in_destination [[VAR_3_]]#0 in writable [[VAR_reinterpret_cast_0_]] : (tensor<4x256xbf16>, memref<4x256xbf16, strided<[1, ?], offset: ?>>) -> ()
+// CHECK:           [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_2_]] to offset: {{.}}[[VAR_0_]]{{.}}, sizes: [4, 256], strides: [1, [[CST_5_]]{{.}} : memref<*xbf16> to memref<4x256xbf16, strided<[1, ?], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_2_]]#0 in writable [[VAR_reinterpret_cast_0_]] : (tensor<4x256xbf16>, memref<4x256xbf16, strided<[1, ?], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/StructuredToMemref/addptr_loopback.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_loopback.mlir
@@ -38,19 +38,17 @@ module {
   tt.return
   }
 }
-// mlir2FileCheck.py
+
 // CHECK-LABEL:  func.func @kernel
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: memref<*xbf16>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
 // CHECK-DAG:       [[CST_6_:%.+]] = arith.constant 6 : index
 // CHECK-DAG:       [[VAR_0_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_0_]]{{.}}, sizes: [4, 256], strides: [1, [[CST_6_]]{{.}} : memref<*xbf16> to memref<4x256xbf16, strided<[1, ?], offset: ?>>
-// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [4, 256], strides: [1, [[CST_6_]]{{.}} : memref<*xbf16> to memref<4x256xbf16, strided<[1, ?], offset: ?>>
+// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_0_]]{{.}}, sizes: [4, 256], strides: [1, [[CST_6_]]{{.}} : memref<*xbf16> to memref<4x256xbf16, strided<[1, ?], offset: ?>>
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<4x256xbf16>
 // CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<4x256xbf16, strided<[1, ?], offset: ?>> to memref<4x256xbf16>
-// CHECK:           [[VAR_2_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<4x256xbf16>
-// CHECK:           bufferization.materialize_in_destination [[VAR_2_]] in writable [[VAR_reinterpret_cast_0_]] : (tensor<4x256xbf16>, memref<4x256xbf16, strided<[1, ?], offset: ?>>) -> ()
+// CHECK:           [[VAR_1_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<4x256xbf16>
+// CHECK:           bufferization.materialize_in_destination [[VAR_1_]] in writable [[VAR_reinterpret_cast_0_]] : (tensor<4x256xbf16>, memref<4x256xbf16, strided<[1, ?], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/StructuredToMemref/addptr_mul_const_const.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_mul_const_const.mlir
@@ -32,19 +32,18 @@ module {
     tt.return
   }
 }
-// mlir2FileCheck.py
+
 // CHECK-LABEL:  func.func @kernel
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: memref<*xbf16>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
 // CHECK-DAG:       [[CST_20480_:%.+]] = arith.constant 20480 : index
 // CHECK-DAG:       [[CST_11_:%.+]] = arith.constant 11 : index
 // CHECK-DAG:       [[VAR_0_:%.+]] = arith.index_cast [[PARAM_6_]] : i32 to index
-// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[PARAM_6_]] : i32 to index
-// CHECK:           [[VAR_2_:%.+]] = arith.addi [[VAR_1_]], [[CST_20480_]] : index
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [1024], strides: {{.}}[[CST_11_]]{{.}} : memref<*xbf16> to memref<1024xbf16, strided<[?], offset: ?>>
+// CHECK:           [[VAR_1_:%.+]] = arith.addi [[VAR_0_]], [[CST_20480_]] : index
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [1024], strides: {{.}}[[CST_11_]]{{.}} : memref<*xbf16> to memref<1024xbf16, strided<[?], offset: ?>>
 // CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_0_]]{{.}}, sizes: [1024], strides: [1] : memref<*xbf16> to memref<1024xbf16, strided<[1], offset: ?>>
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<1024xbf16>
 // CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<1024xbf16, strided<[?], offset: ?>> to memref<1024xbf16>
-// CHECK:           [[VAR_3_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<1024xbf16>
-// CHECK:           bufferization.materialize_in_destination [[VAR_3_]] in writable [[VAR_reinterpret_cast_0_]] : (tensor<1024xbf16>, memref<1024xbf16, strided<[1], offset: ?>>) -> ()
+// CHECK:           [[VAR_2_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<1024xbf16>
+// CHECK:           bufferization.materialize_in_destination [[VAR_2_]] in writable [[VAR_reinterpret_cast_0_]] : (tensor<1024xbf16>, memref<1024xbf16, strided<[1], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/StructuredToMemref/addptr_mul_value_const.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_mul_value_const.mlir
@@ -31,23 +31,22 @@ module {
     tt.return
   }
 }
-// mlir2FileCheck.py
+
 // CHECK-LABEL:  func.func @kernel
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: memref<*xbf16>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
 // CHECK-DAG:       [[CST_2048_:%.+]] = arith.constant 2048 : index
 // CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : index
 // CHECK-DAG:       [[VAR_0_:%.+]] = arith.index_cast [[PARAM_6_]] : i32 to index
-// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[PARAM_6_]] : i32 to index
-// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
-// CHECK:           [[VAR_3_:%.+]] = arith.muli [[VAR_2_]], [[CST_2048_]] : index
-// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_1_]], [[VAR_3_]] : index
-// CHECK-DAG:       [[VAR_5_:%.+]] = arith.addi [[VAR_2_]], [[CST_1_]] : index
+// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_2_:%.+]] = arith.muli [[VAR_1_]], [[CST_2048_]] : index
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.addi [[VAR_0_]], [[VAR_2_]] : index
+// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_1_]], [[CST_1_]] : index
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_4_]]{{.}}, sizes: [1024], strides: {{.}}[[VAR_5_]]{{.}} : memref<*xbf16> to memref<1024xbf16, strided<[?], offset: ?>>
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_3_]]{{.}}, sizes: [1024], strides: {{.}}[[VAR_4_]]{{.}} : memref<*xbf16> to memref<1024xbf16, strided<[?], offset: ?>>
 // CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_0_]]{{.}}, sizes: [1024], strides: [1] : memref<*xbf16> to memref<1024xbf16, strided<[1], offset: ?>>
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<1024xbf16>
 // CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<1024xbf16, strided<[?], offset: ?>> to memref<1024xbf16>
-// CHECK:           [[VAR_6_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<1024xbf16>
-// CHECK:           bufferization.materialize_in_destination [[VAR_6_]] in writable [[VAR_reinterpret_cast_0_]] : (tensor<1024xbf16>, memref<1024xbf16, strided<[1], offset: ?>>) -> ()
+// CHECK:           [[VAR_5_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<1024xbf16>
+// CHECK:           bufferization.materialize_in_destination [[VAR_5_]] in writable [[VAR_reinterpret_cast_0_]] : (tensor<1024xbf16>, memref<1024xbf16, strided<[1], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/StructuredToMemref/addptr_nested.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_nested.mlir
@@ -40,7 +40,7 @@ module {
     tt.return
   }
 }
-// mlir2FileCheck.py
+
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0, d1) -> (d0, d1)>
 // CHECK-LABEL:  func.func @kernel
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: i32, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32) {
@@ -53,20 +53,19 @@ module {
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<4x256xbf16>
 // CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<4x256xbf16, strided<[1, ?], offset: ?>> to memref<4x256xbf16>
 // CHECK-DAG:       [[VAR_1_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<4x256xbf16>
-// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[PARAM_1_]] : i32 to index
-// CHECK:           [[VAR_3_:%.+]] = arith.addi [[VAR_0_]], [[VAR_2_]] : index
-// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_3_]]{{.}}, sizes: [4, 256], strides: [2, [[CST_10_]]{{.}} : memref<*xbf16> to memref<4x256xbf16, strided<[2, ?], offset: ?>>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.addi [[VAR_0_]], [[VAR_0_]] : index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [4, 256], strides: [2, [[CST_10_]]{{.}} : memref<*xbf16> to memref<4x256xbf16, strided<[2, ?], offset: ?>>
 // CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc() : memref<4x256xbf16>
 // CHECK:           memref.copy [[VAR_reinterpret_cast_0_]], [[RES_1_]] : memref<4x256xbf16, strided<[2, ?], offset: ?>> to memref<4x256xbf16>
-// CHECK:           [[VAR_4_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<4x256xbf16>
-// CHECK:           [[VAR_5_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_1_]], [[VAR_4_]] : tensor<4x256xbf16>, tensor<4x256xbf16>) outs([[VAR_1_]] : tensor<4x256xbf16>) {
+// CHECK:           [[VAR_3_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<4x256xbf16>
+// CHECK:           [[VAR_4_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_1_]], [[VAR_3_]] : tensor<4x256xbf16>, tensor<4x256xbf16>) outs([[VAR_1_]] : tensor<4x256xbf16>) {
 // CHECK:           ^bb0([[IN_0_:%.+]]: bf16, [[IN_1_:%.+]]: bf16, [[IN_2_:%.+]]: bf16):
-// CHECK:             [[VAR_8_:%.+]] = arith.addf [[IN_0_]], [[IN_1_]] : bf16
-// CHECK:             linalg.yield [[VAR_8_]] : bf16
+// CHECK:             [[VAR_6_:%.+]] = arith.addf [[IN_0_]], [[IN_1_]] : bf16
+// CHECK:             linalg.yield [[VAR_6_]] : bf16
 // CHECK:           } -> tensor<4x256xbf16>
-// CHECK:           [[VAR_6_:%.+]] = arith.index_cast [[PARAM_1_]] : i32 to index
-// CHECK:           [[VAR_7_:%.+]] = arith.addi [[VAR_3_]], [[VAR_6_]] : index
-// CHECK:           [[VAR_reinterpret_cast_2_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_7_]]{{.}}, sizes: [4, 256], strides: [3, [[CST_15_]]{{.}} : memref<*xbf16> to memref<4x256xbf16, strided<[3, ?], offset: ?>>
-// CHECK:           bufferization.materialize_in_destination [[VAR_5_]] in writable [[VAR_reinterpret_cast_2_]] : (tensor<4x256xbf16>, memref<4x256xbf16, strided<[3, ?], offset: ?>>) -> ()
+// CHECK:           [[VAR_5_:%.+]] = arith.addi [[VAR_2_]], [[VAR_0_]] : index
+// CHECK:           [[VAR_reinterpret_cast_2_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_5_]]{{.}}, sizes: [4, 256], strides: [3, [[CST_15_]]{{.}} : memref<*xbf16> to memref<4x256xbf16, strided<[3, ?], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_4_]] in writable [[VAR_reinterpret_cast_2_]] : (tensor<4x256xbf16>, memref<4x256xbf16, strided<[3, ?], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/StructuredToMemref/addptr_scalar_for.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_scalar_for.mlir
@@ -46,34 +46,32 @@ module {
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_1_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[VAR_0_]] : tensor<1024xf32>) -> tensor<1024xf32>
 // CHECK-DAG:       [[VAR_2_:%.+]] = arith.muli [[PARAM_8_]], [[PARAM_2_]] : i32
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
-// CHECK-DAG:       [[VAR_4_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
-// CHECK:           [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_4_]]{{.}}, sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_5_:%.+]]:3 = scf.for [[VAR_arg11_:%.+]] = [[CST_0_]] to [[CST_12_]] step [[CST_3_]] iter_args([[VAR_arg12_:%.+]] = [[VAR_reinterpret_cast_]], [[VAR_arg13_:%.+]] = [[VAR_1_]], [[VAR_arg14_:%.+]] = [[VAR_3_]]) -> (memref<1xf32, strided<[1], offset: ?>>, tensor<1024xf32>, index) {
-// CHECK-DAG:         [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[PARAM_1_]]4], sizes: [1024], strides: [1] : memref<*xf32> to memref<1024xf32, strided<[1], offset: ?>>
+// CHECK:           [[VAR_3_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
+// CHECK:           [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_3_]]{{.}}, sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_4_:%.+]]:3 = scf.for [[VAR_arg11_:%.+]] = [[CST_0_]] to [[CST_12_]] step [[CST_3_]] iter_args([[VAR_arg12_:%.+]] = [[VAR_reinterpret_cast_]], [[VAR_arg13_:%.+]] = [[VAR_1_]], [[VAR_arg14_:%.+]] = [[VAR_3_]]) -> (memref<1xf32, strided<[1], offset: ?>>, tensor<1024xf32>, index) {
+// CHECK-DAG:         [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_arg14_]]{{.}}, sizes: [1024], strides: [1] : memref<*xf32> to memref<1024xf32, strided<[1], offset: ?>>
 // CHECK-DAG:         [[RES_:%.+]] = memref.alloc() : memref<1024xf32>
 // CHECK:             memref.copy [[VAR_reinterpret_cast_1_]], [[RES_]] : memref<1024xf32, strided<[1], offset: ?>> to memref<1024xf32>
-// CHECK:             [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<1024xf32>
-// CHECK:             [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<1024xf32>) outs([[VAR_8_]] : tensor<1024xf32>) {
+// CHECK:             [[VAR_7_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<1024xf32>
+// CHECK:             [[VAR_8_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_7_]] : tensor<1024xf32>) outs([[VAR_7_]] : tensor<1024xf32>) {
 // CHECK:             ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
-// CHECK:               [[VAR_14_:%.+]] = math.exp [[IN_0_]] : f32
-// CHECK:               linalg.yield [[VAR_14_]] : f32
+// CHECK:               [[VAR_12_:%.+]] = math.exp [[IN_0_]] : f32
+// CHECK:               linalg.yield [[VAR_12_]] : f32
 // CHECK:             } -> tensor<1024xf32>
-// CHECK:             [[VAR_10_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_arg13_]], [[VAR_9_]] : tensor<1024xf32>, tensor<1024xf32>) outs([[VAR_arg13_]] : tensor<1024xf32>) {
+// CHECK:             [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_arg13_]], [[VAR_8_]] : tensor<1024xf32>, tensor<1024xf32>) outs([[VAR_arg13_]] : tensor<1024xf32>) {
 // CHECK:             ^bb0([[IN_2_:%.+]]: f32, [[IN_3_:%.+]]: f32, [[IN_4_:%.+]]: f32):
-// CHECK:               [[VAR_14_1_:%.+]] = arith.addf [[IN_2_]], [[IN_3_]] : f32
-// CHECK:               linalg.yield [[VAR_14_1_]] : f32
+// CHECK:               [[VAR_12_1_:%.+]] = arith.addf [[IN_2_]], [[IN_3_]] : f32
+// CHECK:               linalg.yield [[VAR_12_1_]] : f32
 // CHECK:             } -> tensor<1024xf32>
 // CHECK:             [[base_buffer_:%.+]], [[offset_:%.+]], [[sizes_:%.+]], [[VAR_strides_:%.+]] = memref.extract_strided_metadata [[VAR_arg12_]] : memref<1xf32, strided<[1], offset: ?>> -> memref<f32>, index, index, index
-// CHECK:             [[VAR_11_:%.+]] = arith.addi [[offset_]], [[VAR_arg11_]] : index
-// CHECK-DAG:         [[VAR_reinterpret_cast_2_:%.+]] = memref.reinterpret_cast [[base_buffer_]] to offset: {{.}}[[VAR_11_]]{{.}}, sizes: [1], strides: [1] : memref<f32> to memref<1xf32, strided<[1], offset: ?>>
-// CHECK-DAG:         [[VAR_12_:%.+]] = arith.addi [[VAR_arg14_]], [[VAR_arg11_]] : index
-// CHECK:             scf.yield [[VAR_reinterpret_cast_2_]], [[VAR_10_]], [[VAR_12_]] : memref<1xf32, strided<[1], offset: ?>>, tensor<1024xf32>, index
+// CHECK:             [[VAR_10_:%.+]] = arith.addi [[offset_]], [[VAR_arg11_]] : index
+// CHECK-DAG:         [[VAR_reinterpret_cast_2_:%.+]] = memref.reinterpret_cast [[base_buffer_]] to offset: {{.}}[[VAR_10_]]{{.}}, sizes: [1], strides: [1] : memref<f32> to memref<1xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_11_:%.+]] = arith.addi [[VAR_arg14_]], [[VAR_arg11_]] : index
+// CHECK:             scf.yield [[VAR_reinterpret_cast_2_]], [[VAR_9_]], [[VAR_11_]] : memref<1xf32, strided<[1], offset: ?>>, tensor<1024xf32>, index
 // CHECK:           }
-// CHECK:           [[VAR_6_:%.+]] = arith.muli [[PARAM_8_]], [[PARAM_3_]] : i32
-// CHECK:           [[VAR_7_:%.+]] = arith.index_cast [[VAR_6_]] : i32 to index
-// CHECK:           [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_7_]]{{.}}, sizes: [1024], strides: [1] : memref<*xf32> to memref<1024xf32, strided<[1], offset: ?>>
-// CHECK:           bufferization.materialize_in_destination [[VAR_5_]]#1 in writable [[VAR_reinterpret_cast_0_]] : (tensor<1024xf32>, memref<1024xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           [[VAR_5_:%.+]] = arith.muli [[PARAM_8_]], [[PARAM_3_]] : i32
+// CHECK:           [[VAR_6_:%.+]] = arith.index_cast [[VAR_5_]] : i32 to index
+// CHECK:           [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_6_]]{{.}}, sizes: [1024], strides: [1] : memref<*xf32> to memref<1024xf32, strided<[1], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_4_]]#1 in writable [[VAR_reinterpret_cast_0_]] : (tensor<1024xf32>, memref<1024xf32, strided<[1], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/StructuredToMemref/addptr_scalar_for_2d.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_scalar_for_2d.mlir
@@ -66,37 +66,35 @@ module {
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_1_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[VAR_0_]] : tensor<128x128xf32>) -> tensor<128x128xf32>
 // CHECK-DAG:       [[VAR_2_:%.+]] = arith.muli [[PARAM_8_]], [[PARAM_2_]] : i32
+// CHECK:           [[VAR_3_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
+// CHECK:           [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_3_]]{{.}}, sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_4_:%.+]]:3 = scf.for [[VAR_arg11_:%.+]] = [[CST_0_]] to [[CST_12_]] step [[CST_3_]] iter_args([[VAR_arg12_:%.+]] = [[VAR_1_]], [[VAR_arg13_:%.+]] = [[VAR_reinterpret_cast_]], [[VAR_arg14_:%.+]] = [[VAR_3_]]) -> (tensor<128x128xf32>, memref<1xf32, strided<[1], offset: ?>>, index) {
+// CHECK-DAG:         [[VAR_8_:%.+]] = arith.addi [[VAR_arg14_]], [[CST_128_]] : index
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
-// CHECK-DAG:       [[VAR_4_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
-// CHECK:           [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_4_]]{{.}}, sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_5_:%.+]]:3 = scf.for [[VAR_arg11_:%.+]] = [[CST_0_]] to [[CST_12_]] step [[CST_3_]] iter_args([[VAR_arg12_:%.+]] = [[VAR_1_]], [[VAR_arg13_:%.+]] = [[VAR_reinterpret_cast_]], [[VAR_arg14_:%.+]] = [[VAR_3_]]) -> (tensor<128x128xf32>, memref<1xf32, strided<[1], offset: ?>>, index) {
-// CHECK-DAG:         [[VAR_9_:%.+]] = arith.addi [[VAR_arg14_]], [[CST_128_]] : index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_9_]]{{.}}, sizes: [128, 128], strides: [1, 1] : memref<*xf32> to memref<128x128xf32, strided<[1, 1], offset: ?>>
+// CHECK-DAG:         [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_8_]]{{.}}, sizes: [128, 128], strides: [1, 1] : memref<*xf32> to memref<128x128xf32, strided<[1, 1], offset: ?>>
 // CHECK-DAG:         [[RES_:%.+]] = memref.alloc() : memref<128x128xf32>
 // CHECK:             memref.copy [[VAR_reinterpret_cast_1_]], [[RES_]] : memref<128x128xf32, strided<[1, 1], offset: ?>> to memref<128x128xf32>
-// CHECK:             [[VAR_10_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<128x128xf32>
-// CHECK:             [[VAR_11_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_10_]] : tensor<128x128xf32>) outs([[VAR_10_]] : tensor<128x128xf32>) {
+// CHECK:             [[VAR_9_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<128x128xf32>
+// CHECK:             [[VAR_10_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_9_]] : tensor<128x128xf32>) outs([[VAR_9_]] : tensor<128x128xf32>) {
 // CHECK:             ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
-// CHECK:               [[VAR_16_:%.+]] = math.exp [[IN_0_]] : f32
-// CHECK:               linalg.yield [[VAR_16_]] : f32
+// CHECK:               [[VAR_14_:%.+]] = math.exp [[IN_0_]] : f32
+// CHECK:               linalg.yield [[VAR_14_]] : f32
 // CHECK:             } -> tensor<128x128xf32>
-// CHECK:             [[VAR_12_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_arg12_]], [[VAR_11_]] : tensor<128x128xf32>, tensor<128x128xf32>) outs([[VAR_arg12_]] : tensor<128x128xf32>) {
+// CHECK:             [[VAR_11_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_arg12_]], [[VAR_10_]] : tensor<128x128xf32>, tensor<128x128xf32>) outs([[VAR_arg12_]] : tensor<128x128xf32>) {
 // CHECK:             ^bb0([[IN_2_:%.+]]: f32, [[IN_3_:%.+]]: f32, [[IN_4_:%.+]]: f32):
-// CHECK:               [[VAR_16_1_:%.+]] = arith.addf [[IN_2_]], [[IN_3_]] : f32
-// CHECK:               linalg.yield [[VAR_16_1_]] : f32
+// CHECK:               [[VAR_14_1_:%.+]] = arith.addf [[IN_2_]], [[IN_3_]] : f32
+// CHECK:               linalg.yield [[VAR_14_1_]] : f32
 // CHECK:             } -> tensor<128x128xf32>
 // CHECK:             [[base_buffer_:%.+]], [[offset_:%.+]], [[sizes_:%.+]], [[VAR_strides_:%.+]] = memref.extract_strided_metadata [[VAR_arg13_]] : memref<1xf32, strided<[1], offset: ?>> -> memref<f32>, index, index, index
-// CHECK:             [[VAR_13_:%.+]] = arith.addi [[offset_]], [[VAR_arg11_]] : index
-// CHECK-DAG:         [[VAR_reinterpret_cast_2_:%.+]] = memref.reinterpret_cast [[base_buffer_]] to offset: {{.}}[[VAR_13_]]{{.}}, sizes: [1], strides: [1] : memref<f32> to memref<1xf32, strided<[1], offset: ?>>
-// CHECK-DAG:         [[VAR_14_:%.+]] = arith.addi [[VAR_arg14_]], [[VAR_arg11_]] : index
-// CHECK:             scf.yield [[VAR_12_]], [[VAR_reinterpret_cast_2_]], [[VAR_14_]] : tensor<128x128xf32>, memref<1xf32, strided<[1], offset: ?>>, index
+// CHECK:             [[VAR_12_:%.+]] = arith.addi [[offset_]], [[VAR_arg11_]] : index
+// CHECK-DAG:         [[VAR_reinterpret_cast_2_:%.+]] = memref.reinterpret_cast [[base_buffer_]] to offset: {{.}}[[VAR_12_]]{{.}}, sizes: [1], strides: [1] : memref<f32> to memref<1xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_13_:%.+]] = arith.addi [[VAR_arg14_]], [[VAR_arg11_]] : index
+// CHECK:             scf.yield [[VAR_11_]], [[VAR_reinterpret_cast_2_]], [[VAR_13_]] : tensor<128x128xf32>, memref<1xf32, strided<[1], offset: ?>>, index
 // CHECK:           }
-// CHECK:           [[VAR_6_:%.+]] = arith.muli [[PARAM_8_]], [[PARAM_3_]] : i32
-// CHECK:           [[VAR_7_:%.+]] = arith.index_cast [[VAR_6_]] : i32 to index
-// CHECK:           [[VAR_8_:%.+]] = arith.addi [[VAR_7_]], [[CST_128_]] : index
-// CHECK:           [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_8_]]{{.}}, sizes: [128, 128], strides: [1, 1] : memref<*xf32> to memref<128x128xf32, strided<[1, 1], offset: ?>>
-// CHECK:           bufferization.materialize_in_destination [[VAR_5_]]#0 in writable [[VAR_reinterpret_cast_0_]] : (tensor<128x128xf32>, memref<128x128xf32, strided<[1, 1], offset: ?>>) -> ()
+// CHECK:           [[VAR_5_:%.+]] = arith.muli [[PARAM_8_]], [[PARAM_3_]] : i32
+// CHECK:           [[VAR_6_:%.+]] = arith.index_cast [[VAR_5_]] : i32 to index
+// CHECK:           [[VAR_7_:%.+]] = arith.addi [[VAR_6_]], [[CST_128_]] : index
+// CHECK:           [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_7_]]{{.}}, sizes: [128, 128], strides: [1, 1] : memref<*xf32> to memref<128x128xf32, strided<[1, 1], offset: ?>>
+// CHECK:           bufferization.materialize_in_destination [[VAR_4_]]#0 in writable [[VAR_reinterpret_cast_0_]] : (tensor<128x128xf32>, memref<128x128xf32, strided<[1, 1], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/StructuredToMemref/addptr_scalar_loopback.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_scalar_loopback.mlir
@@ -18,10 +18,8 @@ module {
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: memref<*xbf16>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
 // CHECK:           [[VAR_0_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
 // CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_0_]]{{.}}, sizes: [1], strides: [1] : memref<*xbf16> to memref<1xbf16, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [1], strides: [1] : memref<*xbf16> to memref<1xbf16, strided<[1], offset: ?>>
-// CHECK-DAG:       [[LOAD_VAR_reinterpret_cast_MEM_:%.+]] = affine.load [[VAR_reinterpret_cast_]][0] : memref<1xbf16, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_0_]]{{.}}, sizes: [1], strides: [1] : memref<*xbf16> to memref<1xbf16, strided<[1], offset: ?>>
+// CHECK:           [[LOAD_VAR_reinterpret_cast_MEM_:%.+]] = affine.load [[VAR_reinterpret_cast_]][0] : memref<1xbf16, strided<[1], offset: ?>>
 // CHECK:           affine.store [[LOAD_VAR_reinterpret_cast_MEM_]], [[VAR_reinterpret_cast_0_]][0] : memref<1xbf16, strided<[1], offset: ?>>
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/StructuredToMemref/addptr_scalar_nested.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_scalar_nested.mlir
@@ -30,7 +30,7 @@ module {
     tt.return
   }
 }
-// mlir2FileCheck.py
+
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
 // CHECK-LABEL:  func.func @kernel
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32> {tt.divisibility = 16 : i32}, [[PARAM_1_:%.+]]: memref<*xf32> {tt.divisibility = 16 : i32}, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32, [[PARAM_10_:%.+]]: i32) {
@@ -48,12 +48,10 @@ module {
 // CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<1024xf32>
 // CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<1024xf32>) outs([[VAR_8_]] : tensor<1024xf32>) {
 // CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
-// CHECK:             [[VAR_12_:%.+]] = math.exp [[IN_0_]] : f32
-// CHECK:             linalg.yield [[VAR_12_]] : f32
+// CHECK:             [[VAR_10_:%.+]] = math.exp [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_10_]] : f32
 // CHECK:           } -> tensor<1024xf32>
-// CHECK:           [[VAR_10_:%.+]] = arith.muli [[PARAM_8_]], [[PARAM_3_]] : i32
-// CHECK:           [[VAR_11_:%.+]] = arith.index_cast [[VAR_10_]] : i32 to index
-// CHECK:           [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_11_]]{{.}}, sizes: [1024], strides: [1] : memref<*xf32> to memref<1024xf32, strided<[1], offset: ?>>
+// CHECK:           [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_3_]]{{.}}, sizes: [1024], strides: [1] : memref<*xf32> to memref<1024xf32, strided<[1], offset: ?>>
 // CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_0_]] : (tensor<1024xf32>, memref<1024xf32, strided<[1], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/StructuredToMemref/block_ptr_advance.mlir
+++ b/test/Conversion/StructuredToMemref/block_ptr_advance.mlir
@@ -32,7 +32,6 @@ module {
   }
 }
 
-// mlir2FileCheck.py
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0, d1) -> (d0, d1)>
 // CHECK-LABEL:  func.func @matmul_kernel_with_block_pointers_01234567891011
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: memref<*xbf16>, [[PARAM_2_:%.+]]: memref<*xbf16>, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32, [[PARAM_10_:%.+]]: i32, [[PARAM_11_:%.+]]: i32, [[PARAM_12_:%.+]]: i32, [[PARAM_13_:%.+]]: i32, [[PARAM_14_:%.+]]: i32, [[PARAM_15_:%.+]]: i32, [[PARAM_16_:%.+]]: i32, [[PARAM_17_:%.+]]: i32, [[PARAM_18_:%.+]]: i32, [[PARAM_19_:%.+]]: i32) {
@@ -52,41 +51,39 @@ module {
 // CHECK:           [[VAR_6_:%.+]] = arith.muli [[VAR_5_]], [[CST_64_1_]] : index
 // CHECK-DAG:       [[VAR_7_:%.+]]:3 = scf.for [[VAR_arg20_:%.+]] = [[CST_0_]] to [[PARAM_5_]] step [[CST_64_]] iter_args([[VAR_arg21_:%.+]] = [[VAR_1_]], [[VAR_arg22_:%.+]] = [[VAR_6_]], [[VAR_arg23_:%.+]] = [[VAR_4_]]) -> (tensor<128x64xbf16>, index, index)  : i32 {
 // CHECK-DAG:         [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_arg23_]]{{.}}, sizes: [128, 64], strides: {{.}}[[VAR_2_]], [[VAR_5_]]{{.}} : memref<*xbf16> to memref<128x64xbf16, strided<[?, ?], offset: ?>>
-// CHECK-DAG:         [[VAR_16_:%.+]] = arith.addi [[VAR_4_]], [[VAR_arg22_]] : index
+// CHECK-DAG:         [[VAR_15_:%.+]] = arith.addi [[VAR_4_]], [[VAR_arg22_]] : index
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_16_]]{{.}}, sizes: [128, 64], strides: {{.}}[[VAR_2_]], [[VAR_5_]]{{.}} : memref<*xbf16> to memref<128x64xbf16, strided<[?, ?], offset: ?>>
+// CHECK-DAG:         [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_15_]]{{.}}, sizes: [128, 64], strides: {{.}}[[VAR_2_]], [[VAR_5_]]{{.}} : memref<*xbf16> to memref<128x64xbf16, strided<[?, ?], offset: ?>>
 // CHECK-DAG:         [[RES_:%.+]] = memref.alloc() : memref<128x64xbf16>
 // CHECK:             memref.copy [[VAR_reinterpret_cast_1_]], [[RES_]] : memref<128x64xbf16, strided<[?, ?], offset: ?>> to memref<128x64xbf16>
-// CHECK-DAG:         [[VAR_17_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<128x64xbf16>
+// CHECK-DAG:         [[VAR_16_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<128x64xbf16>
 // CHECK-DAG:         [[RES_1_:%.+]] = memref.alloc() : memref<128x64xbf16>
 // CHECK:             memref.copy [[VAR_reinterpret_cast_0_]], [[RES_1_]] : memref<128x64xbf16, strided<[?, ?], offset: ?>> to memref<128x64xbf16>
-// CHECK:             [[VAR_18_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<128x64xbf16>
-// CHECK:             [[VAR_19_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_17_]], [[VAR_18_]] : tensor<128x64xbf16>, tensor<128x64xbf16>) outs([[VAR_17_]] : tensor<128x64xbf16>) {
+// CHECK:             [[VAR_17_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<128x64xbf16>
+// CHECK:             [[VAR_18_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_16_]], [[VAR_17_]] : tensor<128x64xbf16>, tensor<128x64xbf16>) outs([[VAR_16_]] : tensor<128x64xbf16>) {
 // CHECK:             ^bb0([[IN_0_:%.+]]: bf16, [[IN_1_:%.+]]: bf16, [[IN_2_:%.+]]: bf16):
-// CHECK:               [[VAR_25_:%.+]] = arith.addf [[IN_0_]], [[IN_1_]] : bf16
-// CHECK:               linalg.yield [[VAR_25_]] : bf16
+// CHECK:               [[VAR_23_:%.+]] = arith.addf [[IN_0_]], [[IN_1_]] : bf16
+// CHECK:               linalg.yield [[VAR_23_]] : bf16
 // CHECK:             } -> tensor<128x64xbf16>
-// CHECK:             [[VAR_20_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_arg21_]], [[VAR_19_]] : tensor<128x64xbf16>, tensor<128x64xbf16>) outs([[VAR_arg21_]] : tensor<128x64xbf16>) {
+// CHECK:             [[VAR_19_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_arg21_]], [[VAR_18_]] : tensor<128x64xbf16>, tensor<128x64xbf16>) outs([[VAR_arg21_]] : tensor<128x64xbf16>) {
 // CHECK:             ^bb0([[IN_3_:%.+]]: bf16, [[IN_4_:%.+]]: bf16, [[IN_5_:%.+]]: bf16):
-// CHECK:               [[VAR_25_1_:%.+]] = arith.addf [[IN_3_]], [[IN_4_]] : bf16
-// CHECK:               linalg.yield [[VAR_25_1_]] : bf16
+// CHECK:               [[VAR_23_1_:%.+]] = arith.addf [[IN_3_]], [[IN_4_]] : bf16
+// CHECK:               linalg.yield [[VAR_23_1_]] : bf16
 // CHECK:             } -> tensor<128x64xbf16>
-// CHECK:             [[VAR_21_:%.+]] = arith.muli [[VAR_5_]], [[CST_64_1_]] : index
-// CHECK-DAG:         [[VAR_22_:%.+]] = arith.addi [[VAR_21_]], [[VAR_arg22_]] : index
-// CHECK-DAG:         [[VAR_23_:%.+]] = arith.muli [[VAR_2_]], [[CST_64_1_]] : index
-// CHECK:             [[VAR_24_:%.+]] = arith.addi [[VAR_23_]], [[VAR_arg23_]] : index
-// CHECK:             scf.yield [[VAR_20_]], [[VAR_22_]], [[VAR_24_]] : tensor<128x64xbf16>, index, index
+// CHECK-DAG:         [[VAR_20_:%.+]] = arith.addi [[VAR_6_]], [[VAR_arg22_]] : index
+// CHECK-DAG:         [[VAR_21_:%.+]] = arith.muli [[VAR_2_]], [[CST_64_1_]] : index
+// CHECK:             [[VAR_22_:%.+]] = arith.addi [[VAR_21_]], [[VAR_arg23_]] : index
+// CHECK:             scf.yield [[VAR_19_]], [[VAR_20_]], [[VAR_22_]] : tensor<128x64xbf16>, index, index
 // CHECK:           }
 // CHECK-DAG:       [[VAR_8_:%.+]] = arith.muli [[PARAM_13_]], [[CST_256_]] : i32
 // CHECK-DAG:       [[VAR_9_:%.+]] = arith.index_cast [[PARAM_10_]] : i32 to index
-// CHECK-DAG:       [[VAR_10_:%.+]] = arith.index_cast [[PARAM_12_]] : i32 to index
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_11_:%.+]] = arith.muli [[VAR_10_]], [[VAR_9_]] : index
-// CHECK-DAG:       [[VAR_12_:%.+]] = arith.index_cast [[PARAM_11_]] : i32 to index
-// CHECK-DAG:       [[VAR_13_:%.+]] = arith.index_cast [[VAR_8_]] : i32 to index
-// CHECK:           [[VAR_14_:%.+]] = arith.muli [[VAR_13_]], [[VAR_12_]] : index
-// CHECK:           [[VAR_15_:%.+]] = arith.addi [[VAR_11_]], [[VAR_14_]] : index
-// CHECK:           [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_2_]] to offset: {{.}}[[VAR_15_]]{{.}}, sizes: [128, 64], strides: {{.}}[[VAR_9_]], [[VAR_12_]]{{.}} : memref<*xbf16> to memref<128x64xbf16, strided<[?, ?], offset: ?>>
+// CHECK-DAG:       [[VAR_10_:%.+]] = arith.muli [[VAR_3_]], [[VAR_9_]] : index
+// CHECK-DAG:       [[VAR_11_:%.+]] = arith.index_cast [[PARAM_11_]] : i32 to index
+// CHECK-DAG:       [[VAR_12_:%.+]] = arith.index_cast [[VAR_8_]] : i32 to index
+// CHECK:           [[VAR_13_:%.+]] = arith.muli [[VAR_12_]], [[VAR_11_]] : index
+// CHECK:           [[VAR_14_:%.+]] = arith.addi [[VAR_10_]], [[VAR_13_]] : index
+// CHECK:           [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_2_]] to offset: {{.}}[[VAR_14_]]{{.}}, sizes: [128, 64], strides: {{.}}[[VAR_9_]], [[VAR_11_]]{{.}} : memref<*xbf16> to memref<128x64xbf16, strided<[?, ?], offset: ?>>
 // CHECK:           bufferization.materialize_in_destination [[VAR_7_]]#0 in writable [[VAR_reinterpret_cast_]] : (tensor<128x64xbf16>, memref<128x64xbf16, strided<[?, ?], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/StructuredToMemref/convert_1d_elemwise_arith_unary.mlir
+++ b/test/Conversion/StructuredToMemref/convert_1d_elemwise_arith_unary.mlir
@@ -37,7 +37,7 @@ module {
     tt.return
   }
 }
-// mlir2FileCheck.py
+
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
 // CHECK-LABEL:  func.func @kernel
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xi32>, [[PARAM_2_:%.+]]: memref<*xf16>, [[PARAM_3_:%.+]]: tensor<1024x!tt.ptr<bf16, 1>>, [[PARAM_4_:%.+]]: tensor<1024x!tt.ptr<f32, 1>>, [[PARAM_5_:%.+]]: tensor<1024x!tt.ptr<f32, 1>>, [[PARAM_6_:%.+]]: tensor<1024x!tt.ptr<f32, 1>>, [[PARAM_7_:%.+]]: tensor<1024x!tt.ptr<f32, 1>>, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32, [[PARAM_10_:%.+]]: i32, [[PARAM_11_:%.+]]: i32, [[PARAM_12_:%.+]]: i32, [[PARAM_13_:%.+]]: i32) {
@@ -56,35 +56,34 @@ module {
 // CHECK-DAG:       [[VAR_3_:%.+]] = tensor.empty() : tensor<1024xbf16>
 // CHECK:           [[VAR_4_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_0_]] : tensor<1024xf32>) outs([[VAR_3_]] : tensor<1024xbf16>) {
 // CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: bf16):
-// CHECK:             [[VAR_11_:%.+]] = arith.truncf [[IN_0_]] : f32 to bf16
-// CHECK:             linalg.yield [[VAR_11_]] : bf16
+// CHECK:             [[VAR_10_:%.+]] = arith.truncf [[IN_0_]] : f32 to bf16
+// CHECK:             linalg.yield [[VAR_10_]] : bf16
 // CHECK:           } -> tensor<1024xbf16>
 // CHECK:           [[VAR_5_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_0_]] : tensor<1024xf32>) outs([[VAR_0_]] : tensor<1024xf32>) {
 // CHECK:           ^bb0([[IN_2_:%.+]]: f32, [[IN_3_:%.+]]: f32):
-// CHECK:             [[VAR_11_1_:%.+]] = math.exp [[IN_2_]] : f32
-// CHECK:             linalg.yield [[VAR_11_1_]] : f32
+// CHECK:             [[VAR_10_1_:%.+]] = math.exp [[IN_2_]] : f32
+// CHECK:             linalg.yield [[VAR_10_1_]] : f32
 // CHECK:           } -> tensor<1024xf32>
 // CHECK:           [[VAR_6_:%.+]] = tensor.empty() : tensor<1024xf32>
 // CHECK:           [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_1_]] : tensor<1024xi32>) outs([[VAR_6_]] : tensor<1024xf32>) {
 // CHECK:           ^bb0([[IN_4_:%.+]]: i32, [[IN_5_:%.+]]: f32):
-// CHECK:             [[VAR_11_2_:%.+]] = arith.sitofp [[IN_4_]] : i32 to f32
-// CHECK:             linalg.yield [[VAR_11_2_]] : f32
+// CHECK:             [[VAR_10_2_:%.+]] = arith.sitofp [[IN_4_]] : i32 to f32
+// CHECK:             linalg.yield [[VAR_10_2_]] : f32
 // CHECK:           } -> tensor<1024xf32>
-// CHECK:           [[VAR_8_:%.+]] = tensor.empty() : tensor<1024xf32>
-// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_2_]] : tensor<1024xf16>) outs([[VAR_8_]] : tensor<1024xf32>) {
+// CHECK:           [[VAR_8_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_2_]] : tensor<1024xf16>) outs([[VAR_6_]] : tensor<1024xf32>) {
 // CHECK:           ^bb0([[IN_6_:%.+]]: f16, [[IN_7_:%.+]]: f32):
-// CHECK:             [[VAR_11_3_:%.+]] = arith.extf [[IN_6_]] : f16 to f32
-// CHECK:             linalg.yield [[VAR_11_3_]] : f32
+// CHECK:             [[VAR_10_3_:%.+]] = arith.extf [[IN_6_]] : f16 to f32
+// CHECK:             linalg.yield [[VAR_10_3_]] : f32
 // CHECK:           } -> tensor<1024xf32>
-// CHECK:           [[VAR_10_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_0_]] : tensor<1024xf32>) outs([[VAR_0_]] : tensor<1024xf32>) {
+// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_0_]] : tensor<1024xf32>) outs([[VAR_0_]] : tensor<1024xf32>) {
 // CHECK:           ^bb0([[IN_8_:%.+]]: f32, [[IN_9_:%.+]]: f32):
-// CHECK:             [[VAR_11_4_:%.+]] = math.sqrt [[IN_8_]] : f32
-// CHECK:             linalg.yield [[VAR_11_4_]] : f32
+// CHECK:             [[VAR_10_4_:%.+]] = math.sqrt [[IN_8_]] : f32
+// CHECK:             linalg.yield [[VAR_10_4_]] : f32
 // CHECK:           } -> tensor<1024xf32>
 // CHECK:           tt.store [[PARAM_3_]], [[VAR_4_]] {cache = 1 : i32, evict = 1 : i32} : tensor<1024xbf16>
 // CHECK:           tt.store [[PARAM_4_]], [[VAR_5_]] {cache = 1 : i32, evict = 1 : i32} : tensor<1024xf32>
 // CHECK:           tt.store [[PARAM_5_]], [[VAR_7_]] {cache = 1 : i32, evict = 1 : i32} : tensor<1024xf32>
-// CHECK:           tt.store [[PARAM_6_]], [[VAR_9_]] {cache = 1 : i32, evict = 1 : i32} : tensor<1024xf32>
-// CHECK:           tt.store [[PARAM_7_]], [[VAR_10_]] {cache = 1 : i32, evict = 1 : i32} : tensor<1024xf32>
+// CHECK:           tt.store [[PARAM_6_]], [[VAR_8_]] {cache = 1 : i32, evict = 1 : i32} : tensor<1024xf32>
+// CHECK:           tt.store [[PARAM_7_]], [[VAR_9_]] {cache = 1 : i32, evict = 1 : i32} : tensor<1024xf32>
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/StructuredToMemref/convert_2d_elemwise_arith_unary.mlir
+++ b/test/Conversion/StructuredToMemref/convert_2d_elemwise_arith_unary.mlir
@@ -43,7 +43,7 @@ module {
     tt.return
   }
 }
-// mlir2FileCheck.py
+
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0, d1) -> (d0, d1)>
 // CHECK-LABEL:  func.func @kernel
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xi32>, [[PARAM_2_:%.+]]: memref<*xf16>, [[PARAM_3_:%.+]]: tensor<128x128x!tt.ptr<bf16, 1>>, [[PARAM_4_:%.+]]: tensor<128x128x!tt.ptr<f32, 1>>, [[PARAM_5_:%.+]]: tensor<128x128x!tt.ptr<f32, 1>>, [[PARAM_6_:%.+]]: tensor<128x128x!tt.ptr<f32, 1>>, [[PARAM_7_:%.+]]: tensor<128x128x!tt.ptr<f32, 1>>, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32, [[PARAM_10_:%.+]]: i32, [[PARAM_11_:%.+]]: i32, [[PARAM_12_:%.+]]: i32, [[PARAM_13_:%.+]]: i32) {
@@ -62,35 +62,34 @@ module {
 // CHECK-DAG:       [[VAR_3_:%.+]] = tensor.empty() : tensor<128x128xbf16>
 // CHECK:           [[VAR_4_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_0_]] : tensor<128x128xf32>) outs([[VAR_3_]] : tensor<128x128xbf16>) {
 // CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: bf16):
-// CHECK:             [[VAR_11_:%.+]] = arith.truncf [[IN_0_]] : f32 to bf16
-// CHECK:             linalg.yield [[VAR_11_]] : bf16
+// CHECK:             [[VAR_10_:%.+]] = arith.truncf [[IN_0_]] : f32 to bf16
+// CHECK:             linalg.yield [[VAR_10_]] : bf16
 // CHECK:           } -> tensor<128x128xbf16>
 // CHECK:           [[VAR_5_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_0_]] : tensor<128x128xf32>) outs([[VAR_0_]] : tensor<128x128xf32>) {
 // CHECK:           ^bb0([[IN_2_:%.+]]: f32, [[IN_3_:%.+]]: f32):
-// CHECK:             [[VAR_11_1_:%.+]] = math.exp [[IN_2_]] : f32
-// CHECK:             linalg.yield [[VAR_11_1_]] : f32
+// CHECK:             [[VAR_10_1_:%.+]] = math.exp [[IN_2_]] : f32
+// CHECK:             linalg.yield [[VAR_10_1_]] : f32
 // CHECK:           } -> tensor<128x128xf32>
 // CHECK:           [[VAR_6_:%.+]] = tensor.empty() : tensor<128x128xf32>
 // CHECK:           [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_1_]] : tensor<128x128xi32>) outs([[VAR_6_]] : tensor<128x128xf32>) {
 // CHECK:           ^bb0([[IN_4_:%.+]]: i32, [[IN_5_:%.+]]: f32):
-// CHECK:             [[VAR_11_2_:%.+]] = arith.sitofp [[IN_4_]] : i32 to f32
-// CHECK:             linalg.yield [[VAR_11_2_]] : f32
+// CHECK:             [[VAR_10_2_:%.+]] = arith.sitofp [[IN_4_]] : i32 to f32
+// CHECK:             linalg.yield [[VAR_10_2_]] : f32
 // CHECK:           } -> tensor<128x128xf32>
-// CHECK:           [[VAR_8_:%.+]] = tensor.empty() : tensor<128x128xf32>
-// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_2_]] : tensor<128x128xf16>) outs([[VAR_8_]] : tensor<128x128xf32>) {
+// CHECK:           [[VAR_8_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_2_]] : tensor<128x128xf16>) outs([[VAR_6_]] : tensor<128x128xf32>) {
 // CHECK:           ^bb0([[IN_6_:%.+]]: f16, [[IN_7_:%.+]]: f32):
-// CHECK:             [[VAR_11_3_:%.+]] = arith.extf [[IN_6_]] : f16 to f32
-// CHECK:             linalg.yield [[VAR_11_3_]] : f32
+// CHECK:             [[VAR_10_3_:%.+]] = arith.extf [[IN_6_]] : f16 to f32
+// CHECK:             linalg.yield [[VAR_10_3_]] : f32
 // CHECK:           } -> tensor<128x128xf32>
-// CHECK:           [[VAR_10_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_0_]] : tensor<128x128xf32>) outs([[VAR_0_]] : tensor<128x128xf32>) {
+// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_0_]] : tensor<128x128xf32>) outs([[VAR_0_]] : tensor<128x128xf32>) {
 // CHECK:           ^bb0([[IN_8_:%.+]]: f32, [[IN_9_:%.+]]: f32):
-// CHECK:             [[VAR_11_4_:%.+]] = math.sqrt [[IN_8_]] : f32
-// CHECK:             linalg.yield [[VAR_11_4_]] : f32
+// CHECK:             [[VAR_10_4_:%.+]] = math.sqrt [[IN_8_]] : f32
+// CHECK:             linalg.yield [[VAR_10_4_]] : f32
 // CHECK:           } -> tensor<128x128xf32>
 // CHECK:           tt.store [[PARAM_3_]], [[VAR_4_]] {cache = 1 : i32, evict = 1 : i32} : tensor<128x128xbf16>
 // CHECK:           tt.store [[PARAM_4_]], [[VAR_5_]] {cache = 1 : i32, evict = 1 : i32} : tensor<128x128xf32>
 // CHECK:           tt.store [[PARAM_5_]], [[VAR_7_]] {cache = 1 : i32, evict = 1 : i32} : tensor<128x128xf32>
-// CHECK:           tt.store [[PARAM_6_]], [[VAR_9_]] {cache = 1 : i32, evict = 1 : i32} : tensor<128x128xf32>
-// CHECK:           tt.store [[PARAM_7_]], [[VAR_10_]] {cache = 1 : i32, evict = 1 : i32} : tensor<128x128xf32>
+// CHECK:           tt.store [[PARAM_6_]], [[VAR_8_]] {cache = 1 : i32, evict = 1 : i32} : tensor<128x128xf32>
+// CHECK:           tt.store [[PARAM_7_]], [[VAR_9_]] {cache = 1 : i32, evict = 1 : i32} : tensor<128x128xf32>
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/StructuredToMemref/convert_argmin_argmax_2d.mlir
+++ b/test/Conversion/StructuredToMemref/convert_argmin_argmax_2d.mlir
@@ -62,9 +62,9 @@ module {
 // CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<4xi32>
 // CHECK:           [[VAR_1_:%.+]] = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel"]} outs([[VAR_0_]] : tensor<4xi32>) {
 // CHECK:           ^bb0([[IN_0_:%.+]]: i32):
-// CHECK:             [[VAR_13_:%.+]] = linalg.index 0 : index
-// CHECK:             [[VAR_14_:%.+]] = arith.index_cast [[VAR_13_]] : index to i32
-// CHECK:             linalg.yield [[VAR_14_]] : i32
+// CHECK:             [[VAR_11_:%.+]] = linalg.index 0 : index
+// CHECK:             [[VAR_12_:%.+]] = arith.index_cast [[VAR_11_]] : index to i32
+// CHECK:             linalg.yield [[VAR_12_]] : i32
 // CHECK:           } -> tensor<4xi32>
 // CHECK-DAG:       [[VAR_expanded_:%.+]] = tensor.expand_shape [[VAR_1_]] {{.}}[0, 1]{{.}} : tensor<4xi32> into tensor<1x4xi32>
 // CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
@@ -81,28 +81,26 @@ module {
 // CHECK:           } -> tensor<4x4xi32>
 // CHECK:           [[VAR_7_:%.+]] = tensor.empty() : tensor<4xf32>
 // CHECK-DAG:       [[VAR_8_:%.+]] = linalg.fill ins([[CST_0_]] : f32) outs([[VAR_7_]] : tensor<4xf32>) -> tensor<4xf32>
-// CHECK-DAG:       [[VAR_9_:%.+]] = tensor.empty() : tensor<4xi32>
-// CHECK:           [[VAR_10_:%.+]] = linalg.fill ins([[CST_minus_1_]] : i32) outs([[VAR_9_]] : tensor<4xi32>) -> tensor<4xi32>
-// CHECK:           [[VAR_reduced_:%.+]]:2 = linalg.reduce ins([[VAR_4_]], [[VAR_6_]] : tensor<4x4xf32>, tensor<4x4xi32>) outs([[VAR_8_]], [[VAR_10_]] : tensor<4xf32>, tensor<4xi32>) dimensions = [1]
+// CHECK-DAG:       [[VAR_9_:%.+]] = linalg.fill ins([[CST_minus_1_]] : i32) outs([[VAR_0_]] : tensor<4xi32>) -> tensor<4xi32>
+// CHECK:           [[VAR_reduced_:%.+]]:2 = linalg.reduce ins([[VAR_4_]], [[VAR_6_]] : tensor<4x4xf32>, tensor<4x4xi32>) outs([[VAR_8_]], [[VAR_9_]] : tensor<4xf32>, tensor<4xi32>) dimensions = [1]
 // CHECK:             ([[IN_1_:%.+]]: f32, [[in_1_:%.+]]: i32, [[init_:%.+]]: f32, [[init_2_:%.+]]: i32) {
-// CHECK-DAG:           [[VAR_13_1_:%.+]] = arith.cmpf oeq, [[IN_1_]], [[init_]] : f32
-// CHECK-DAG:           [[VAR_14_1_:%.+]] = arith.cmpi slt, [[in_1_]], [[init_2_]] : i32
+// CHECK-DAG:           [[VAR_11_1_:%.+]] = arith.cmpf oeq, [[IN_1_]], [[init_]] : f32
+// CHECK-DAG:           [[VAR_12_1_:%.+]] = arith.cmpi slt, [[in_1_]], [[init_2_]] : i32
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:           [[VAR_15_:%.+]] = arith.andi [[VAR_13_1_]], [[VAR_14_1_]] : i1
-// CHECK-DAG:           [[VAR_16_:%.+]] = arith.cmpf ogt, [[IN_1_]], [[init_]] : f32
-// CHECK:               [[VAR_17_:%.+]] = arith.ori [[VAR_16_]], [[VAR_15_]] : i1
-// CHECK-DAG:           [[VAR_18_:%.+]] = arith.select [[VAR_17_]], [[IN_1_]], [[init_]] : f32
-// CHECK-DAG:           [[VAR_19_:%.+]] = arith.select [[VAR_17_]], [[in_1_]], [[init_2_]] : i32
-// CHECK:               linalg.yield [[VAR_18_]], [[VAR_19_]] : f32, i32
+// CHECK-DAG:           [[VAR_13_:%.+]] = arith.andi [[VAR_11_1_]], [[VAR_12_1_]] : i1
+// CHECK-DAG:           [[VAR_14_:%.+]] = arith.cmpf ogt, [[IN_1_]], [[init_]] : f32
+// CHECK:               [[VAR_15_:%.+]] = arith.ori [[VAR_14_]], [[VAR_13_]] : i1
+// CHECK-DAG:           [[VAR_16_:%.+]] = arith.select [[VAR_15_]], [[IN_1_]], [[init_]] : f32
+// CHECK-DAG:           [[VAR_17_:%.+]] = arith.select [[VAR_15_]], [[in_1_]], [[init_2_]] : i32
+// CHECK:               linalg.yield [[VAR_16_]], [[VAR_17_]] : f32, i32
 // CHECK:             }
 // CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: [0], sizes: [4], strides: [1] : memref<*xf32> to memref<4xf32, strided<[1]>>
-// CHECK-DAG:       [[VAR_11_:%.+]] = tensor.empty() : tensor<4xf32>
-// CHECK:           [[VAR_12_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_reduced_]]#1 : tensor<4xi32>) outs([[VAR_11_]] : tensor<4xf32>) {
+// CHECK-DAG:       [[VAR_10_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_reduced_]]#1 : tensor<4xi32>) outs([[VAR_7_]] : tensor<4xf32>) {
 // CHECK:           ^bb0([[IN_3_:%.+]]: i32, [[IN_4_:%.+]]: f32):
-// CHECK:             [[VAR_13_2_:%.+]] = arith.sitofp [[IN_3_]] : i32 to f32
-// CHECK:             linalg.yield [[VAR_13_2_]] : f32
+// CHECK:             [[VAR_11_2_:%.+]] = arith.sitofp [[IN_3_]] : i32 to f32
+// CHECK:             linalg.yield [[VAR_11_2_]] : f32
 // CHECK:           } -> tensor<4xf32>
-// CHECK:           bufferization.materialize_in_destination [[VAR_12_]] in writable [[VAR_reinterpret_cast_0_]] : (tensor<4xf32>, memref<4xf32, strided<[1]>>) -> ()
+// CHECK:           bufferization.materialize_in_destination [[VAR_10_]] in writable [[VAR_reinterpret_cast_0_]] : (tensor<4xf32>, memref<4xf32, strided<[1]>>) -> ()
 // CHECK:           return
 // CHECK:         }
 
@@ -171,9 +169,9 @@ module {
 // CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<4xi32>
 // CHECK:           [[VAR_1_:%.+]] = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel"]} outs([[VAR_0_]] : tensor<4xi32>) {
 // CHECK:           ^bb0([[IN_0_:%.+]]: i32):
-// CHECK:             [[VAR_13_:%.+]] = linalg.index 0 : index
-// CHECK:             [[VAR_14_:%.+]] = arith.index_cast [[VAR_13_]] : index to i32
-// CHECK:             linalg.yield [[VAR_14_]] : i32
+// CHECK:             [[VAR_11_:%.+]] = linalg.index 0 : index
+// CHECK:             [[VAR_12_:%.+]] = arith.index_cast [[VAR_11_]] : index to i32
+// CHECK:             linalg.yield [[VAR_12_]] : i32
 // CHECK:           } -> tensor<4xi32>
 // CHECK-DAG:       [[VAR_expanded_:%.+]] = tensor.expand_shape [[VAR_1_]] {{.}}[0, 1]{{.}} : tensor<4xi32> into tensor<1x4xi32>
 // CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
@@ -190,27 +188,25 @@ module {
 // CHECK:           } -> tensor<4x4xi32>
 // CHECK:           [[VAR_7_:%.+]] = tensor.empty() : tensor<4xf32>
 // CHECK-DAG:       [[VAR_8_:%.+]] = linalg.fill ins([[CST_0_]] : f32) outs([[VAR_7_]] : tensor<4xf32>) -> tensor<4xf32>
-// CHECK-DAG:       [[VAR_9_:%.+]] = tensor.empty() : tensor<4xi32>
-// CHECK:           [[VAR_10_:%.+]] = linalg.fill ins([[CST_minus_1_]] : i32) outs([[VAR_9_]] : tensor<4xi32>) -> tensor<4xi32>
-// CHECK:           [[VAR_reduced_:%.+]]:2 = linalg.reduce ins([[VAR_4_]], [[VAR_6_]] : tensor<4x4xf32>, tensor<4x4xi32>) outs([[VAR_8_]], [[VAR_10_]] : tensor<4xf32>, tensor<4xi32>) dimensions = [1]
+// CHECK-DAG:       [[VAR_9_:%.+]] = linalg.fill ins([[CST_minus_1_]] : i32) outs([[VAR_0_]] : tensor<4xi32>) -> tensor<4xi32>
+// CHECK:           [[VAR_reduced_:%.+]]:2 = linalg.reduce ins([[VAR_4_]], [[VAR_6_]] : tensor<4x4xf32>, tensor<4x4xi32>) outs([[VAR_8_]], [[VAR_9_]] : tensor<4xf32>, tensor<4xi32>) dimensions = [1]
 // CHECK:             ([[IN_1_:%.+]]: f32, [[in_1_:%.+]]: i32, [[init_:%.+]]: f32, [[init_2_:%.+]]: i32) {
-// CHECK-DAG:           [[VAR_13_1_:%.+]] = arith.cmpf oeq, [[IN_1_]], [[init_]] : f32
-// CHECK-DAG:           [[VAR_14_1_:%.+]] = arith.cmpi slt, [[in_1_]], [[init_2_]] : i32
+// CHECK-DAG:           [[VAR_11_1_:%.+]] = arith.cmpf oeq, [[IN_1_]], [[init_]] : f32
+// CHECK-DAG:           [[VAR_12_1_:%.+]] = arith.cmpi slt, [[in_1_]], [[init_2_]] : i32
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:           [[VAR_15_:%.+]] = arith.andi [[VAR_13_1_]], [[VAR_14_1_]] : i1
-// CHECK-DAG:           [[VAR_16_:%.+]] = arith.cmpf olt, [[IN_1_]], [[init_]] : f32
-// CHECK:               [[VAR_17_:%.+]] = arith.ori [[VAR_16_]], [[VAR_15_]] : i1
-// CHECK-DAG:           [[VAR_18_:%.+]] = arith.select [[VAR_17_]], [[IN_1_]], [[init_]] : f32
-// CHECK-DAG:           [[VAR_19_:%.+]] = arith.select [[VAR_17_]], [[in_1_]], [[init_2_]] : i32
-// CHECK:               linalg.yield [[VAR_18_]], [[VAR_19_]] : f32, i32
+// CHECK-DAG:           [[VAR_13_:%.+]] = arith.andi [[VAR_11_1_]], [[VAR_12_1_]] : i1
+// CHECK-DAG:           [[VAR_14_:%.+]] = arith.cmpf olt, [[IN_1_]], [[init_]] : f32
+// CHECK:               [[VAR_15_:%.+]] = arith.ori [[VAR_14_]], [[VAR_13_]] : i1
+// CHECK-DAG:           [[VAR_16_:%.+]] = arith.select [[VAR_15_]], [[IN_1_]], [[init_]] : f32
+// CHECK-DAG:           [[VAR_17_:%.+]] = arith.select [[VAR_15_]], [[in_1_]], [[init_2_]] : i32
+// CHECK:               linalg.yield [[VAR_16_]], [[VAR_17_]] : f32, i32
 // CHECK:             }
 // CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: [0], sizes: [4], strides: [1] : memref<*xf32> to memref<4xf32, strided<[1]>>
-// CHECK-DAG:       [[VAR_11_:%.+]] = tensor.empty() : tensor<4xf32>
-// CHECK:           [[VAR_12_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_reduced_]]#1 : tensor<4xi32>) outs([[VAR_11_]] : tensor<4xf32>) {
+// CHECK-DAG:       [[VAR_10_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_reduced_]]#1 : tensor<4xi32>) outs([[VAR_7_]] : tensor<4xf32>) {
 // CHECK:           ^bb0([[IN_3_:%.+]]: i32, [[IN_4_:%.+]]: f32):
-// CHECK:             [[VAR_13_2_:%.+]] = arith.sitofp [[IN_3_]] : i32 to f32
-// CHECK:             linalg.yield [[VAR_13_2_]] : f32
+// CHECK:             [[VAR_11_2_:%.+]] = arith.sitofp [[IN_3_]] : i32 to f32
+// CHECK:             linalg.yield [[VAR_11_2_]] : f32
 // CHECK:           } -> tensor<4xf32>
-// CHECK:           bufferization.materialize_in_destination [[VAR_12_]] in writable [[VAR_reinterpret_cast_0_]] : (tensor<4xf32>, memref<4xf32, strided<[1]>>) -> ()
+// CHECK:           bufferization.materialize_in_destination [[VAR_10_]] in writable [[VAR_reinterpret_cast_0_]] : (tensor<4xf32>, memref<4xf32, strided<[1]>>) -> ()
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/StructuredToMemref/convert_extern_elementwise.mlir
+++ b/test/Conversion/StructuredToMemref/convert_extern_elementwise.mlir
@@ -625,50 +625,38 @@ module {
   }
 }
 
-// mlir2FileCheck.py
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
 // CHECK-LABEL:  func.func @atan2_kernel_0123
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: memref<*xf32>, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32) {
 // CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
 // CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
 // CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_7_]], [[CST_32_]] : i32
-// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_3_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_4_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_5_:%.+]] = arith.addi [[VAR_4_]], [[CST_32_1_]] : index
-// CHECK-DAG:       [[VAR_6_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
-// CHECK:           [[VAR_7_:%.+]] = arith.minsi [[VAR_5_]], [[VAR_6_]] : index
-// CHECK-DAG:       [[VAR_8_:%.+]] = arith.subi [[VAR_7_]], [[VAR_4_]] : index
+// CHECK:           [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.addi [[VAR_1_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
+// CHECK:           [[VAR_4_:%.+]] = arith.minsi [[VAR_2_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.subi [[VAR_4_]], [[VAR_1_]] : index
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_8_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_8_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
 // CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
-// CHECK-DAG:       [[VAR_9_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
-// CHECK-DAG:       [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_10_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_11_:%.+]] = arith.addi [[VAR_10_]], [[CST_32_1_]] : index
-// CHECK-DAG:       [[VAR_12_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
-// CHECK:           [[VAR_13_:%.+]] = arith.minsi [[VAR_11_]], [[VAR_12_]] : index
-// CHECK-DAG:       [[VAR_14_:%.+]] = arith.subi [[VAR_13_]], [[VAR_10_]] : index
+// CHECK-DAG:       [[VAR_6_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK-DAG:       [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
 // CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc() : memref<32xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_subview_3_:%.+]] = memref.subview [[VAR_reinterpret_cast_1_]][0] {{.}}[[VAR_14_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_subview_4_:%.+]] = memref.subview [[RES_1_]][0] {{.}}[[VAR_14_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:       [[VAR_subview_3_:%.+]] = memref.subview [[VAR_reinterpret_cast_1_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_4_:%.+]] = memref.subview [[RES_1_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
 // CHECK:           memref.copy [[VAR_subview_3_]], [[VAR_subview_4_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
-// CHECK:           [[VAR_15_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<32xf32>
-// CHECK:           [[VAR_16_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_9_]], [[VAR_15_]] : tensor<32xf32>, tensor<32xf32>) outs([[VAR_9_]] : tensor<32xf32>) {
+// CHECK:           [[VAR_7_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_8_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_6_]], [[VAR_7_]] : tensor<32xf32>, tensor<32xf32>) outs([[VAR_6_]] : tensor<32xf32>) {
 // CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32, [[IN_2_:%.+]]: f32):
-// CHECK:             [[VAR_17_:%.+]] = math.atan2 [[IN_0_]], [[IN_1_]] : f32
-// CHECK:             linalg.yield [[VAR_17_]] : f32
+// CHECK:             [[VAR_9_:%.+]] = math.atan2 [[IN_0_]], [[IN_1_]] : f32
+// CHECK:             linalg.yield [[VAR_9_]] : f32
 // CHECK:           } -> tensor<32xf32>
 // CHECK:           [[VAR_reinterpret_cast_5_:%.+]] = memref.reinterpret_cast [[PARAM_2_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK:           bufferization.materialize_in_destination [[VAR_16_]] in writable [[VAR_reinterpret_cast_5_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           bufferization.materialize_in_destination [[VAR_8_]] in writable [[VAR_reinterpret_cast_5_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
@@ -677,43 +665,32 @@ module {
 // CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
 // CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
 // CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_7_]], [[CST_32_]] : i32
-// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_3_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_4_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_5_:%.+]] = arith.addi [[VAR_4_]], [[CST_32_1_]] : index
-// CHECK-DAG:       [[VAR_6_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
-// CHECK:           [[VAR_7_:%.+]] = arith.minsi [[VAR_5_]], [[VAR_6_]] : index
-// CHECK-DAG:       [[VAR_8_:%.+]] = arith.subi [[VAR_7_]], [[VAR_4_]] : index
+// CHECK:           [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.addi [[VAR_1_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
+// CHECK:           [[VAR_4_:%.+]] = arith.minsi [[VAR_2_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.subi [[VAR_4_]], [[VAR_1_]] : index
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_8_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_8_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
 // CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
-// CHECK-DAG:       [[VAR_9_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
-// CHECK-DAG:       [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_10_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_11_:%.+]] = arith.addi [[VAR_10_]], [[CST_32_1_]] : index
-// CHECK-DAG:       [[VAR_12_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
-// CHECK:           [[VAR_13_:%.+]] = arith.minsi [[VAR_11_]], [[VAR_12_]] : index
-// CHECK-DAG:       [[VAR_14_:%.+]] = arith.subi [[VAR_13_]], [[VAR_10_]] : index
+// CHECK-DAG:       [[VAR_6_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK-DAG:       [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
 // CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc() : memref<32xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_subview_3_:%.+]] = memref.subview [[VAR_reinterpret_cast_1_]][0] {{.}}[[VAR_14_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_subview_4_:%.+]] = memref.subview [[RES_1_]][0] {{.}}[[VAR_14_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:       [[VAR_subview_3_:%.+]] = memref.subview [[VAR_reinterpret_cast_1_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_4_:%.+]] = memref.subview [[RES_1_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
 // CHECK:           memref.copy [[VAR_subview_3_]], [[VAR_subview_4_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
-// CHECK:           [[VAR_15_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<32xf32>
-// CHECK:           [[VAR_16_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_9_]], [[VAR_15_]] : tensor<32xf32>, tensor<32xf32>) outs([[VAR_9_]] : tensor<32xf32>) {
+// CHECK:           [[VAR_7_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_8_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_6_]], [[VAR_7_]] : tensor<32xf32>, tensor<32xf32>) outs([[VAR_6_]] : tensor<32xf32>) {
 // CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32, [[IN_2_:%.+]]: f32):
-// CHECK:             [[VAR_17_:%.+]] = math.powf [[IN_0_]], [[IN_1_]] : f32
-// CHECK:             linalg.yield [[VAR_17_]] : f32
+// CHECK:             [[VAR_9_:%.+]] = math.powf [[IN_0_]], [[IN_1_]] : f32
+// CHECK:             linalg.yield [[VAR_9_]] : f32
 // CHECK:           } -> tensor<32xf32>
 // CHECK:           [[VAR_reinterpret_cast_5_:%.+]] = memref.reinterpret_cast [[PARAM_2_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK:           bufferization.materialize_in_destination [[VAR_16_]] in writable [[VAR_reinterpret_cast_5_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           bufferization.materialize_in_destination [[VAR_8_]] in writable [[VAR_reinterpret_cast_5_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
@@ -722,29 +699,25 @@ module {
 // CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
 // CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
 // CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
-// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
-// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
-// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
-// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK:           [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.addi [[VAR_1_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_4_:%.+]] = arith.minsi [[VAR_2_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.subi [[VAR_4_]], [[VAR_1_]] : index
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
 // CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
-// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
-// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           [[VAR_6_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_6_]] : tensor<32xf32>) outs([[VAR_6_]] : tensor<32xf32>) {
 // CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
-// CHECK:             [[VAR_10_:%.+]] = math.absf [[IN_0_]] : f32
-// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:             [[VAR_8_:%.+]] = math.absf [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_8_]] : f32
 // CHECK:           } -> tensor<32xf32>
 // CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           bufferization.materialize_in_destination [[VAR_7_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
@@ -753,29 +726,25 @@ module {
 // CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
 // CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
 // CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
-// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
-// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
-// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
-// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK:           [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.addi [[VAR_1_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_4_:%.+]] = arith.minsi [[VAR_2_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.subi [[VAR_4_]], [[VAR_1_]] : index
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
 // CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
-// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
-// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           [[VAR_6_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_6_]] : tensor<32xf32>) outs([[VAR_6_]] : tensor<32xf32>) {
 // CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
-// CHECK:             [[VAR_10_:%.+]] = math.sin [[IN_0_]] : f32
-// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:             [[VAR_8_:%.+]] = math.sin [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_8_]] : f32
 // CHECK:           } -> tensor<32xf32>
 // CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           bufferization.materialize_in_destination [[VAR_7_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
@@ -784,29 +753,25 @@ module {
 // CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
 // CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
 // CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
-// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
-// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
-// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
-// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK:           [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.addi [[VAR_1_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_4_:%.+]] = arith.minsi [[VAR_2_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.subi [[VAR_4_]], [[VAR_1_]] : index
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
 // CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
-// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
-// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           [[VAR_6_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_6_]] : tensor<32xf32>) outs([[VAR_6_]] : tensor<32xf32>) {
 // CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
-// CHECK:             [[VAR_10_:%.+]] = math.cos [[IN_0_]] : f32
-// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:             [[VAR_8_:%.+]] = math.cos [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_8_]] : f32
 // CHECK:           } -> tensor<32xf32>
 // CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           bufferization.materialize_in_destination [[VAR_7_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
@@ -815,29 +780,25 @@ module {
 // CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
 // CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
 // CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
-// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
-// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
-// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
-// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK:           [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.addi [[VAR_1_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_4_:%.+]] = arith.minsi [[VAR_2_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.subi [[VAR_4_]], [[VAR_1_]] : index
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
 // CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
-// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
-// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           [[VAR_6_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_6_]] : tensor<32xf32>) outs([[VAR_6_]] : tensor<32xf32>) {
 // CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
-// CHECK:             [[VAR_10_:%.+]] = math.tan [[IN_0_]] : f32
-// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:             [[VAR_8_:%.+]] = math.tan [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_8_]] : f32
 // CHECK:           } -> tensor<32xf32>
 // CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           bufferization.materialize_in_destination [[VAR_7_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
@@ -846,29 +807,25 @@ module {
 // CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
 // CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
 // CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
-// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
-// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
-// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
-// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK:           [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.addi [[VAR_1_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_4_:%.+]] = arith.minsi [[VAR_2_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.subi [[VAR_4_]], [[VAR_1_]] : index
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
 // CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
-// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
-// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           [[VAR_6_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_6_]] : tensor<32xf32>) outs([[VAR_6_]] : tensor<32xf32>) {
 // CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
-// CHECK:             [[VAR_10_:%.+]] = math.asin [[IN_0_]] : f32
-// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:             [[VAR_8_:%.+]] = math.asin [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_8_]] : f32
 // CHECK:           } -> tensor<32xf32>
 // CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           bufferization.materialize_in_destination [[VAR_7_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
@@ -877,29 +834,25 @@ module {
 // CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
 // CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
 // CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
-// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
-// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
-// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
-// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK:           [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.addi [[VAR_1_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_4_:%.+]] = arith.minsi [[VAR_2_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.subi [[VAR_4_]], [[VAR_1_]] : index
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
 // CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
-// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
-// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           [[VAR_6_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_6_]] : tensor<32xf32>) outs([[VAR_6_]] : tensor<32xf32>) {
 // CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
-// CHECK:             [[VAR_10_:%.+]] = math.acos [[IN_0_]] : f32
-// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:             [[VAR_8_:%.+]] = math.acos [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_8_]] : f32
 // CHECK:           } -> tensor<32xf32>
 // CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           bufferization.materialize_in_destination [[VAR_7_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
@@ -908,29 +861,25 @@ module {
 // CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
 // CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
 // CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
-// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
-// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
-// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
-// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK:           [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.addi [[VAR_1_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_4_:%.+]] = arith.minsi [[VAR_2_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.subi [[VAR_4_]], [[VAR_1_]] : index
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
 // CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
-// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
-// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           [[VAR_6_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_6_]] : tensor<32xf32>) outs([[VAR_6_]] : tensor<32xf32>) {
 // CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
-// CHECK:             [[VAR_10_:%.+]] = math.atan [[IN_0_]] : f32
-// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:             [[VAR_8_:%.+]] = math.atan [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_8_]] : f32
 // CHECK:           } -> tensor<32xf32>
 // CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           bufferization.materialize_in_destination [[VAR_7_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
@@ -939,29 +888,25 @@ module {
 // CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
 // CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
 // CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
-// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
-// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
-// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
-// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK:           [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.addi [[VAR_1_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_4_:%.+]] = arith.minsi [[VAR_2_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.subi [[VAR_4_]], [[VAR_1_]] : index
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
 // CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
-// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
-// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           [[VAR_6_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_6_]] : tensor<32xf32>) outs([[VAR_6_]] : tensor<32xf32>) {
 // CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
-// CHECK:             [[VAR_10_:%.+]] = math.sinh [[IN_0_]] : f32
-// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:             [[VAR_8_:%.+]] = math.sinh [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_8_]] : f32
 // CHECK:           } -> tensor<32xf32>
 // CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           bufferization.materialize_in_destination [[VAR_7_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
@@ -970,29 +915,25 @@ module {
 // CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
 // CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
 // CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
-// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
-// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
-// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
-// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK:           [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.addi [[VAR_1_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_4_:%.+]] = arith.minsi [[VAR_2_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.subi [[VAR_4_]], [[VAR_1_]] : index
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
 // CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
-// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
-// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           [[VAR_6_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_6_]] : tensor<32xf32>) outs([[VAR_6_]] : tensor<32xf32>) {
 // CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
-// CHECK:             [[VAR_10_:%.+]] = math.cosh [[IN_0_]] : f32
-// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:             [[VAR_8_:%.+]] = math.cosh [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_8_]] : f32
 // CHECK:           } -> tensor<32xf32>
 // CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           bufferization.materialize_in_destination [[VAR_7_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
@@ -1001,29 +942,25 @@ module {
 // CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
 // CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
 // CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
-// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
-// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
-// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
-// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK:           [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.addi [[VAR_1_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_4_:%.+]] = arith.minsi [[VAR_2_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.subi [[VAR_4_]], [[VAR_1_]] : index
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
 // CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
-// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
-// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           [[VAR_6_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_6_]] : tensor<32xf32>) outs([[VAR_6_]] : tensor<32xf32>) {
 // CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
-// CHECK:             [[VAR_10_:%.+]] = math.tanh [[IN_0_]] : f32
-// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:             [[VAR_8_:%.+]] = math.tanh [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_8_]] : f32
 // CHECK:           } -> tensor<32xf32>
 // CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           bufferization.materialize_in_destination [[VAR_7_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
@@ -1032,29 +969,25 @@ module {
 // CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
 // CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
 // CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
-// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
-// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
-// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
-// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK:           [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.addi [[VAR_1_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_4_:%.+]] = arith.minsi [[VAR_2_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.subi [[VAR_4_]], [[VAR_1_]] : index
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
 // CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
-// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
-// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           [[VAR_6_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_6_]] : tensor<32xf32>) outs([[VAR_6_]] : tensor<32xf32>) {
 // CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
-// CHECK:             [[VAR_10_:%.+]] = math.asinh [[IN_0_]] : f32
-// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:             [[VAR_8_:%.+]] = math.asinh [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_8_]] : f32
 // CHECK:           } -> tensor<32xf32>
 // CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           bufferization.materialize_in_destination [[VAR_7_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
@@ -1063,29 +996,25 @@ module {
 // CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
 // CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
 // CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
-// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
-// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
-// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
-// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK:           [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.addi [[VAR_1_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_4_:%.+]] = arith.minsi [[VAR_2_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.subi [[VAR_4_]], [[VAR_1_]] : index
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
 // CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
-// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
-// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           [[VAR_6_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_6_]] : tensor<32xf32>) outs([[VAR_6_]] : tensor<32xf32>) {
 // CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
-// CHECK:             [[VAR_10_:%.+]] = math.acosh [[IN_0_]] : f32
-// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:             [[VAR_8_:%.+]] = math.acosh [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_8_]] : f32
 // CHECK:           } -> tensor<32xf32>
 // CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           bufferization.materialize_in_destination [[VAR_7_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
@@ -1094,29 +1023,25 @@ module {
 // CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
 // CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
 // CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
-// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
-// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
-// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
-// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK:           [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.addi [[VAR_1_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_4_:%.+]] = arith.minsi [[VAR_2_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.subi [[VAR_4_]], [[VAR_1_]] : index
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
 // CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
-// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
-// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           [[VAR_6_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_6_]] : tensor<32xf32>) outs([[VAR_6_]] : tensor<32xf32>) {
 // CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
-// CHECK:             [[VAR_10_:%.+]] = math.atanh [[IN_0_]] : f32
-// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:             [[VAR_8_:%.+]] = math.atanh [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_8_]] : f32
 // CHECK:           } -> tensor<32xf32>
 // CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           bufferization.materialize_in_destination [[VAR_7_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
@@ -1125,29 +1050,25 @@ module {
 // CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
 // CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
 // CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
-// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
-// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
-// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
-// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK:           [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.addi [[VAR_1_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_4_:%.+]] = arith.minsi [[VAR_2_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.subi [[VAR_4_]], [[VAR_1_]] : index
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
 // CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
-// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
-// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           [[VAR_6_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_6_]] : tensor<32xf32>) outs([[VAR_6_]] : tensor<32xf32>) {
 // CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
-// CHECK:             [[VAR_10_:%.+]] = math.log [[IN_0_]] : f32
-// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:             [[VAR_8_:%.+]] = math.log [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_8_]] : f32
 // CHECK:           } -> tensor<32xf32>
 // CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           bufferization.materialize_in_destination [[VAR_7_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
@@ -1156,29 +1077,25 @@ module {
 // CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
 // CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
 // CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
-// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
-// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
-// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
-// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK:           [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.addi [[VAR_1_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_4_:%.+]] = arith.minsi [[VAR_2_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.subi [[VAR_4_]], [[VAR_1_]] : index
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
 // CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
-// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
-// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           [[VAR_6_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_6_]] : tensor<32xf32>) outs([[VAR_6_]] : tensor<32xf32>) {
 // CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
-// CHECK:             [[VAR_10_:%.+]] = math.log10 [[IN_0_]] : f32
-// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:             [[VAR_8_:%.+]] = math.log10 [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_8_]] : f32
 // CHECK:           } -> tensor<32xf32>
 // CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           bufferization.materialize_in_destination [[VAR_7_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
@@ -1187,29 +1104,25 @@ module {
 // CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
 // CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
 // CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
-// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
-// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
-// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
-// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK:           [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.addi [[VAR_1_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_4_:%.+]] = arith.minsi [[VAR_2_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.subi [[VAR_4_]], [[VAR_1_]] : index
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
 // CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
-// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
-// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           [[VAR_6_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_6_]] : tensor<32xf32>) outs([[VAR_6_]] : tensor<32xf32>) {
 // CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
-// CHECK:             [[VAR_10_:%.+]] = math.log1p [[IN_0_]] : f32
-// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:             [[VAR_8_:%.+]] = math.log1p [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_8_]] : f32
 // CHECK:           } -> tensor<32xf32>
 // CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           bufferization.materialize_in_destination [[VAR_7_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
@@ -1218,29 +1131,25 @@ module {
 // CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
 // CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
 // CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
-// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
-// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
-// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
-// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK:           [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.addi [[VAR_1_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_4_:%.+]] = arith.minsi [[VAR_2_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.subi [[VAR_4_]], [[VAR_1_]] : index
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
 // CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
-// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
-// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           [[VAR_6_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_6_]] : tensor<32xf32>) outs([[VAR_6_]] : tensor<32xf32>) {
 // CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
-// CHECK:             [[VAR_10_:%.+]] = math.exp [[IN_0_]] : f32
-// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:             [[VAR_8_:%.+]] = math.exp [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_8_]] : f32
 // CHECK:           } -> tensor<32xf32>
 // CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           bufferization.materialize_in_destination [[VAR_7_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
@@ -1249,29 +1158,25 @@ module {
 // CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
 // CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
 // CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
-// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
-// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
-// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
-// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK:           [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.addi [[VAR_1_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_4_:%.+]] = arith.minsi [[VAR_2_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.subi [[VAR_4_]], [[VAR_1_]] : index
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
 // CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
-// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
-// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           [[VAR_6_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_6_]] : tensor<32xf32>) outs([[VAR_6_]] : tensor<32xf32>) {
 // CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
-// CHECK:             [[VAR_10_:%.+]] = math.exp2 [[IN_0_]] : f32
-// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:             [[VAR_8_:%.+]] = math.exp2 [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_8_]] : f32
 // CHECK:           } -> tensor<32xf32>
 // CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           bufferization.materialize_in_destination [[VAR_7_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
@@ -1280,29 +1185,25 @@ module {
 // CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
 // CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
 // CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
-// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
-// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
-// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
-// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK:           [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.addi [[VAR_1_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_4_:%.+]] = arith.minsi [[VAR_2_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.subi [[VAR_4_]], [[VAR_1_]] : index
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
 // CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
-// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
-// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           [[VAR_6_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_6_]] : tensor<32xf32>) outs([[VAR_6_]] : tensor<32xf32>) {
 // CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
-// CHECK:             [[VAR_10_:%.+]] = math.erf [[IN_0_]] : f32
-// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:             [[VAR_8_:%.+]] = math.erf [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_8_]] : f32
 // CHECK:           } -> tensor<32xf32>
 // CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           bufferization.materialize_in_destination [[VAR_7_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
@@ -1311,29 +1212,25 @@ module {
 // CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
 // CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
 // CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
-// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
-// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
-// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
-// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK:           [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.addi [[VAR_1_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_4_:%.+]] = arith.minsi [[VAR_2_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.subi [[VAR_4_]], [[VAR_1_]] : index
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
 // CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
-// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
-// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           [[VAR_6_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_6_]] : tensor<32xf32>) outs([[VAR_6_]] : tensor<32xf32>) {
 // CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
-// CHECK:             [[VAR_10_:%.+]] = math.sqrt [[IN_0_]] : f32
-// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:             [[VAR_8_:%.+]] = math.sqrt [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_8_]] : f32
 // CHECK:           } -> tensor<32xf32>
 // CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           bufferization.materialize_in_destination [[VAR_7_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
@@ -1342,29 +1239,25 @@ module {
 // CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
 // CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
 // CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
-// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
-// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
-// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
-// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK:           [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.addi [[VAR_1_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_4_:%.+]] = arith.minsi [[VAR_2_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.subi [[VAR_4_]], [[VAR_1_]] : index
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
 // CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
-// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
-// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           [[VAR_6_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_6_]] : tensor<32xf32>) outs([[VAR_6_]] : tensor<32xf32>) {
 // CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
-// CHECK:             [[VAR_10_:%.+]] = math.rsqrt [[IN_0_]] : f32
-// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:             [[VAR_8_:%.+]] = math.rsqrt [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_8_]] : f32
 // CHECK:           } -> tensor<32xf32>
 // CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           bufferization.materialize_in_destination [[VAR_7_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
@@ -1373,29 +1266,25 @@ module {
 // CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
 // CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
 // CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
-// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
-// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
-// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
-// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK:           [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.addi [[VAR_1_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_4_:%.+]] = arith.minsi [[VAR_2_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.subi [[VAR_4_]], [[VAR_1_]] : index
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
 // CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
-// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
-// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           [[VAR_6_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_6_]] : tensor<32xf32>) outs([[VAR_6_]] : tensor<32xf32>) {
 // CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
-// CHECK:             [[VAR_10_:%.+]] = math.ceil [[IN_0_]] : f32
-// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:             [[VAR_8_:%.+]] = math.ceil [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_8_]] : f32
 // CHECK:           } -> tensor<32xf32>
 // CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           bufferization.materialize_in_destination [[VAR_7_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
@@ -1404,29 +1293,25 @@ module {
 // CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
 // CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
 // CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
-// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
-// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
-// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
-// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK:           [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.addi [[VAR_1_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_4_:%.+]] = arith.minsi [[VAR_2_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.subi [[VAR_4_]], [[VAR_1_]] : index
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
 // CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
-// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
-// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           [[VAR_6_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_6_]] : tensor<32xf32>) outs([[VAR_6_]] : tensor<32xf32>) {
 // CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
-// CHECK:             [[VAR_10_:%.+]] = math.floor [[IN_0_]] : f32
-// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:             [[VAR_8_:%.+]] = math.floor [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_8_]] : f32
 // CHECK:           } -> tensor<32xf32>
 // CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           bufferization.materialize_in_destination [[VAR_7_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
@@ -1435,28 +1320,24 @@ module {
 // CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
 // CHECK-DAG:       [[CST_32_1_:%.+]] = arith.constant 32 : index
 // CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[CST_32_]] : i32
-// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[VAR_3_]], [[CST_32_1_]] : index
-// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
-// CHECK:           [[VAR_6_:%.+]] = arith.minsi [[VAR_4_]], [[VAR_5_]] : index
-// CHECK-DAG:       [[VAR_7_:%.+]] = arith.subi [[VAR_6_]], [[VAR_3_]] : index
+// CHECK:           [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.addi [[VAR_1_]], [[CST_32_1_]] : index
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
+// CHECK:           [[VAR_4_:%.+]] = arith.minsi [[VAR_2_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.subi [[VAR_4_]], [[VAR_1_]] : index
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_7_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<32xf32> to memref<?xf32, strided<[1]>>
 // CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
-// CHECK:           [[VAR_8_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
-// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<32xf32>) outs([[VAR_8_]] : tensor<32xf32>) {
+// CHECK:           [[VAR_6_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK:           [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_6_]] : tensor<32xf32>) outs([[VAR_6_]] : tensor<32xf32>) {
 // CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
-// CHECK:             [[VAR_10_:%.+]] = math.trunc [[IN_0_]] : f32
-// CHECK:             linalg.yield [[VAR_10_]] : f32
+// CHECK:             [[VAR_8_:%.+]] = math.trunc [[IN_0_]] : f32
+// CHECK:             linalg.yield [[VAR_8_]] : f32
 // CHECK:           } -> tensor<32xf32>
 // CHECK:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
-// CHECK:           bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           bufferization.materialize_in_destination [[VAR_7_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<32xf32>, memref<32xf32, strided<[1], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/StructuredToMemref/convert_tensor_reshape.mlir
+++ b/test/Conversion/StructuredToMemref/convert_tensor_reshape.mlir
@@ -23,8 +23,6 @@ module {
   }
 }
 
-
-// mlir2FileCheck.py
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0, d1) -> (0, d1)>
 // CHECK-DAG:   [[MAP_1_:#.+]] = affine_map<(d0, d1) -> (d0, d1)>
 // CHECK-LABEL:  func.func @bcast_kernel_01
@@ -33,22 +31,20 @@ module {
 // CHECK-DAG:       [[VAR_cst_:%.+]] = arith.constant dense<[1, 32]> : tensor<2xi64>
 // CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : i32
 // CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_5_]], [[CST_32_]] : i32
-// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
+// CHECK:           [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [32], strides: [1] : memref<*xf32> to memref<32xf32, strided<[1], offset: ?>>
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32xf32>
 // CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<32xf32, strided<[1], offset: ?>> to memref<32xf32>
-// CHECK:           [[VAR_3_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
-// CHECK-DAG:       [[VAR_reshape_:%.+]] = tensor.reshape [[VAR_3_]]([[VAR_cst_]]) : (tensor<32xf32>, tensor<2xi64>) -> tensor<1x32xf32>
-// CHECK-DAG:       [[VAR_4_:%.+]] = tensor.empty() : tensor<64x32xf32>
-// CHECK:           [[VAR_5_:%.+]] = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel"]} ins([[VAR_reshape_]] : tensor<1x32xf32>) outs([[VAR_4_]] : tensor<64x32xf32>) attrs =  {broadcastDims = array<i64: 0>} {
+// CHECK:           [[VAR_2_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32xf32>
+// CHECK-DAG:       [[VAR_reshape_:%.+]] = tensor.reshape [[VAR_2_]]([[VAR_cst_]]) : (tensor<32xf32>, tensor<2xi64>) -> tensor<1x32xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tensor.empty() : tensor<64x32xf32>
+// CHECK:           [[VAR_4_:%.+]] = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel"]} ins([[VAR_reshape_]] : tensor<1x32xf32>) outs([[VAR_3_]] : tensor<64x32xf32>) attrs =  {broadcastDims = array<i64: 0>} {
 // CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32):
 // CHECK:             linalg.yield [[IN_0_]] : f32
 // CHECK:           } -> tensor<64x32xf32>
-// CHECK:           [[VAR_6_:%.+]] = tensor.empty() : tensor<1xi64>
-// CHECK:           [[VAR_7_:%.+]] = linalg.fill ins([[CST_2048_]] : i64) outs([[VAR_6_]] : tensor<1xi64>) -> tensor<1xi64>
-// CHECK-DAG:       [[VAR_reshape_0_:%.+]] = tensor.reshape [[VAR_5_]]([[VAR_7_]]) : (tensor<64x32xf32>, tensor<1xi64>) -> tensor<2048xf32>
+// CHECK:           [[VAR_5_:%.+]] = tensor.empty() : tensor<1xi64>
+// CHECK:           [[VAR_6_:%.+]] = linalg.fill ins([[CST_2048_]] : i64) outs([[VAR_5_]] : tensor<1xi64>) -> tensor<1xi64>
+// CHECK-DAG:       [[VAR_reshape_0_:%.+]] = tensor.reshape [[VAR_4_]]([[VAR_6_]]) : (tensor<64x32xf32>, tensor<1xi64>) -> tensor<2048xf32>
 // CHECK-DAG:       [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [2048], strides: [1] : memref<*xf32> to memref<2048xf32, strided<[1], offset: ?>>
 // CHECK:           bufferization.materialize_in_destination [[VAR_reshape_0_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<2048xf32>, memref<2048xf32, strided<[1], offset: ?>>) -> ()
 // CHECK:           return

--- a/test/Conversion/StructuredToMemref/cumsum.mlir
+++ b/test/Conversion/StructuredToMemref/cumsum.mlir
@@ -42,28 +42,25 @@ module {
   }
 }
 
-// mlir2FileCheck.py
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
 // CHECK-LABEL:  func.func @test_cumsum_op_012
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xi32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
 // CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[PARAM_2_]] : i32
-// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [4096], strides: [1] : memref<*xf32> to memref<4096xf32, strided<[1], offset: ?>>
+// CHECK:           [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [4096], strides: [1] : memref<*xf32> to memref<4096xf32, strided<[1], offset: ?>>
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<4096xf32>
 // CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<4096xf32, strided<[1], offset: ?>> to memref<4096xf32>
-// CHECK-DAG:       [[VAR_3_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<4096xf32>
-// CHECK-DAG:       [[VAR_4_:%.+]] = tensor.empty() : tensor<4096xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<4096xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = tensor.empty() : tensor<4096xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_5_:%.+]] = ttx.cumsum {axis = 0 : ui32, operandSegmentSizes = array<i32: 1, 1>} ins([[VAR_3_]] : tensor<4096xf32>) outs([[VAR_4_]] : tensor<4096xf32>) -> tensor<4096xf32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = ttx.cumsum {axis = 0 : ui32, operandSegmentSizes = array<i32: 1, 1>} ins([[VAR_2_]] : tensor<4096xf32>) outs([[VAR_3_]] : tensor<4096xf32>) -> tensor<4096xf32>
 // CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [4096], strides: [1] : memref<*xi32> to memref<4096xi32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_6_:%.+]] = tensor.empty() : tensor<4096xi32>
-// CHECK:           [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_5_]] : tensor<4096xf32>) outs([[VAR_6_]] : tensor<4096xi32>) {
+// CHECK-DAG:       [[VAR_5_:%.+]] = tensor.empty() : tensor<4096xi32>
+// CHECK:           [[VAR_6_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_4_]] : tensor<4096xf32>) outs([[VAR_5_]] : tensor<4096xi32>) {
 // CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: i32):
-// CHECK:             [[VAR_8_:%.+]] = arith.fptosi [[IN_0_]] : f32 to i32
-// CHECK:             linalg.yield [[VAR_8_]] : i32
+// CHECK:             [[VAR_7_:%.+]] = arith.fptosi [[IN_0_]] : f32 to i32
+// CHECK:             linalg.yield [[VAR_7_]] : i32
 // CHECK:           } -> tensor<4096xi32>
-// CHECK:           bufferization.materialize_in_destination [[VAR_7_]] in writable [[VAR_reinterpret_cast_0_]] : (tensor<4096xi32>, memref<4096xi32, strided<[1], offset: ?>>) -> ()
+// CHECK:           bufferization.materialize_in_destination [[VAR_6_]] in writable [[VAR_reinterpret_cast_0_]] : (tensor<4096xi32>, memref<4096xi32, strided<[1], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/StructuredToMemref/get_num_programs.mlir
+++ b/test/Conversion/StructuredToMemref/get_num_programs.mlir
@@ -22,7 +22,6 @@ module {
   }
 }
 
-// mlir2FileCheck.py
 // CHECK-LABEL:  func.func @num_programs
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xi32>, [[PARAM_1_:%.+]]: i32, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32) {
 // CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [1], strides: [1] : memref<*xi32> to memref<1xi32, strided<[1]>>
@@ -30,12 +29,10 @@ module {
 // CHECK:           [[VAR_1_:%.+]] = linalg.fill ins([[PARAM_1_]] : i32) outs([[VAR_0_]] : tensor<1xi32>) -> tensor<1xi32>
 // CHECK:           bufferization.materialize_in_destination [[VAR_1_]] in writable [[VAR_reinterpret_cast_]] : (tensor<1xi32>, memref<1xi32, strided<[1]>>) -> ()
 // CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [1], sizes: [1], strides: [1] : memref<*xi32> to memref<1xi32, strided<[1], offset: 1>>
-// CHECK-DAG:       [[VAR_2_:%.+]] = tensor.empty() : tensor<1xi32>
-// CHECK:           [[VAR_3_:%.+]] = linalg.fill ins([[PARAM_2_]] : i32) outs([[VAR_2_]] : tensor<1xi32>) -> tensor<1xi32>
-// CHECK:           bufferization.materialize_in_destination [[VAR_3_]] in writable [[VAR_reinterpret_cast_0_]] : (tensor<1xi32>, memref<1xi32, strided<[1], offset: 1>>) -> ()
+// CHECK-DAG:       [[VAR_2_:%.+]] = linalg.fill ins([[PARAM_2_]] : i32) outs([[VAR_0_]] : tensor<1xi32>) -> tensor<1xi32>
+// CHECK:           bufferization.materialize_in_destination [[VAR_2_]] in writable [[VAR_reinterpret_cast_0_]] : (tensor<1xi32>, memref<1xi32, strided<[1], offset: 1>>) -> ()
 // CHECK-DAG:       [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [2], sizes: [1], strides: [1] : memref<*xi32> to memref<1xi32, strided<[1], offset: 2>>
-// CHECK-DAG:       [[VAR_4_:%.+]] = tensor.empty() : tensor<1xi32>
-// CHECK:           [[VAR_5_:%.+]] = linalg.fill ins([[PARAM_3_]] : i32) outs([[VAR_4_]] : tensor<1xi32>) -> tensor<1xi32>
-// CHECK:           bufferization.materialize_in_destination [[VAR_5_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<1xi32>, memref<1xi32, strided<[1], offset: 2>>) -> ()
+// CHECK-DAG:       [[VAR_3_:%.+]] = linalg.fill ins([[PARAM_3_]] : i32) outs([[VAR_0_]] : tensor<1xi32>) -> tensor<1xi32>
+// CHECK:           bufferization.materialize_in_destination [[VAR_3_]] in writable [[VAR_reinterpret_cast_1_]] : (tensor<1xi32>, memref<1xi32, strided<[1], offset: 2>>) -> ()
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/StructuredToMemref/kernel-01-vector-add.mlir
+++ b/test/Conversion/StructuredToMemref/kernel-01-vector-add.mlir
@@ -24,57 +24,39 @@ module {
   }
 }
 
-// mlir2FileCheck.py
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
 // CHECK-LABEL:  func.func @add_kernel_01234
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: memref<*xf32>, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32) {
 // CHECK-DAG:       [[CST_1024_:%.+]] = arith.constant 1024 : i32
 // CHECK-DAG:       [[CST_1024_1_:%.+]] = arith.constant 1024 : index
 // CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_7_]], [[CST_1024_]] : i32
-// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_3_]]{{.}}, sizes: [1024], strides: [1] : memref<*xf32> to memref<1024xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_4_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_5_:%.+]] = arith.addi [[VAR_4_]], [[CST_1024_1_]] : index
-// CHECK-DAG:       [[VAR_6_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
-// CHECK:           [[VAR_7_:%.+]] = arith.minsi [[VAR_5_]], [[VAR_6_]] : index
-// CHECK-DAG:       [[VAR_8_:%.+]] = arith.subi [[VAR_7_]], [[VAR_4_]] : index
+// CHECK:           [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [1024], strides: [1] : memref<*xf32> to memref<1024xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.addi [[VAR_1_]], [[CST_1024_1_]] : index
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
+// CHECK:           [[VAR_4_:%.+]] = arith.minsi [[VAR_2_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.subi [[VAR_4_]], [[VAR_1_]] : index
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<1024xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_8_]]{{.}} [1] : memref<1024xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_8_]]{{.}} [1] : memref<1024xf32> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<1024xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<1024xf32> to memref<?xf32, strided<[1]>>
 // CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
-// CHECK-DAG:       [[VAR_9_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<1024xf32>
-// CHECK-DAG:       [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [1024], strides: [1] : memref<*xf32> to memref<1024xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_10_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_11_:%.+]] = arith.addi [[VAR_10_]], [[CST_1024_1_]] : index
-// CHECK-DAG:       [[VAR_12_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
-// CHECK:           [[VAR_13_:%.+]] = arith.minsi [[VAR_11_]], [[VAR_12_]] : index
-// CHECK-DAG:       [[VAR_14_:%.+]] = arith.subi [[VAR_13_]], [[VAR_10_]] : index
+// CHECK-DAG:       [[VAR_6_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<1024xf32>
+// CHECK-DAG:       [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [1024], strides: [1] : memref<*xf32> to memref<1024xf32, strided<[1], offset: ?>>
 // CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc() : memref<1024xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_subview_3_:%.+]] = memref.subview [[VAR_reinterpret_cast_1_]][0] {{.}}[[VAR_14_]]{{.}} [1] : memref<1024xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_subview_4_:%.+]] = memref.subview [[RES_1_]][0] {{.}}[[VAR_14_]]{{.}} [1] : memref<1024xf32> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:       [[VAR_subview_3_:%.+]] = memref.subview [[VAR_reinterpret_cast_1_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<1024xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_4_:%.+]] = memref.subview [[RES_1_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<1024xf32> to memref<?xf32, strided<[1]>>
 // CHECK:           memref.copy [[VAR_subview_3_]], [[VAR_subview_4_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
-// CHECK:           [[VAR_15_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<1024xf32>
-// CHECK:           [[VAR_16_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_9_]], [[VAR_15_]] : tensor<1024xf32>, tensor<1024xf32>) outs([[VAR_9_]] : tensor<1024xf32>) {
+// CHECK:           [[VAR_7_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<1024xf32>
+// CHECK:           [[VAR_8_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_6_]], [[VAR_7_]] : tensor<1024xf32>, tensor<1024xf32>) outs([[VAR_6_]] : tensor<1024xf32>) {
 // CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32, [[IN_2_:%.+]]: f32):
-// CHECK:             [[VAR_22_:%.+]] = arith.addf [[IN_0_]], [[IN_1_]] : f32
-// CHECK:             linalg.yield [[VAR_22_]] : f32
+// CHECK:             [[VAR_9_:%.+]] = arith.addf [[IN_0_]], [[IN_1_]] : f32
+// CHECK:             linalg.yield [[VAR_9_]] : f32
 // CHECK:           } -> tensor<1024xf32>
 // CHECK-DAG:       [[VAR_reinterpret_cast_5_:%.+]] = memref.reinterpret_cast [[PARAM_2_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [1024], strides: [1] : memref<*xf32> to memref<1024xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_17_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_18_:%.+]] = arith.addi [[VAR_17_]], [[CST_1024_1_]] : index
-// CHECK-DAG:       [[VAR_19_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
-// CHECK:           [[VAR_20_:%.+]] = arith.minsi [[VAR_18_]], [[VAR_19_]] : index
-// CHECK:           [[VAR_21_:%.+]] = arith.subi [[VAR_20_]], [[VAR_17_]] : index
-// CHECK-DAG:       [[VAR_extracted_slice_:%.+]] = tensor.extract_slice [[VAR_16_]][0] {{.}}[[VAR_21_]]{{.}} [1] : tensor<1024xf32> to tensor<?xf32>
-// CHECK-DAG:       [[VAR_subview_6_:%.+]] = memref.subview [[VAR_reinterpret_cast_5_]][0] {{.}}[[VAR_21_]]{{.}} [1] : memref<1024xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_extracted_slice_:%.+]] = tensor.extract_slice [[VAR_8_]][0] {{.}}[[VAR_5_]]{{.}} [1] : tensor<1024xf32> to tensor<?xf32>
+// CHECK:           [[VAR_subview_6_:%.+]] = memref.subview [[VAR_reinterpret_cast_5_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<1024xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
 // CHECK:           bufferization.materialize_in_destination [[VAR_extracted_slice_]] in writable [[VAR_subview_6_]] : (tensor<?xf32>, memref<?xf32, strided<[1], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/StructuredToMemref/kernel-02-fused-softmax.mlir
+++ b/test/Conversion/StructuredToMemref/kernel-02-fused-softmax.mlir
@@ -38,7 +38,6 @@ module {
   }
 }
 
-// mlir2FileCheck.py
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
 // CHECK-LABEL:  func.func @softmax_kernel_012345
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32, [[PARAM_10_:%.+]]: i32) {
@@ -63,45 +62,42 @@ module {
 // CHECK-DAG:       [[VAR_6_:%.+]] = bufferization.alloc_tensor() : tensor<f32>
 // CHECK:           [[VAR_inserted_:%.+]] = tensor.insert [[CST_0_]] into [[VAR_6_]][] : tensor<f32>
 // CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_5_]] : tensor<128xf32>) outs([[VAR_inserted_]] : tensor<f32>) dimensions = [0]
-// CHECK:             ([[in_:%.+]]: f32, [[init_:%.+]]: f32) {
-// CHECK:               [[VAR_19_:%.+]] = arith.maximumf [[in_]], [[init_]] : f32
-// CHECK:               linalg.yield [[VAR_19_]] : f32
+// CHECK:             ([[in_:.+]]: f32, [[init_:.+]]: f32) {
+// CHECK:               [[VAR_16_:%.+]] = arith.maximumf [[in_]], [[init_]] : f32
+// CHECK:               linalg.yield [[VAR_16_]] : f32
 // CHECK:             }
 // CHECK-DAG:       [[VAR_extracted_:%.+]] = tensor.extract [[VAR_reduced_]][] : tensor<f32>
 // CHECK-DAG:       [[VAR_7_:%.+]] = tensor.empty() : tensor<128xf32>
 // CHECK:           [[VAR_8_:%.+]] = linalg.fill ins([[VAR_extracted_]] : f32) outs([[VAR_7_]] : tensor<128xf32>) -> tensor<128xf32>
 // CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_5_]], [[VAR_8_]] : tensor<128xf32>, tensor<128xf32>) outs([[VAR_5_]] : tensor<128xf32>) {
 // CHECK:           ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32, [[IN_2_:%.+]]: f32):
-// CHECK:             [[VAR_19_1_:%.+]] = arith.subf [[IN_0_]], [[IN_1_]] : f32
-// CHECK:             linalg.yield [[VAR_19_1_]] : f32
+// CHECK:             [[VAR_16_1_:%.+]] = arith.subf [[IN_0_]], [[IN_1_]] : f32
+// CHECK:             linalg.yield [[VAR_16_1_]] : f32
 // CHECK:           } -> tensor<128xf32>
 // CHECK:           [[VAR_10_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_9_]] : tensor<128xf32>) outs([[VAR_9_]] : tensor<128xf32>) {
 // CHECK:           ^bb0([[IN_3_:%.+]]: f32, [[IN_4_:%.+]]: f32):
-// CHECK:             [[VAR_19_2_:%.+]] = math.exp [[IN_3_]] : f32
-// CHECK:             linalg.yield [[VAR_19_2_]] : f32
+// CHECK:             [[VAR_16_2_:%.+]] = math.exp [[IN_3_]] : f32
+// CHECK:             linalg.yield [[VAR_16_2_]] : f32
 // CHECK:           } -> tensor<128xf32>
 // CHECK:           [[VAR_11_:%.+]] = bufferization.alloc_tensor() : tensor<f32>
 // CHECK:           [[VAR_inserted_2_:%.+]] = tensor.insert [[CST_0_dot_000000_]] into [[VAR_11_]][] : tensor<f32>
 // CHECK:           [[VAR_reduced_3_:%.+]] = linalg.reduce ins([[VAR_10_]] : tensor<128xf32>) outs([[VAR_inserted_2_]] : tensor<f32>) dimensions = [0]
-// CHECK:             ([[IN_3_:%.+]]: f32, [[init_:%.+]]: f32) {
-// CHECK:               [[VAR_19_3_:%.+]] = arith.addf [[IN_3_]], [[init_]] : f32
-// CHECK:               linalg.yield [[VAR_19_3_]] : f32
+// CHECK:             ([[IN_3_:.+]]: f32, [[init_:.+]]: f32) {
+// CHECK:               [[VAR_16_3_:%.+]] = arith.addf [[IN_3_]], [[init_]] : f32
+// CHECK:               linalg.yield [[VAR_16_3_]] : f32
 // CHECK:             }
-// CHECK-DAG:       [[VAR_extracted_4_:%.+]] = tensor.extract [[VAR_reduced_3_]][] : tensor<f32>
-// CHECK-DAG:       [[VAR_12_:%.+]] = tensor.empty() : tensor<128xf32>
-// CHECK:           [[VAR_13_:%.+]] = linalg.fill ins([[VAR_extracted_4_]] : f32) outs([[VAR_12_]] : tensor<128xf32>) -> tensor<128xf32>
-// CHECK:           [[VAR_14_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_10_]], [[VAR_13_]] : tensor<128xf32>, tensor<128xf32>) outs([[VAR_10_]] : tensor<128xf32>) {
+// CHECK:           [[VAR_extracted_4_:%.+]] = tensor.extract [[VAR_reduced_3_]][] : tensor<f32>
+// CHECK:           [[VAR_12_:%.+]] = linalg.fill ins([[VAR_extracted_4_]] : f32) outs([[VAR_7_]] : tensor<128xf32>) -> tensor<128xf32>
+// CHECK:           [[VAR_13_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_10_]], [[VAR_12_]] : tensor<128xf32>, tensor<128xf32>) outs([[VAR_10_]] : tensor<128xf32>) {
 // CHECK:           ^bb0([[IN_5_:%.+]]: f32, [[IN_6_:%.+]]: f32, [[IN_7_:%.+]]: f32):
-// CHECK:             [[VAR_19_4_:%.+]] = arith.divf [[IN_5_]], [[IN_6_]] : f32
-// CHECK:             linalg.yield [[VAR_19_4_]] : f32
+// CHECK:             [[VAR_16_4_:%.+]] = arith.divf [[IN_5_]], [[IN_6_]] : f32
+// CHECK:             linalg.yield [[VAR_16_4_]] : f32
 // CHECK:           } -> tensor<128xf32>
-// CHECK:           [[VAR_15_:%.+]] = arith.muli [[PARAM_8_]], [[PARAM_3_]] : i32
-// CHECK:           [[VAR_16_:%.+]] = arith.index_cast [[VAR_15_]] : i32 to index
-// CHECK-DAG:       [[VAR_reinterpret_cast_5_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_16_]]{{.}}, sizes: [128], strides: [1] : memref<*xf32> to memref<128xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_17_:%.+]] = arith.index_cast [[PARAM_4_]] : i32 to index
-// CHECK:           [[VAR_18_:%.+]] = arith.minsi [[VAR_17_]], [[CST_128_]] : index
-// CHECK-DAG:       [[VAR_extracted_slice_:%.+]] = tensor.extract_slice [[VAR_14_]][0] {{.}}[[VAR_18_]]{{.}} [1] : tensor<128xf32> to tensor<?xf32>
-// CHECK-DAG:       [[VAR_subview_6_:%.+]] = memref.subview [[VAR_reinterpret_cast_5_]][0] {{.}}[[VAR_18_]]{{.}} [1] : memref<128xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK:           [[VAR_14_:%.+]] = arith.muli [[PARAM_8_]], [[PARAM_3_]] : i32
+// CHECK:           [[VAR_15_:%.+]] = arith.index_cast [[VAR_14_]] : i32 to index
+// CHECK-DAG:       [[VAR_reinterpret_cast_5_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_15_]]{{.}}, sizes: [128], strides: [1] : memref<*xf32> to memref<128xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_extracted_slice_:%.+]] = tensor.extract_slice [[VAR_13_]][0] {{.}}[[VAR_3_]]{{.}} [1] : tensor<128xf32> to tensor<?xf32>
+// CHECK:           [[VAR_subview_6_:%.+]] = memref.subview [[VAR_reinterpret_cast_5_]][0] {{.}}[[VAR_3_]]{{.}} [1] : memref<128xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
 // CHECK:           bufferization.materialize_in_destination [[VAR_extracted_slice_]] in writable [[VAR_subview_6_]] : (tensor<?xf32>, memref<?xf32, strided<[1], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/StructuredToMemref/kernel-03-matrix-multiplication.mlir
+++ b/test/Conversion/StructuredToMemref/kernel-03-matrix-multiplication.mlir
@@ -96,7 +96,6 @@ module {
   }
 }
 
-// mlir2FileCheck.py
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0, d1) -> (d0, d1)>
 // CHECK-LABEL:  func.func @matmul_kernel_0123456789101112131415
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: memref<*xbf16>, [[PARAM_2_:%.+]]: memref<*xbf16>, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32, [[PARAM_10_:%.+]]: i32, [[PARAM_11_:%.+]]: i32, [[PARAM_12_:%.+]]: i32, [[PARAM_13_:%.+]]: i32, [[PARAM_14_:%.+]]: i32, [[PARAM_15_:%.+]]: i32, [[PARAM_16_:%.+]]: i32, [[PARAM_17_:%.+]]: i32) {
@@ -138,76 +137,68 @@ module {
 // CHECK-DAG:       [[VAR_17_:%.+]] = arith.muli [[VAR_14_]], [[CST_128_]] : i32
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_18_:%.+]] = arith.index_cast [[VAR_17_]] : i32 to index
-// CHECK-DAG:       [[VAR_19_:%.+]] = arith.index_cast [[VAR_17_]] : i32 to index
-// CHECK-DAG:       [[VAR_20_:%.+]] = arith.muli [[VAR_16_]], [[CST_256_]] : i32
+// CHECK-DAG:       [[VAR_19_:%.+]] = arith.muli [[VAR_16_]], [[CST_256_]] : i32
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_21_:%.+]] = arith.index_cast [[VAR_20_]] : i32 to index
-// CHECK-DAG:       [[VAR_22_:%.+]] = arith.index_cast [[VAR_20_]] : i32 to index
-// CHECK-DAG:       [[VAR_23_:%.+]] = arith.index_cast [[PARAM_6_]] : i32 to index
+// CHECK-DAG:       [[VAR_20_:%.+]] = arith.index_cast [[VAR_19_]] : i32 to index
+// CHECK-DAG:       [[VAR_21_:%.+]] = arith.index_cast [[PARAM_6_]] : i32 to index
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_24_:%.+]] = arith.muli [[VAR_19_]], [[VAR_23_]] : index
-// CHECK-DAG:       [[VAR_25_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
-// CHECK-DAG:       [[VAR_26_:%.+]] = arith.index_cast [[PARAM_8_]] : i32 to index
-// CHECK-DAG:       [[VAR_27_:%.+]] = arith.index_cast [[PARAM_9_]] : i32 to index
+// CHECK-DAG:       [[VAR_22_:%.+]] = arith.muli [[VAR_18_]], [[VAR_21_]] : index
+// CHECK-DAG:       [[VAR_23_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
+// CHECK-DAG:       [[VAR_24_:%.+]] = arith.index_cast [[PARAM_8_]] : i32 to index
+// CHECK-DAG:       [[VAR_25_:%.+]] = arith.index_cast [[PARAM_9_]] : i32 to index
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_28_:%.+]] = arith.muli [[VAR_22_]], [[VAR_27_]] : index
-// CHECK-DAG:       [[VAR_29_:%.+]] = arith.muli [[PARAM_7_]], [[CST_64_]] : i32
+// CHECK-DAG:       [[VAR_26_:%.+]] = arith.muli [[VAR_20_]], [[VAR_25_]] : index
+// CHECK-DAG:       [[VAR_27_:%.+]] = arith.muli [[PARAM_7_]], [[CST_64_]] : i32
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_28_:%.+]] = arith.index_cast [[VAR_27_]] : i32 to index
+// CHECK-DAG:       [[VAR_29_:%.+]] = arith.muli [[PARAM_8_]], [[CST_64_]] : i32
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_30_:%.+]] = arith.index_cast [[VAR_29_]] : i32 to index
-// CHECK-DAG:       [[VAR_31_:%.+]] = arith.muli [[PARAM_8_]], [[CST_64_]] : i32
+// CHECK-DAG:       [[VAR_31_:%.+]]:3 = scf.for [[VAR_arg18_:%.+]] = [[CST_0_]] to [[VAR_7_]] step [[CST_1_]] iter_args([[VAR_arg19_:%.+]] = [[VAR_1_]], [[VAR_arg20_:%.+]] = [[VAR_22_]], [[VAR_arg21_:%.+]] = [[CST_0_1_]]) -> (tensor<128x256xf32>, index, index)  : i32 {
+// CHECK-DAG:         [[VAR_49_:%.+]] = arith.addi [[VAR_arg21_]], [[VAR_26_]] : index
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_32_:%.+]] = arith.index_cast [[VAR_31_]] : i32 to index
-// CHECK-DAG:       [[VAR_33_:%.+]]:3 = scf.for [[VAR_arg18_:%.+]] = [[CST_0_]] to [[VAR_7_]] step [[CST_1_]] iter_args([[VAR_arg19_:%.+]] = [[VAR_1_]], [[VAR_arg20_:%.+]] = [[VAR_24_]], [[VAR_arg21_:%.+]] = [[CST_0_1_]]) -> (tensor<128x256xf32>, index, index)  : i32 {
-// CHECK-DAG:         [[VAR_53_:%.+]] = arith.addi [[VAR_arg21_]], [[VAR_28_]] : index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_53_]]{{.}}, sizes: [64, 256], strides: {{.}}[[VAR_26_]], [[VAR_27_]]{{.}} : memref<*xbf16> to memref<64x256xbf16, strided<[?, ?], offset: ?>>
-// CHECK-DAG:         [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_arg20_]]{{.}}, sizes: [128, 64], strides: {{.}}[[VAR_23_]], [[VAR_25_]]{{.}} : memref<*xbf16> to memref<128x64xbf16, strided<[?, ?], offset: ?>>
+// CHECK-DAG:         [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_49_]]{{.}}, sizes: [64, 256], strides: {{.}}[[VAR_24_]], [[VAR_25_]]{{.}} : memref<*xbf16> to memref<64x256xbf16, strided<[?, ?], offset: ?>>
+// CHECK-DAG:         [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_arg20_]]{{.}}, sizes: [128, 64], strides: {{.}}[[VAR_21_]], [[VAR_23_]]{{.}} : memref<*xbf16> to memref<128x64xbf16, strided<[?, ?], offset: ?>>
 // CHECK-DAG:         [[RES_:%.+]] = memref.alloc() : memref<128x64xbf16>
 // CHECK:             memref.copy [[VAR_reinterpret_cast_1_]], [[RES_]] : memref<128x64xbf16, strided<[?, ?], offset: ?>> to memref<128x64xbf16>
-// CHECK-DAG:         [[VAR_54_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<128x64xbf16>
+// CHECK-DAG:         [[VAR_50_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<128x64xbf16>
 // CHECK-DAG:         [[RES_1_:%.+]] = memref.alloc() : memref<64x256xbf16>
 // CHECK:             memref.copy [[VAR_reinterpret_cast_0_]], [[RES_1_]] : memref<64x256xbf16, strided<[?, ?], offset: ?>> to memref<64x256xbf16>
-// CHECK-DAG:         [[VAR_55_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<64x256xbf16>
-// CHECK-DAG:         [[VAR_56_:%.+]] = tensor.empty() : tensor<128x256xf32>
-// CHECK:             [[VAR_57_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[VAR_56_]] : tensor<128x256xf32>) -> tensor<128x256xf32>
-// CHECK:             [[VAR_58_:%.+]] = linalg.matmul ins([[VAR_54_]], [[VAR_55_]] : tensor<128x64xbf16>, tensor<64x256xbf16>) outs([[VAR_57_]] : tensor<128x256xf32>) -> tensor<128x256xf32>
-// CHECK:             [[VAR_59_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_arg19_]], [[VAR_58_]] : tensor<128x256xf32>, tensor<128x256xf32>) outs([[VAR_arg19_]] : tensor<128x256xf32>) {
+// CHECK:             [[VAR_51_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<64x256xbf16>
+// CHECK:             [[VAR_52_:%.+]] = linalg.matmul ins([[VAR_50_]], [[VAR_51_]] : tensor<128x64xbf16>, tensor<64x256xbf16>) outs([[VAR_1_]] : tensor<128x256xf32>) -> tensor<128x256xf32>
+// CHECK:             [[VAR_53_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_arg19_]], [[VAR_52_]] : tensor<128x256xf32>, tensor<128x256xf32>) outs([[VAR_arg19_]] : tensor<128x256xf32>) {
 // CHECK:             ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32, [[IN_2_:%.+]]: f32):
-// CHECK:               [[VAR_62_:%.+]] = arith.addf [[IN_0_]], [[IN_1_]] : f32
-// CHECK:               linalg.yield [[VAR_62_]] : f32
+// CHECK:               [[VAR_56_:%.+]] = arith.addf [[IN_0_]], [[IN_1_]] : f32
+// CHECK:               linalg.yield [[VAR_56_]] : f32
 // CHECK:             } -> tensor<128x256xf32>
-// CHECK-DAG:         [[VAR_60_:%.+]] = arith.addi [[VAR_arg20_]], [[VAR_30_]] : index
-// CHECK-DAG:         [[VAR_61_:%.+]] = arith.addi [[VAR_arg21_]], [[VAR_32_]] : index
-// CHECK:             scf.yield [[VAR_59_]], [[VAR_60_]], [[VAR_61_]] : tensor<128x256xf32>, index, index
+// CHECK-DAG:         [[VAR_54_:%.+]] = arith.addi [[VAR_arg20_]], [[VAR_28_]] : index
+// CHECK-DAG:         [[VAR_55_:%.+]] = arith.addi [[VAR_arg21_]], [[VAR_30_]] : index
+// CHECK:             scf.yield [[VAR_53_]], [[VAR_54_]], [[VAR_55_]] : tensor<128x256xf32>, index, index
 // CHECK:           }
-// CHECK:           [[VAR_34_:%.+]] = tensor.empty() : tensor<128x256xbf16>
-// CHECK:           [[VAR_35_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_33_]]#0 : tensor<128x256xf32>) outs([[VAR_34_]] : tensor<128x256xbf16>) {
+// CHECK:           [[VAR_32_:%.+]] = tensor.empty() : tensor<128x256xbf16>
+// CHECK:           [[VAR_33_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_31_]]#0 : tensor<128x256xf32>) outs([[VAR_32_]] : tensor<128x256xbf16>) {
 // CHECK:           ^bb0([[IN_3_:%.+]]: f32, [[IN_4_:%.+]]: bf16):
-// CHECK:             [[VAR_53_1_:%.+]] = arith.truncf [[IN_3_]] : f32 to bf16
-// CHECK:             linalg.yield [[VAR_53_1_]] : bf16
+// CHECK:             [[VAR_49_1_:%.+]] = arith.truncf [[IN_3_]] : f32 to bf16
+// CHECK:             linalg.yield [[VAR_49_1_]] : bf16
 // CHECK:           } -> tensor<128x256xbf16>
-// CHECK:           [[VAR_36_:%.+]] = arith.index_cast [[PARAM_10_]] : i32 to index
-// CHECK-DAG:       [[VAR_37_:%.+]] = arith.muli [[VAR_18_]], [[VAR_36_]] : index
-// CHECK-DAG:       [[VAR_38_:%.+]] = arith.index_cast [[PARAM_11_]] : i32 to index
-// CHECK:           [[VAR_39_:%.+]] = arith.muli [[VAR_21_]], [[VAR_38_]] : index
-// CHECK:           [[VAR_40_:%.+]] = arith.addi [[VAR_37_]], [[VAR_39_]] : index
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_2_]] to offset: {{.}}[[VAR_40_]]{{.}}, sizes: [128, 256], strides: {{.}}[[VAR_36_]], [[VAR_38_]]{{.}} : memref<*xbf16> to memref<128x256xbf16, strided<[?, ?], offset: ?>>
-// CHECK-DAG:       [[VAR_41_:%.+]] = arith.index_cast [[VAR_17_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_42_:%.+]] = arith.addi [[VAR_41_]], [[CST_128_1_]] : index
-// CHECK-DAG:       [[VAR_43_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
-// CHECK:           [[VAR_44_:%.+]] = arith.minsi [[VAR_42_]], [[VAR_43_]] : index
-// CHECK-DAG:       [[VAR_45_:%.+]] = arith.subi [[VAR_44_]], [[VAR_41_]] : index
-// CHECK-DAG:       [[VAR_46_:%.+]] = arith.index_cast [[VAR_20_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_47_:%.+]] = arith.addi [[VAR_46_]], [[CST_256_1_]] : index
-// CHECK-DAG:       [[VAR_48_:%.+]] = arith.index_cast [[PARAM_4_]] : i32 to index
-// CHECK:           [[VAR_49_:%.+]] = arith.minsi [[VAR_47_]], [[VAR_48_]] : index
-// CHECK-DAG:       [[VAR_50_:%.+]] = arith.subi [[VAR_49_]], [[VAR_46_]] : index
-// CHECK-DAG:       [[VAR_51_:%.+]] = arith.minsi [[VAR_45_]], [[CST_128_1_]] : index
-// CHECK:           [[VAR_52_:%.+]] = arith.minsi [[VAR_50_]], [[CST_256_1_]] : index
-// CHECK-DAG:       [[VAR_extracted_slice_:%.+]] = tensor.extract_slice [[VAR_35_]][0, 0] {{.}}[[VAR_51_]], [[VAR_52_]]{{.}} [1, 1] : tensor<128x256xbf16> to tensor<?x?xbf16>
-// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0, 0] {{.}}[[VAR_51_]], [[VAR_52_]]{{.}} [1, 1] : memref<128x256xbf16, strided<[?, ?], offset: ?>> to memref<?x?xbf16, strided<[?, ?], offset: ?>>
+// CHECK:           [[VAR_34_:%.+]] = arith.index_cast [[PARAM_10_]] : i32 to index
+// CHECK-DAG:       [[VAR_35_:%.+]] = arith.muli [[VAR_18_]], [[VAR_34_]] : index
+// CHECK-DAG:       [[VAR_36_:%.+]] = arith.index_cast [[PARAM_11_]] : i32 to index
+// CHECK:           [[VAR_37_:%.+]] = arith.muli [[VAR_20_]], [[VAR_36_]] : index
+// CHECK:           [[VAR_38_:%.+]] = arith.addi [[VAR_35_]], [[VAR_37_]] : index
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_2_]] to offset: {{.}}[[VAR_38_]]{{.}}, sizes: [128, 256], strides: {{.}}[[VAR_34_]], [[VAR_36_]]{{.}} : memref<*xbf16> to memref<128x256xbf16, strided<[?, ?], offset: ?>>
+// CHECK-DAG:       [[VAR_39_:%.+]] = arith.addi [[VAR_18_]], [[CST_128_1_]] : index
+// CHECK-DAG:       [[VAR_40_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
+// CHECK:           [[VAR_41_:%.+]] = arith.minsi [[VAR_39_]], [[VAR_40_]] : index
+// CHECK-DAG:       [[VAR_42_:%.+]] = arith.subi [[VAR_41_]], [[VAR_18_]] : index
+// CHECK-DAG:       [[VAR_43_:%.+]] = arith.addi [[VAR_20_]], [[CST_256_1_]] : index
+// CHECK-DAG:       [[VAR_44_:%.+]] = arith.index_cast [[PARAM_4_]] : i32 to index
+// CHECK:           [[VAR_45_:%.+]] = arith.minsi [[VAR_43_]], [[VAR_44_]] : index
+// CHECK-DAG:       [[VAR_46_:%.+]] = arith.subi [[VAR_45_]], [[VAR_20_]] : index
+// CHECK-DAG:       [[VAR_47_:%.+]] = arith.minsi [[VAR_42_]], [[CST_128_1_]] : index
+// CHECK:           [[VAR_48_:%.+]] = arith.minsi [[VAR_46_]], [[CST_256_1_]] : index
+// CHECK-DAG:       [[VAR_extracted_slice_:%.+]] = tensor.extract_slice [[VAR_33_]][0, 0] {{.}}[[VAR_47_]], [[VAR_48_]]{{.}} [1, 1] : tensor<128x256xbf16> to tensor<?x?xbf16>
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0, 0] {{.}}[[VAR_47_]], [[VAR_48_]]{{.}} [1, 1] : memref<128x256xbf16, strided<[?, ?], offset: ?>> to memref<?x?xbf16, strided<[?, ?], offset: ?>>
 // CHECK:           bufferization.materialize_in_destination [[VAR_extracted_slice_]] in writable [[VAR_subview_]] : (tensor<?x?xbf16>, memref<?x?xbf16, strided<[?, ?], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/StructuredToMemref/kernel-05-layer-norm-dwdb.mlir
+++ b/test/Conversion/StructuredToMemref/kernel-05-layer-norm-dwdb.mlir
@@ -60,7 +60,6 @@ module {
   }
 }
 
-// mlir2FileCheck.py
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0, d1) -> (d0, d1)>
 // CHECK-LABEL:  func.func @_layer_norm_bwd_dwdb_0123456
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: memref<*xf32>, [[PARAM_3_:%.+]]: memref<*xf32>, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32, [[PARAM_10_:%.+]]: i32, [[PARAM_11_:%.+]]: i32) {
@@ -74,117 +73,77 @@ module {
 // CHECK-DAG:       [[VAR_2_:%.+]] = arith.muli [[PARAM_9_]], [[CST_256_]] : i32
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
-// CHECK-DAG:       [[VAR_4_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
-// CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
-// CHECK-DAG:       [[VAR_6_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
-// CHECK-DAG:       [[VAR_7_:%.+]]:2 = scf.for [[VAR_arg12_:%.+]] = [[CST_0_]] to [[PARAM_4_]] step [[CST_256_]] iter_args([[VAR_arg13_:%.+]] = [[VAR_1_]], [[VAR_arg14_:%.+]] = [[VAR_1_]]) -> (tensor<256x256xf32>, tensor<256x256xf32>)  : i32 {
-// CHECK-DAG:         [[VAR_22_:%.+]] = arith.index_cast [[VAR_arg12_]] : i32 to index
-// CHECK-DAG:         [[VAR_23_:%.+]] = arith.index_cast [[PARAM_5_]] : i32 to index
-// CHECK:             [[VAR_24_:%.+]] = arith.muli [[VAR_22_]], [[VAR_23_]] : index
-// CHECK:             [[VAR_25_:%.+]] = arith.addi [[VAR_24_]], [[VAR_6_]] : index
-// CHECK-DAG:         [[VAR_reinterpret_cast_4_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_25_]]{{.}}, sizes: [256, 256], strides: {{.}}[[VAR_23_]], 1] : memref<*xf32> to memref<256x256xf32, strided<[?, 1], offset: ?>>
-// CHECK-DAG:         [[VAR_26_:%.+]] = arith.index_cast [[VAR_arg12_]] : i32 to index
+// CHECK-DAG:       [[VAR_4_:%.+]]:2 = scf.for [[VAR_arg12_:%.+]] = [[CST_0_]] to [[PARAM_4_]] step [[CST_256_]] iter_args([[VAR_arg13_:%.+]] = [[VAR_1_]], [[VAR_arg14_:%.+]] = [[VAR_1_]]) -> (tensor<256x256xf32>, tensor<256x256xf32>)  : i32 {
+// CHECK-DAG:         [[VAR_11_:%.+]] = arith.index_cast [[VAR_arg12_]] : i32 to index
+// CHECK-DAG:         [[VAR_12_:%.+]] = arith.index_cast [[PARAM_5_]] : i32 to index
+// CHECK:             [[VAR_13_:%.+]] = arith.muli [[VAR_11_]], [[VAR_12_]] : index
+// CHECK:             [[VAR_14_:%.+]] = arith.addi [[VAR_13_]], [[VAR_3_]] : index
+// CHECK-DAG:         [[VAR_reinterpret_cast_4_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_14_]]{{.}}, sizes: [256, 256], strides: {{.}}[[VAR_12_]], 1] : memref<*xf32> to memref<256x256xf32, strided<[?, 1], offset: ?>>
+// CHECK-DAG:         [[VAR_15_:%.+]] = arith.addi [[VAR_11_]], [[CST_256_1_]] : index
+// CHECK-DAG:         [[VAR_16_:%.+]] = arith.index_cast [[PARAM_4_]] : i32 to index
+// CHECK:             [[VAR_17_:%.+]] = arith.minsi [[VAR_15_]], [[VAR_16_]] : index
+// CHECK-DAG:         [[VAR_18_:%.+]] = arith.subi [[VAR_17_]], [[VAR_11_]] : index
+// CHECK-DAG:         [[VAR_19_:%.+]] = arith.addi [[VAR_3_]], [[CST_256_1_]] : index
+// CHECK:             [[VAR_20_:%.+]] = arith.minsi [[VAR_19_]], [[VAR_12_]] : index
+// CHECK-DAG:         [[VAR_21_:%.+]] = arith.subi [[VAR_20_]], [[VAR_3_]] : index
+// CHECK-DAG:         [[VAR_22_:%.+]] = arith.minsi [[VAR_18_]], [[CST_256_1_]] : index
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_27_:%.+]] = arith.addi [[VAR_26_]], [[CST_256_1_]] : index
-// CHECK-DAG:         [[VAR_28_:%.+]] = arith.index_cast [[PARAM_4_]] : i32 to index
-// CHECK:             [[VAR_29_:%.+]] = arith.minsi [[VAR_27_]], [[VAR_28_]] : index
-// CHECK-DAG:         [[VAR_30_:%.+]] = arith.subi [[VAR_29_]], [[VAR_26_]] : index
-// CHECK-DAG:         [[VAR_31_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_32_:%.+]] = arith.addi [[VAR_31_]], [[CST_256_1_]] : index
-// CHECK-DAG:         [[VAR_33_:%.+]] = arith.index_cast [[PARAM_5_]] : i32 to index
-// CHECK:             [[VAR_34_:%.+]] = arith.minsi [[VAR_32_]], [[VAR_33_]] : index
-// CHECK-DAG:         [[VAR_35_:%.+]] = arith.subi [[VAR_34_]], [[VAR_31_]] : index
-// CHECK-DAG:         [[VAR_36_:%.+]] = arith.minsi [[VAR_30_]], [[CST_256_1_]] : index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_37_:%.+]] = arith.minsi [[VAR_35_]], [[CST_256_1_]] : index
+// CHECK-DAG:         [[VAR_23_:%.+]] = arith.minsi [[VAR_21_]], [[CST_256_1_]] : index
 // CHECK-DAG:         [[RES_:%.+]] = memref.alloc() : memref<256x256xf32>
-// CHECK-DAG:         [[VAR_38_:%.+]] = arith.cmpi slt, [[VAR_36_]], [[CST_256_1_]] : index
-// CHECK:             [[VAR_39_:%.+]] = arith.cmpi slt, [[VAR_37_]], [[CST_256_1_]] : index
-// CHECK:             [[VAR_40_:%.+]] = arith.ori [[VAR_38_]], [[VAR_39_]] : i1
-// CHECK:             scf.if [[VAR_40_]] {
+// CHECK-DAG:         [[VAR_24_:%.+]] = arith.cmpi slt, [[VAR_22_]], [[CST_256_1_]] : index
+// CHECK:             [[VAR_25_:%.+]] = arith.cmpi slt, [[VAR_23_]], [[CST_256_1_]] : index
+// CHECK:             [[VAR_26_:%.+]] = arith.ori [[VAR_24_]], [[VAR_25_]] : i1
+// CHECK:             scf.if [[VAR_26_]] {
 // CHECK:               linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[RES_]] : memref<256x256xf32>)
 // CHECK:             }
-// CHECK-DAG:         [[VAR_subview_5_:%.+]] = memref.subview [[VAR_reinterpret_cast_4_]][0, 0] {{.}}[[VAR_36_]], [[VAR_37_]]{{.}} [1, 1] : memref<256x256xf32, strided<[?, 1], offset: ?>> to memref<?x?xf32, strided<[?, 1], offset: ?>>
-// CHECK-DAG:         [[VAR_subview_6_:%.+]] = memref.subview [[RES_]][0, 0] {{.}}[[VAR_36_]], [[VAR_37_]]{{.}} [1, 1] : memref<256x256xf32> to memref<?x?xf32, strided<[256, 1]>>
+// CHECK-DAG:         [[VAR_subview_5_:%.+]] = memref.subview [[VAR_reinterpret_cast_4_]][0, 0] {{.}}[[VAR_22_]], [[VAR_23_]]{{.}} [1, 1] : memref<256x256xf32, strided<[?, 1], offset: ?>> to memref<?x?xf32, strided<[?, 1], offset: ?>>
+// CHECK-DAG:         [[VAR_subview_6_:%.+]] = memref.subview [[RES_]][0, 0] {{.}}[[VAR_22_]], [[VAR_23_]]{{.}} [1, 1] : memref<256x256xf32> to memref<?x?xf32, strided<[256, 1]>>
 // CHECK:             memref.copy [[VAR_subview_5_]], [[VAR_subview_6_]] : memref<?x?xf32, strided<[?, 1], offset: ?>> to memref<?x?xf32, strided<[256, 1]>>
-// CHECK:             [[VAR_41_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<256x256xf32>
-// CHECK:             [[VAR_42_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_arg13_]], [[VAR_41_]] : tensor<256x256xf32>, tensor<256x256xf32>) outs([[VAR_arg13_]] : tensor<256x256xf32>) {
+// CHECK:             [[VAR_27_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<256x256xf32>
+// CHECK:             [[VAR_28_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_arg13_]], [[VAR_27_]] : tensor<256x256xf32>, tensor<256x256xf32>) outs([[VAR_arg13_]] : tensor<256x256xf32>) {
 // CHECK:             ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32, [[IN_2_:%.+]]: f32):
-// CHECK:               [[VAR_64_:%.+]] = arith.addf [[IN_0_]], [[IN_1_]] : f32
-// CHECK:               linalg.yield [[VAR_64_]] : f32
+// CHECK:               [[VAR_31_:%.+]] = arith.addf [[IN_0_]], [[IN_1_]] : f32
+// CHECK:               linalg.yield [[VAR_31_]] : f32
 // CHECK:             } -> tensor<256x256xf32>
-// CHECK-DAG:         [[VAR_43_:%.+]] = arith.index_cast [[VAR_arg12_]] : i32 to index
-// CHECK-DAG:         [[VAR_44_:%.+]] = arith.index_cast [[PARAM_5_]] : i32 to index
-// CHECK:             [[VAR_45_:%.+]] = arith.muli [[VAR_43_]], [[VAR_44_]] : index
-// CHECK:             [[VAR_46_:%.+]] = arith.addi [[VAR_45_]], [[VAR_5_]] : index
-// CHECK-DAG:         [[VAR_reinterpret_cast_7_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_46_]]{{.}}, sizes: [256, 256], strides: {{.}}[[VAR_44_]], 1] : memref<*xf32> to memref<256x256xf32, strided<[?, 1], offset: ?>>
-// CHECK-DAG:         [[VAR_47_:%.+]] = arith.index_cast [[VAR_arg12_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_48_:%.+]] = arith.addi [[VAR_47_]], [[CST_256_1_]] : index
-// CHECK-DAG:         [[VAR_49_:%.+]] = arith.index_cast [[PARAM_4_]] : i32 to index
-// CHECK:             [[VAR_50_:%.+]] = arith.minsi [[VAR_48_]], [[VAR_49_]] : index
-// CHECK-DAG:         [[VAR_51_:%.+]] = arith.subi [[VAR_50_]], [[VAR_47_]] : index
-// CHECK-DAG:         [[VAR_52_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_53_:%.+]] = arith.addi [[VAR_52_]], [[CST_256_1_]] : index
-// CHECK-DAG:         [[VAR_54_:%.+]] = arith.index_cast [[PARAM_5_]] : i32 to index
-// CHECK:             [[VAR_55_:%.+]] = arith.minsi [[VAR_53_]], [[VAR_54_]] : index
-// CHECK-DAG:         [[VAR_56_:%.+]] = arith.subi [[VAR_55_]], [[VAR_52_]] : index
-// CHECK-DAG:         [[VAR_57_:%.+]] = arith.minsi [[VAR_51_]], [[CST_256_1_]] : index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_58_:%.+]] = arith.minsi [[VAR_56_]], [[CST_256_1_]] : index
+// CHECK-DAG:         [[VAR_reinterpret_cast_7_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_14_]]{{.}}, sizes: [256, 256], strides: {{.}}[[VAR_12_]], 1] : memref<*xf32> to memref<256x256xf32, strided<[?, 1], offset: ?>>
 // CHECK-DAG:         [[RES_1_:%.+]] = memref.alloc() : memref<256x256xf32>
-// CHECK-DAG:         [[VAR_59_:%.+]] = arith.cmpi slt, [[VAR_57_]], [[CST_256_1_]] : index
-// CHECK:             [[VAR_60_:%.+]] = arith.cmpi slt, [[VAR_58_]], [[CST_256_1_]] : index
-// CHECK:             [[VAR_61_:%.+]] = arith.ori [[VAR_59_]], [[VAR_60_]] : i1
-// CHECK:             scf.if [[VAR_61_]] {
+// CHECK:             scf.if [[VAR_26_]] {
 // CHECK:               linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[RES_1_]] : memref<256x256xf32>)
 // CHECK:             }
-// CHECK-DAG:         [[VAR_subview_9_:%.+]] = memref.subview [[VAR_reinterpret_cast_7_]][0, 0] {{.}}[[VAR_57_]], [[VAR_58_]]{{.}} [1, 1] : memref<256x256xf32, strided<[?, 1], offset: ?>> to memref<?x?xf32, strided<[?, 1], offset: ?>>
-// CHECK-DAG:         [[VAR_subview_10_:%.+]] = memref.subview [[RES_1_]][0, 0] {{.}}[[VAR_57_]], [[VAR_58_]]{{.}} [1, 1] : memref<256x256xf32> to memref<?x?xf32, strided<[256, 1]>>
+// CHECK-DAG:         [[VAR_subview_9_:%.+]] = memref.subview [[VAR_reinterpret_cast_7_]][0, 0] {{.}}[[VAR_22_]], [[VAR_23_]]{{.}} [1, 1] : memref<256x256xf32, strided<[?, 1], offset: ?>> to memref<?x?xf32, strided<[?, 1], offset: ?>>
+// CHECK-DAG:         [[VAR_subview_10_:%.+]] = memref.subview [[RES_1_]][0, 0] {{.}}[[VAR_22_]], [[VAR_23_]]{{.}} [1, 1] : memref<256x256xf32> to memref<?x?xf32, strided<[256, 1]>>
 // CHECK:             memref.copy [[VAR_subview_9_]], [[VAR_subview_10_]] : memref<?x?xf32, strided<[?, 1], offset: ?>> to memref<?x?xf32, strided<[256, 1]>>
-// CHECK:             [[VAR_62_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<256x256xf32>
-// CHECK:             [[VAR_63_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_arg14_]], [[VAR_62_]] : tensor<256x256xf32>, tensor<256x256xf32>) outs([[VAR_arg14_]] : tensor<256x256xf32>) {
+// CHECK:             [[VAR_29_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<256x256xf32>
+// CHECK:             [[VAR_30_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_arg14_]], [[VAR_29_]] : tensor<256x256xf32>, tensor<256x256xf32>) outs([[VAR_arg14_]] : tensor<256x256xf32>) {
 // CHECK:             ^bb0([[IN_3_:%.+]]: f32, [[IN_4_:%.+]]: f32, [[IN_5_:%.+]]: f32):
-// CHECK:               [[VAR_64_1_:%.+]] = arith.addf [[IN_3_]], [[IN_4_]] : f32
-// CHECK:               linalg.yield [[VAR_64_1_]] : f32
+// CHECK:               [[VAR_31_1_:%.+]] = arith.addf [[IN_3_]], [[IN_4_]] : f32
+// CHECK:               linalg.yield [[VAR_31_1_]] : f32
 // CHECK:             } -> tensor<256x256xf32>
-// CHECK:             scf.yield [[VAR_42_]], [[VAR_63_]] : tensor<256x256xf32>, tensor<256x256xf32>
+// CHECK:             scf.yield [[VAR_28_]], [[VAR_30_]] : tensor<256x256xf32>, tensor<256x256xf32>
 // CHECK:           }
-// CHECK:           [[VAR_8_:%.+]] = tensor.empty() : tensor<256xf32>
-// CHECK:           [[VAR_9_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[VAR_8_]] : tensor<256xf32>) -> tensor<256xf32>
-// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_7_]]#0 : tensor<256x256xf32>) outs([[VAR_9_]] : tensor<256xf32>) dimensions = [0]
-// CHECK:             ([[IN_3_:%.+]]: f32, [[init_:%.+]]: f32) {
-// CHECK:               [[VAR_22_1_:%.+]] = arith.addf [[IN_3_]], [[init_]] : f32
-// CHECK:               linalg.yield [[VAR_22_1_]] : f32
+// CHECK:           [[VAR_5_:%.+]] = tensor.empty() : tensor<256xf32>
+// CHECK:           [[VAR_6_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[VAR_5_]] : tensor<256xf32>) -> tensor<256xf32>
+// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_4_]]#0 : tensor<256x256xf32>) outs([[VAR_6_]] : tensor<256xf32>) dimensions = [0]
+// CHECK:             ([[IN_3_:.+]]: f32, [[init_:.+]]: f32) {
+// CHECK:               [[VAR_11_1_:%.+]] = arith.addf [[IN_3_]], [[init_]] : f32
+// CHECK:               linalg.yield [[VAR_11_1_]] : f32
 // CHECK:             }
-// CHECK:           [[VAR_10_:%.+]] = tensor.empty() : tensor<256xf32>
-// CHECK:           [[VAR_11_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[VAR_10_]] : tensor<256xf32>) -> tensor<256xf32>
-// CHECK:           [[VAR_reduced_0_:%.+]] = linalg.reduce ins([[VAR_7_]]#1 : tensor<256x256xf32>) outs([[VAR_11_]] : tensor<256xf32>) dimensions = [0]
-// CHECK:             ([[IN_3_:%.+]]: f32, [[init_:%.+]]: f32) {
-// CHECK:               [[VAR_22_2_:%.+]] = arith.addf [[IN_3_]], [[init_]] : f32
-// CHECK:               linalg.yield [[VAR_22_2_]] : f32
+// CHECK:           [[VAR_reduced_0_:%.+]] = linalg.reduce ins([[VAR_4_]]#1 : tensor<256x256xf32>) outs([[VAR_6_]] : tensor<256xf32>) dimensions = [0]
+// CHECK:             ([[IN_3_:.+]]: f32, [[init_:.+]]: f32) {
+// CHECK:               [[VAR_11_2_:%.+]] = arith.addf [[IN_3_]], [[init_]] : f32
+// CHECK:               linalg.yield [[VAR_11_2_]] : f32
 // CHECK:             }
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_2_]] to offset: {{.}}[[VAR_4_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_12_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_13_:%.+]] = arith.addi [[VAR_12_]], [[CST_256_1_]] : index
-// CHECK-DAG:       [[VAR_14_:%.+]] = arith.index_cast [[PARAM_5_]] : i32 to index
-// CHECK:           [[VAR_15_:%.+]] = arith.minsi [[VAR_13_]], [[VAR_14_]] : index
-// CHECK:           [[VAR_16_:%.+]] = arith.subi [[VAR_15_]], [[VAR_12_]] : index
-// CHECK-DAG:       [[VAR_extracted_slice_:%.+]] = tensor.extract_slice [[VAR_reduced_]][0] {{.}}[[VAR_16_]]{{.}} [1] : tensor<256xf32> to tensor<?xf32>
-// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_16_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_2_]] to offset: {{.}}[[VAR_3_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_7_:%.+]] = arith.addi [[VAR_3_]], [[CST_256_1_]] : index
+// CHECK-DAG:       [[VAR_8_:%.+]] = arith.index_cast [[PARAM_5_]] : i32 to index
+// CHECK:           [[VAR_9_:%.+]] = arith.minsi [[VAR_7_]], [[VAR_8_]] : index
+// CHECK:           [[VAR_10_:%.+]] = arith.subi [[VAR_9_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[VAR_extracted_slice_:%.+]] = tensor.extract_slice [[VAR_reduced_]][0] {{.}}[[VAR_10_]]{{.}} [1] : tensor<256xf32> to tensor<?xf32>
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_10_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
 // CHECK:           bufferization.materialize_in_destination [[VAR_extracted_slice_]] in writable [[VAR_subview_]] : (tensor<?xf32>, memref<?xf32, strided<[1], offset: ?>>) -> ()
 // CHECK-DAG:       [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_3_]] to offset: {{.}}[[VAR_3_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_17_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_18_:%.+]] = arith.addi [[VAR_17_]], [[CST_256_1_]] : index
-// CHECK-DAG:       [[VAR_19_:%.+]] = arith.index_cast [[PARAM_5_]] : i32 to index
-// CHECK:           [[VAR_20_:%.+]] = arith.minsi [[VAR_18_]], [[VAR_19_]] : index
-// CHECK:           [[VAR_21_:%.+]] = arith.subi [[VAR_20_]], [[VAR_17_]] : index
-// CHECK-DAG:       [[VAR_extracted_slice_2_:%.+]] = tensor.extract_slice [[VAR_reduced_0_]][0] {{.}}[[VAR_21_]]{{.}} [1] : tensor<256xf32> to tensor<?xf32>
-// CHECK-DAG:       [[VAR_subview_3_:%.+]] = memref.subview [[VAR_reinterpret_cast_1_]][0] {{.}}[[VAR_21_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_extracted_slice_2_:%.+]] = tensor.extract_slice [[VAR_reduced_0_]][0] {{.}}[[VAR_10_]]{{.}} [1] : tensor<256xf32> to tensor<?xf32>
+// CHECK:           [[VAR_subview_3_:%.+]] = memref.subview [[VAR_reinterpret_cast_1_]][0] {{.}}[[VAR_10_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
 // CHECK:           bufferization.materialize_in_destination [[VAR_extracted_slice_2_]] in writable [[VAR_subview_3_]] : (tensor<?xf32>, memref<?xf32, strided<[1], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/StructuredToMemref/kernel-05-layer-norm-fwd.mlir
+++ b/test/Conversion/StructuredToMemref/kernel-05-layer-norm-fwd.mlir
@@ -102,211 +102,173 @@ module {
 // CHECK-DAG:       [[VAR_2_:%.+]] = arith.muli [[PARAM_12_]], [[PARAM_6_]] : i32
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
-// CHECK-DAG:       [[VAR_4_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
-// CHECK-DAG:       [[VAR_5_:%.+]] = scf.for [[VAR_arg15_:%.+]] = [[CST_0_]] to [[PARAM_7_]] step [[CST_256_]] iter_args([[VAR_arg16_:%.+]] = [[VAR_1_]]) -> (tensor<256xf32>)  : i32 {
-// CHECK-DAG:         [[VAR_27_:%.+]] = arith.index_cast [[VAR_arg15_]] : i32 to index
-// CHECK:             [[VAR_28_:%.+]] = arith.addi [[VAR_3_]], [[VAR_27_]] : index
-// CHECK-DAG:         [[VAR_reinterpret_cast_5_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_28_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
-// CHECK-DAG:         [[VAR_29_:%.+]] = arith.index_cast [[VAR_arg15_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_30_:%.+]] = arith.addi [[VAR_29_]], [[CST_256_1_]] : index
-// CHECK-DAG:         [[VAR_31_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
-// CHECK:             [[VAR_32_:%.+]] = arith.minsi [[VAR_30_]], [[VAR_31_]] : index
-// CHECK-DAG:         [[VAR_33_:%.+]] = arith.subi [[VAR_32_]], [[VAR_29_]] : index
+// CHECK-DAG:       [[VAR_4_:%.+]] = tensor.empty() : tensor<256xi32>
+// CHECK:           [[VAR_5_:%.+]] = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel"]} outs([[VAR_4_]] : tensor<256xi32>) {
+// CHECK:           ^bb0([[IN_0_:%.+]]: i32):
+// CHECK:             [[VAR_20_:%.+]] = linalg.index 0 : index
+// CHECK:             [[VAR_21_:%.+]] = arith.index_cast [[VAR_20_]] : index to i32
+// CHECK:             linalg.yield [[VAR_21_]] : i32
+// CHECK:           } -> tensor<256xi32>
+// CHECK-DAG:       [[VAR_6_:%.+]] = linalg.fill ins([[PARAM_7_]] : i32) outs([[VAR_4_]] : tensor<256xi32>) -> tensor<256xi32>
+// CHECK-DAG:       [[VAR_7_:%.+]] = scf.for [[VAR_arg15_:%.+]] = [[CST_0_]] to [[PARAM_7_]] step [[CST_256_]] iter_args([[VAR_arg16_:%.+]] = [[VAR_1_]]) -> (tensor<256xf32>)  : i32 {
+// CHECK-DAG:         [[VAR_20_1_:%.+]] = arith.index_cast [[VAR_arg15_]] : i32 to index
+// CHECK:             [[VAR_21_1_:%.+]] = arith.addi [[VAR_3_]], [[VAR_20_1_]] : index
+// CHECK-DAG:         [[VAR_reinterpret_cast_5_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_21_1_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_22_:%.+]] = arith.addi [[VAR_20_1_]], [[CST_256_1_]] : index
+// CHECK-DAG:         [[VAR_23_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
+// CHECK:             [[VAR_24_:%.+]] = arith.minsi [[VAR_22_]], [[VAR_23_]] : index
+// CHECK-DAG:         [[VAR_25_:%.+]] = arith.subi [[VAR_24_]], [[VAR_20_1_]] : index
 // CHECK-DAG:         [[RES_:%.+]] = memref.alloc() : memref<256xf32>
-// CHECK:             [[VAR_34_:%.+]] = arith.cmpi slt, [[VAR_33_]], [[CST_256_1_]] : index
-// CHECK:             scf.if [[VAR_34_]] {
+// CHECK:             [[VAR_26_:%.+]] = arith.cmpi slt, [[VAR_25_]], [[CST_256_1_]] : index
+// CHECK:             scf.if [[VAR_26_]] {
 // CHECK:               linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[RES_]] : memref<256xf32>)
 // CHECK:             }
-// CHECK-DAG:         [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_5_]][0] {{.}}[[VAR_33_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-// CHECK-DAG:         [[VAR_subview_6_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_33_]]{{.}} [1] : memref<256xf32> to memref<?xf32, strided<[1]>>
-// CHECK:             memref.copy [[VAR_subview_]], [[VAR_subview_]]_6 : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
-// CHECK:             [[VAR_35_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<256xf32>
-// CHECK:             [[VAR_36_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_arg16_]], [[VAR_35_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_arg16_]] : tensor<256xf32>) {
-// CHECK:             ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32, [[IN_2_:%.+]]: f32):
-// CHECK:               [[VAR_39_:%.+]] = arith.addf [[IN_0_]], [[IN_1_]] : f32
-// CHECK:               linalg.yield [[VAR_39_]] : f32
+// CHECK-DAG:         [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_5_]][0] {{.}}[[VAR_25_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_subview_6_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_25_]]{{.}} [1] : memref<256xf32> to memref<?xf32, strided<[1]>>
+// CHECK:             memref.copy [[VAR_subview_]], [[VAR_subview_6_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK:             [[VAR_27_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<256xf32>
+// CHECK:             [[VAR_28_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_arg16_]], [[VAR_27_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_arg16_]] : tensor<256xf32>) {
+// CHECK:             ^bb0([[IN_1_:%.+]]: f32, [[IN_2_:%.+]]: f32, [[IN_3_:%.+]]: f32):
+// CHECK:               [[VAR_29_:%.+]] = arith.addf [[IN_1_]], [[IN_2_]] : f32
+// CHECK:               linalg.yield [[VAR_29_]] : f32
 // CHECK:             } -> tensor<256xf32>
-// CHECK:             scf.yield [[VAR_36_]] : tensor<256xf32>
+// CHECK:             scf.yield [[VAR_28_]] : tensor<256xf32>
 // CHECK:           }
-// CHECK:           [[VAR_6_:%.+]] = bufferization.alloc_tensor() : tensor<f32>
-// CHECK:           [[VAR_inserted_:%.+]] = tensor.insert [[CST_0_dot_000000_]] into [[VAR_6_]][] : tensor<f32>
-// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_5_]] : tensor<256xf32>) outs([[VAR_inserted_]] : tensor<f32>) dimensions = [0]
-// CHECK:             ([[IN_0_:%.+]]: f32, [[init_:%.+]]: f32) {
-// CHECK:               [[VAR_29_1_:%.+]] = arith.addf [[IN_0_]], [[init_]] : f32
-// CHECK:               linalg.yield [[VAR_29_1_]] : f32
+// CHECK:           [[VAR_8_:%.+]] = bufferization.alloc_tensor() : tensor<f32>
+// CHECK:           [[VAR_inserted_:%.+]] = tensor.insert [[CST_0_dot_000000_]] into [[VAR_8_]][] : tensor<f32>
+// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_7_]] : tensor<256xf32>) outs([[VAR_inserted_]] : tensor<f32>) dimensions = [0]
+// CHECK:             ([[IN_1_:.+]]: f32, [[init_:.+]]: f32) {
+// CHECK:               [[VAR_20_2_:%.+]] = arith.addf [[IN_1_]], [[init_]] : f32
+// CHECK:               linalg.yield [[VAR_20_2_]] : f32
 // CHECK:             }
 // CHECK-DAG:       [[VAR_extracted_:%.+]] = tensor.extract [[VAR_reduced_]][] : tensor<f32>
-// CHECK-DAG:       [[VAR_7_:%.+]] = arith.sitofp [[PARAM_7_]] : i32 to f32
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_8_:%.+]] = arith.divf [[VAR_extracted_]], [[VAR_7_]] : f32
-// CHECK-DAG:       [[VAR_9_:%.+]] = tensor.empty() : tensor<256xi32>
-// CHECK:           [[VAR_10_:%.+]] = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel"]} outs([[VAR_9_]] : tensor<256xi32>) {
-// CHECK:           ^bb0([[IN_3_:%.+]]: i32):
-// CHECK:             [[VAR_29_2_:%.+]] = linalg.index 0 : index
-// CHECK:             [[VAR_30_1_:%.+]] = arith.index_cast [[VAR_29_2_]] : index to i32
-// CHECK:             linalg.yield [[VAR_30_1_]] : i32
-// CHECK:           } -> tensor<256xi32>
-// CHECK:           [[VAR_11_:%.+]] = tensor.empty() : tensor<256xi32>
-// CHECK-DAG:       [[VAR_12_:%.+]] = linalg.fill ins([[PARAM_7_]] : i32) outs([[VAR_11_]] : tensor<256xi32>) -> tensor<256xi32>
-// CHECK-DAG:       [[VAR_13_:%.+]] = tensor.empty() : tensor<256xf32>
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_14_:%.+]] = linalg.fill ins([[VAR_8_]] : f32) outs([[VAR_13_]] : tensor<256xf32>) -> tensor<256xf32>
-// CHECK-DAG:       [[VAR_15_:%.+]] = scf.for [[VAR_arg15_1_:%.+]] = [[CST_0_]] to [[PARAM_7_]] step [[CST_256_]] iter_args([[VAR_arg16_1_:%.+]] = [[VAR_1_]]) -> (tensor<256xf32>)  : i32 {
-// CHECK-DAG:         [[VAR_27_3_:%.+]] = tensor.empty() : tensor<256xi32>
-// CHECK:             [[VAR_28_2_:%.+]] = linalg.fill ins([[VAR_arg15_1_]] : i32) outs([[VAR_27_3_]] : tensor<256xi32>) -> tensor<256xi32>
-// CHECK:             [[VAR_29_1_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_28_2_]], [[VAR_10_]] : tensor<256xi32>, tensor<256xi32>) outs([[VAR_28_2_]] : tensor<256xi32>) {
+// CHECK-DAG:       [[VAR_9_:%.+]] = arith.sitofp [[PARAM_7_]] : i32 to f32
+// CHECK:           [[VAR_10_:%.+]] = arith.divf [[VAR_extracted_]], [[VAR_9_]] : f32
+// CHECK-DAG:       [[VAR_11_:%.+]] = linalg.fill ins([[VAR_10_]] : f32) outs([[VAR_0_]] : tensor<256xf32>) -> tensor<256xf32>
+// CHECK-DAG:       [[VAR_12_:%.+]] = scf.for [[VAR_arg15_1_:%.+]] = [[CST_0_]] to [[PARAM_7_]] step [[CST_256_]] iter_args([[VAR_arg16_1_:%.+]] = [[VAR_1_]]) -> (tensor<256xf32>)  : i32 {
+// CHECK-DAG:         [[VAR_20_3_:%.+]] = linalg.fill ins([[VAR_arg15_1_]] : i32) outs([[VAR_4_]] : tensor<256xi32>) -> tensor<256xi32>
+// CHECK:             [[VAR_21_2_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_20_3_]], [[VAR_5_]] : tensor<256xi32>, tensor<256xi32>) outs([[VAR_20_3_]] : tensor<256xi32>) {
 // CHECK:             ^bb0([[IN_4_:%.+]]: i32, [[IN_5_:%.+]]: i32, [[IN_6_:%.+]]: i32):
-// CHECK:               [[VAR_47_:%.+]] = arith.addi [[IN_4_]], [[IN_5_]] : i32
-// CHECK:               linalg.yield [[VAR_47_]] : i32
+// CHECK:               [[VAR_36_:%.+]] = arith.addi [[IN_4_]], [[IN_5_]] : i32
+// CHECK:               linalg.yield [[VAR_36_]] : i32
 // CHECK:             } -> tensor<256xi32>
-// CHECK:             [[VAR_30_1_:%.+]] = tensor.empty() : tensor<256xi1>
-// CHECK:             [[VAR_31_1_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_29_1_]], [[VAR_12_]] : tensor<256xi32>, tensor<256xi32>) outs([[VAR_30_1_]] : tensor<256xi1>) {
+// CHECK:             [[VAR_22_1_:%.+]] = tensor.empty() : tensor<256xi1>
+// CHECK:             [[VAR_23_1_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_21_2_]], [[VAR_6_]] : tensor<256xi32>, tensor<256xi32>) outs([[VAR_22_1_]] : tensor<256xi1>) {
 // CHECK:             ^bb0([[IN_7_:%.+]]: i32, [[IN_8_:%.+]]: i32, [[IN_9_:%.+]]: i1):
-// CHECK:               [[VAR_47_1_:%.+]] = arith.cmpi slt, [[IN_7_]], [[IN_8_]] : i32
-// CHECK:               linalg.yield [[VAR_47_1_]] : i1
+// CHECK:               [[VAR_36_1_:%.+]] = arith.cmpi slt, [[IN_7_]], [[IN_8_]] : i32
+// CHECK:               linalg.yield [[VAR_36_1_]] : i1
 // CHECK:             } -> tensor<256xi1>
-// CHECK:             [[VAR_32_1_:%.+]] = arith.index_cast [[VAR_arg15_1_]] : i32 to index
-// CHECK:             [[VAR_33_1_:%.+]] = arith.addi [[VAR_3_]], [[VAR_3_]]2 : index
-// CHECK-DAG:         [[VAR_reinterpret_cast_5_1_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_33_1_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
-// CHECK-DAG:         [[VAR_34_1_:%.+]] = arith.index_cast [[VAR_arg15_1_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_35_1_:%.+]] = arith.addi [[VAR_34_1_]], [[CST_256_1_]] : index
-// CHECK-DAG:         [[VAR_36_1_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
-// CHECK:             [[VAR_37_1_:%.+]] = arith.minsi [[VAR_35_1_]], [[VAR_36_1_]] : index
-// CHECK-DAG:         [[VAR_38_:%.+]] = arith.subi [[VAR_37_1_]], [[VAR_34_1_]] : index
+// CHECK:             [[VAR_24_1_:%.+]] = arith.index_cast [[VAR_arg15_1_]] : i32 to index
+// CHECK:             [[VAR_25_1_:%.+]] = arith.addi [[VAR_3_]], [[VAR_24_1_]] : index
+// CHECK-DAG:         [[VAR_reinterpret_cast_5_1_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_25_1_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_26_1_:%.+]] = arith.addi [[VAR_24_1_]], [[CST_256_1_]] : index
+// CHECK-DAG:         [[VAR_27_1_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
+// CHECK:             [[VAR_28_1_:%.+]] = arith.minsi [[VAR_26_1_]], [[VAR_27_1_]] : index
+// CHECK-DAG:         [[VAR_29_1_:%.+]] = arith.subi [[VAR_28_1_]], [[VAR_24_1_]] : index
 // CHECK-DAG:         [[RES_1_:%.+]] = memref.alloc() : memref<256xf32>
-// CHECK:             [[VAR_39_:%.+]] = arith.cmpi slt, [[VAR_38_]], [[CST_256_1_]] : index
-// CHECK:             scf.if [[VAR_39_]] {
+// CHECK:             [[VAR_30_:%.+]] = arith.cmpi slt, [[VAR_29_1_]], [[CST_256_1_]] : index
+// CHECK:             scf.if [[VAR_30_]] {
 // CHECK:               linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[RES_1_]] : memref<256xf32>)
 // CHECK:             }
-// CHECK-DAG:         [[VAR_subview_1_:%.+]] = memref.subview [[VAR_reinterpret_cast_5_1_]][0] {{.}}[[VAR_38_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-// CHECK-DAG:         [[VAR_subview_6_1_:%.+]] = memref.subview [[RES_1_]][0] {{.}}[[VAR_38_]]{{.}} [1] : memref<256xf32> to memref<?xf32, strided<[1]>>
-// CHECK:             memref.copy [[VAR_subview_1_]], [[VAR_subview_1_]]_6 : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
-// CHECK:             [[VAR_40_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<256xf32>
-// CHECK:             [[VAR_41_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_40_]], [[VAR_14_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_40_]] : tensor<256xf32>) {
+// CHECK-DAG:         [[VAR_subview_1_:%.+]] = memref.subview [[VAR_reinterpret_cast_5_1_]][0] {{.}}[[VAR_29_1_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_subview_6_1_:%.+]] = memref.subview [[RES_1_]][0] {{.}}[[VAR_29_1_]]{{.}} [1] : memref<256xf32> to memref<?xf32, strided<[1]>>
+// CHECK:             memref.copy [[VAR_subview_1_]], [[VAR_subview_6_1_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK:             [[VAR_31_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<256xf32>
+// CHECK:             [[VAR_32_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_31_]], [[VAR_11_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_31_]] : tensor<256xf32>) {
 // CHECK:             ^bb0([[IN_10_:%.+]]: f32, [[IN_11_:%.+]]: f32, [[IN_12_:%.+]]: f32):
-// CHECK:               [[VAR_47_2_:%.+]] = arith.subf [[IN_10_]], [[IN_11_]] : f32
-// CHECK:               linalg.yield [[VAR_47_2_]] : f32
+// CHECK:               [[VAR_36_2_:%.+]] = arith.subf [[IN_10_]], [[IN_11_]] : f32
+// CHECK:               linalg.yield [[VAR_36_2_]] : f32
 // CHECK:             } -> tensor<256xf32>
-// CHECK:             [[VAR_42_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_31_1_]], [[VAR_41_]], [[VAR_1_]] : tensor<256xi1>, tensor<256xf32>, tensor<256xf32>) outs([[VAR_41_]] : tensor<256xf32>) {
+// CHECK:             [[VAR_33_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_23_1_]], [[VAR_32_]], [[VAR_1_]] : tensor<256xi1>, tensor<256xf32>, tensor<256xf32>) outs([[VAR_32_]] : tensor<256xf32>) {
 // CHECK:             ^bb0([[IN_13_:%.+]]: i1, [[IN_14_:%.+]]: f32, [[IN_15_:%.+]]: f32, [[IN_16_:%.+]]: f32):
-// CHECK:               [[VAR_47_3_:%.+]] = arith.select [[IN_13_]], [[IN_14_]], [[IN_15_]] : f32
-// CHECK:               linalg.yield [[VAR_47_3_]] : f32
+// CHECK:               [[VAR_36_3_:%.+]] = arith.select [[IN_13_]], [[IN_14_]], [[IN_15_]] : f32
+// CHECK:               linalg.yield [[VAR_36_3_]] : f32
 // CHECK:             } -> tensor<256xf32>
-// CHECK:             [[VAR_43_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_42_]], [[VAR_42_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_42_]] : tensor<256xf32>) {
+// CHECK:             [[VAR_34_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_33_]], [[VAR_33_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_33_]] : tensor<256xf32>) {
 // CHECK:             ^bb0([[IN_17_:%.+]]: f32, [[IN_18_:%.+]]: f32, [[IN_19_:%.+]]: f32):
-// CHECK:               [[VAR_47_4_:%.+]] = arith.mulf [[IN_17_]], [[IN_18_]] : f32
-// CHECK:               linalg.yield [[VAR_47_4_]] : f32
+// CHECK:               [[VAR_36_4_:%.+]] = arith.mulf [[IN_17_]], [[IN_18_]] : f32
+// CHECK:               linalg.yield [[VAR_36_4_]] : f32
 // CHECK:             } -> tensor<256xf32>
-// CHECK:             [[VAR_44_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_arg16_1_]], [[VAR_43_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_arg16_1_]] : tensor<256xf32>) {
+// CHECK:             [[VAR_35_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_arg16_1_]], [[VAR_34_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_arg16_1_]] : tensor<256xf32>) {
 // CHECK:             ^bb0([[IN_20_:%.+]]: f32, [[IN_21_:%.+]]: f32, [[IN_22_:%.+]]: f32):
-// CHECK:               [[VAR_47_5_:%.+]] = arith.addf [[IN_20_]], [[IN_21_]] : f32
-// CHECK:               linalg.yield [[VAR_47_5_]] : f32
+// CHECK:               [[VAR_36_5_:%.+]] = arith.addf [[IN_20_]], [[IN_21_]] : f32
+// CHECK:               linalg.yield [[VAR_36_5_]] : f32
 // CHECK:             } -> tensor<256xf32>
-// CHECK:             scf.yield [[VAR_44_]] : tensor<256xf32>
+// CHECK:             scf.yield [[VAR_35_]] : tensor<256xf32>
 // CHECK:           }
-// CHECK:           [[VAR_16_:%.+]] = bufferization.alloc_tensor() : tensor<f32>
-// CHECK:           [[VAR_inserted_1_:%.+]] = tensor.insert [[CST_0_dot_000000_]] into [[VAR_16_]][] : tensor<f32>
-// CHECK:           [[VAR_reduced_2_:%.+]] = linalg.reduce ins([[VAR_15_]] : tensor<256xf32>) outs([[VAR_inserted_1_]] : tensor<f32>) dimensions = [0]
-// CHECK:             ([[IN_20_:%.+]]: f32, [[init_:%.+]]: f32) {
-// CHECK:               [[VAR_29_4_:%.+]] = arith.addf [[IN_20_]], [[init_]] : f32
-// CHECK:               linalg.yield [[VAR_29_4_]] : f32
+// CHECK:           [[VAR_13_:%.+]] = bufferization.alloc_tensor() : tensor<f32>
+// CHECK:           [[VAR_inserted_1_:%.+]] = tensor.insert [[CST_0_dot_000000_]] into [[VAR_13_]][] : tensor<f32>
+// CHECK:           [[VAR_reduced_2_:%.+]] = linalg.reduce ins([[VAR_12_]] : tensor<256xf32>) outs([[VAR_inserted_1_]] : tensor<f32>) dimensions = [0]
+// CHECK:             ([[IN_20_:.+]]: f32, [[init_:.+]]: f32) {
+// CHECK:               [[VAR_20_4_:%.+]] = arith.addf [[IN_20_]], [[init_]] : f32
+// CHECK:               linalg.yield [[VAR_20_4_]] : f32
 // CHECK:             }
 // CHECK:           [[VAR_extracted_3_:%.+]] = tensor.extract [[VAR_reduced_2_]][] : tensor<f32>
-// CHECK:           [[VAR_17_:%.+]] = arith.divf [[VAR_extracted_3_]], [[VAR_7_]] : f32
-// CHECK:           [[VAR_18_:%.+]] = arith.addf [[VAR_17_]], [[PARAM_8_]] : f32
-// CHECK:           [[VAR_19_:%.+]] = math.sqrt [[VAR_18_]] : f32
-// CHECK-DAG:       [[VAR_20_:%.+]] = arith.divf [[CST_1_dot_000000_]], [[VAR_19_]] : f32
-// CHECK-DAG:       [[VAR_21_:%.+]] = arith.index_cast [[PARAM_12_]] : i32 to index
-// CHECK:           [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_4_]] to offset: {{.}}[[VAR_21_]]{{.}}, sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
-// CHECK:           affine.store [[VAR_8_]], [[VAR_reinterpret_cast_]][0] : memref<1xf32, strided<[1], offset: ?>>
-// CHECK:           [[VAR_22_:%.+]] = arith.index_cast [[PARAM_12_]] : i32 to index
-// CHECK:           [[VAR_reinterpret_cast_4_:%.+]] = memref.reinterpret_cast [[PARAM_5_]] to offset: {{.}}[[VAR_22_]]{{.}}, sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
-// CHECK:           affine.store [[VAR_20_]], [[VAR_reinterpret_cast_4_]][0] : memref<1xf32, strided<[1], offset: ?>>
-// CHECK:           [[VAR_23_:%.+]] = tensor.empty() : tensor<256xf32>
-// CHECK-DAG:       [[VAR_24_:%.+]] = linalg.fill ins([[VAR_8_]] : f32) outs([[VAR_23_]] : tensor<256xf32>) -> tensor<256xf32>
-// CHECK-DAG:       [[VAR_25_:%.+]] = tensor.empty() : tensor<256xf32>
-// CHECK:           [[VAR_26_:%.+]] = linalg.fill ins([[VAR_20_]] : f32) outs([[VAR_25_]] : tensor<256xf32>) -> tensor<256xf32>
+// CHECK:           [[VAR_14_:%.+]] = arith.divf [[VAR_extracted_3_]], [[VAR_9_]] : f32
+// CHECK:           [[VAR_15_:%.+]] = arith.addf [[VAR_14_]], [[PARAM_8_]] : f32
+// CHECK:           [[VAR_16_:%.+]] = math.sqrt [[VAR_15_]] : f32
+// CHECK-DAG:       [[VAR_17_:%.+]] = arith.divf [[CST_1_dot_000000_]], [[VAR_16_]] : f32
+// CHECK-DAG:       [[VAR_18_:%.+]] = arith.index_cast [[PARAM_12_]] : i32 to index
+// CHECK:           [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_4_]] to offset: {{.}}[[VAR_18_]]{{.}}, sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
+// CHECK:           affine.store [[VAR_10_]], [[VAR_reinterpret_cast_]][0] : memref<1xf32, strided<[1], offset: ?>>
+// CHECK:           [[VAR_reinterpret_cast_4_:%.+]] = memref.reinterpret_cast [[PARAM_5_]] to offset: {{.}}[[VAR_18_]]{{.}}, sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
+// CHECK:           affine.store [[VAR_17_]], [[VAR_reinterpret_cast_4_]][0] : memref<1xf32, strided<[1], offset: ?>>
+// CHECK:           [[VAR_19_:%.+]] = linalg.fill ins([[VAR_17_]] : f32) outs([[VAR_0_]] : tensor<256xf32>) -> tensor<256xf32>
 // CHECK:           scf.for [[VAR_arg15_1_:%.+]] = [[CST_0_]] to [[PARAM_7_]] step [[CST_256_]]  : i32 {
-// CHECK:             [[VAR_27_5_:%.+]] = arith.index_cast [[VAR_arg15_1_]] : i32 to index
-// CHECK-DAG:         [[VAR_reinterpret_cast_5_2_:%.+]] = memref.reinterpret_cast [[PARAM_2_]] to offset: {{.}}[[VAR_27_5_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
-// CHECK-DAG:         [[VAR_28_3_:%.+]] = arith.index_cast [[VAR_arg15_1_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_29_2_:%.+]] = arith.addi [[VAR_28_3_]], [[CST_256_1_]] : index
-// CHECK-DAG:         [[VAR_30_2_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
-// CHECK:             [[VAR_31_2_:%.+]] = arith.minsi [[VAR_29_2_]], [[VAR_30_2_]] : index
-// CHECK-DAG:         [[VAR_32_2_:%.+]] = arith.subi [[VAR_31_2_]], [[VAR_28_3_]] : index
+// CHECK:             [[VAR_20_5_:%.+]] = arith.index_cast [[VAR_arg15_1_]] : i32 to index
+// CHECK-DAG:         [[VAR_reinterpret_cast_5_2_:%.+]] = memref.reinterpret_cast [[PARAM_2_]] to offset: {{.}}[[VAR_20_5_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_21_3_:%.+]] = arith.addi [[VAR_20_5_]], [[CST_256_1_]] : index
+// CHECK-DAG:         [[VAR_22_2_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
+// CHECK:             [[VAR_23_2_:%.+]] = arith.minsi [[VAR_21_3_]], [[VAR_22_2_]] : index
+// CHECK-DAG:         [[VAR_24_2_:%.+]] = arith.subi [[VAR_23_2_]], [[VAR_20_5_]] : index
 // CHECK-DAG:         [[RES_2_:%.+]] = memref.alloc() : memref<256xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_subview_2_:%.+]] = memref.subview [[VAR_reinterpret_cast_5_2_]][0] {{.}}[[VAR_32_2_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-// CHECK-DAG:         [[VAR_subview_6_2_:%.+]] = memref.subview [[RES_2_]][0] {{.}}[[VAR_32_2_]]{{.}} [1] : memref<256xf32> to memref<?xf32, strided<[1]>>
-// CHECK:             memref.copy [[VAR_subview_2_]], [[VAR_subview_2_]]_6 : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
-// CHECK-DAG:         [[VAR_33_2_:%.+]] = bufferization.to_tensor [[RES_2_]] restrict writable : memref<256xf32>
-// CHECK-DAG:         [[VAR_34_2_:%.+]] = arith.index_cast [[VAR_arg15_1_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_reinterpret_cast_7_:%.+]] = memref.reinterpret_cast [[PARAM_3_]] to offset: {{.}}[[VAR_34_2_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
-// CHECK-DAG:         [[VAR_35_2_:%.+]] = arith.index_cast [[VAR_arg15_1_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_36_2_:%.+]] = arith.addi [[VAR_35_2_]], [[CST_256_1_]] : index
-// CHECK-DAG:         [[VAR_37_2_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
-// CHECK:             [[VAR_38_1_:%.+]] = arith.minsi [[VAR_36_2_]], [[VAR_37_2_]] : index
-// CHECK-DAG:         [[VAR_39_1_:%.+]] = arith.subi [[VAR_38_1_]], [[VAR_35_2_]] : index
+// CHECK-DAG:         [[VAR_subview_2_:%.+]] = memref.subview [[VAR_reinterpret_cast_5_2_]][0] {{.}}[[VAR_24_2_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_subview_6_2_:%.+]] = memref.subview [[RES_2_]][0] {{.}}[[VAR_24_2_]]{{.}} [1] : memref<256xf32> to memref<?xf32, strided<[1]>>
+// CHECK:             memref.copy [[VAR_subview_2_]], [[VAR_subview_6_2_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:         [[VAR_25_2_:%.+]] = bufferization.to_tensor [[RES_2_]] restrict writable : memref<256xf32>
+// CHECK-DAG:         [[VAR_reinterpret_cast_7_:%.+]] = memref.reinterpret_cast [[PARAM_3_]] to offset: {{.}}[[VAR_20_5_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
 // CHECK-DAG:         [[RES_3_:%.+]] = memref.alloc() : memref<256xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_subview_9_:%.+]] = memref.subview [[VAR_reinterpret_cast_7_]][0] {{.}}[[VAR_39_1_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-// CHECK-DAG:         [[VAR_subview_10_:%.+]] = memref.subview [[RES_3_]][0] {{.}}[[VAR_39_1_]]{{.}} [1] : memref<256xf32> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:         [[VAR_subview_9_:%.+]] = memref.subview [[VAR_reinterpret_cast_7_]][0] {{.}}[[VAR_24_2_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_subview_10_:%.+]] = memref.subview [[RES_3_]][0] {{.}}[[VAR_24_2_]]{{.}} [1] : memref<256xf32> to memref<?xf32, strided<[1]>>
 // CHECK:             memref.copy [[VAR_subview_9_]], [[VAR_subview_10_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
-// CHECK-DAG:         [[VAR_40_1_:%.+]] = bufferization.to_tensor [[RES_3_]] restrict writable : memref<256xf32>
-// CHECK-DAG:         [[VAR_41_1_:%.+]] = arith.index_cast [[VAR_arg15_1_]] : i32 to index
-// CHECK:             [[VAR_42_1_:%.+]] = arith.addi [[VAR_3_]], [[VAR_41_1_]] : index
-// CHECK-DAG:         [[VAR_reinterpret_cast_11_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_42_1_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
-// CHECK-DAG:         [[VAR_43_1_:%.+]] = arith.index_cast [[VAR_arg15_1_]] : i32 to index
+// CHECK-DAG:         [[VAR_26_2_:%.+]] = bufferization.to_tensor [[RES_3_]] restrict writable : memref<256xf32>
+// CHECK-DAG:         [[VAR_27_2_:%.+]] = arith.addi [[VAR_3_]], [[VAR_20_5_]] : index
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_44_1_:%.+]] = arith.addi [[VAR_43_1_]], [[CST_256_1_]] : index
-// CHECK-DAG:         [[VAR_45_6_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
-// CHECK:             [[VAR_46_:%.+]] = arith.minsi [[VAR_44_1_]], [[VAR_45_6_]] : index
-// CHECK-DAG:         [[VAR_47_:%.+]] = arith.subi [[VAR_46_]], [[VAR_43_1_]] : index
+// CHECK-DAG:         [[VAR_reinterpret_cast_11_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_27_2_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
 // CHECK-DAG:         [[RES_4_:%.+]] = memref.alloc() : memref<256xf32>
-// CHECK:             [[VAR_48_:%.+]] = arith.cmpi slt, [[VAR_47_]], [[CST_256_1_]] : index
-// CHECK:             scf.if [[VAR_48_]] {
+// CHECK-DAG:         [[VAR_28_2_:%.+]] = arith.cmpi slt, [[VAR_24_2_]], [[CST_256_1_]] : index
+// CHECK:             scf.if [[VAR_28_2_]] {
 // CHECK:               linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[RES_4_]] : memref<256xf32>)
 // CHECK:             }
-// CHECK-DAG:         [[VAR_subview_13_:%.+]] = memref.subview [[VAR_reinterpret_cast_11_]][0] {{.}}[[VAR_47_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-// CHECK-DAG:         [[VAR_subview_14_:%.+]] = memref.subview [[RES_4_]][0] {{.}}[[VAR_47_]]{{.}} [1] : memref<256xf32> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:         [[VAR_subview_13_:%.+]] = memref.subview [[VAR_reinterpret_cast_11_]][0] {{.}}[[VAR_24_2_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_subview_14_:%.+]] = memref.subview [[RES_4_]][0] {{.}}[[VAR_24_2_]]{{.}} [1] : memref<256xf32> to memref<?xf32, strided<[1]>>
 // CHECK:             memref.copy [[VAR_subview_13_]], [[VAR_subview_14_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
-// CHECK:             [[VAR_49_:%.+]] = bufferization.to_tensor [[RES_4_]] restrict writable : memref<256xf32>
-// CHECK:             [[VAR_50_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_49_]], [[VAR_24_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_49_]] : tensor<256xf32>) {
+// CHECK:             [[VAR_29_2_:%.+]] = bufferization.to_tensor [[RES_4_]] restrict writable : memref<256xf32>
+// CHECK:             [[VAR_30_1_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_29_2_]], [[VAR_11_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_29_2_]] : tensor<256xf32>) {
 // CHECK:             ^bb0([[IN_23_:%.+]]: f32, [[IN_24_:%.+]]: f32, [[IN_25_:%.+]]: f32):
-// CHECK:               [[VAR_63_:%.+]] = arith.subf [[IN_23_]], [[IN_24_]] : f32
-// CHECK:               linalg.yield [[VAR_63_]] : f32
+// CHECK:               [[VAR_34_1_:%.+]] = arith.subf [[IN_23_]], [[IN_24_]] : f32
+// CHECK:               linalg.yield [[VAR_34_1_]] : f32
 // CHECK:             } -> tensor<256xf32>
-// CHECK:             [[VAR_51_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_50_]], [[VAR_26_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_50_]] : tensor<256xf32>) {
+// CHECK:             [[VAR_31_1_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_30_1_]], [[VAR_19_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_30_1_]] : tensor<256xf32>) {
 // CHECK:             ^bb0([[IN_26_:%.+]]: f32, [[IN_27_:%.+]]: f32, [[IN_28_:%.+]]: f32):
-// CHECK:               [[VAR_63_1_:%.+]] = arith.mulf [[IN_26_]], [[IN_27_]] : f32
-// CHECK:               linalg.yield [[VAR_63_1_]] : f32
+// CHECK:               [[VAR_34_2_:%.+]] = arith.mulf [[IN_26_]], [[IN_27_]] : f32
+// CHECK:               linalg.yield [[VAR_34_2_]] : f32
 // CHECK:             } -> tensor<256xf32>
-// CHECK:             [[VAR_52_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_51_]], [[VAR_33_2_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_51_]] : tensor<256xf32>) {
+// CHECK:             [[VAR_32_1_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_31_1_]], [[VAR_25_2_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_31_1_]] : tensor<256xf32>) {
 // CHECK:             ^bb0([[IN_29_:%.+]]: f32, [[IN_30_:%.+]]: f32, [[IN_31_:%.+]]: f32):
-// CHECK:               [[VAR_63_2_:%.+]] = arith.mulf [[IN_29_]], [[IN_30_]] : f32
-// CHECK:               linalg.yield [[VAR_63_2_]] : f32
+// CHECK:               [[VAR_34_3_:%.+]] = arith.mulf [[IN_29_]], [[IN_30_]] : f32
+// CHECK:               linalg.yield [[VAR_34_3_]] : f32
 // CHECK:             } -> tensor<256xf32>
-// CHECK:             [[VAR_53_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_52_]], [[VAR_40_1_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_52_]] : tensor<256xf32>) {
+// CHECK:             [[VAR_33_1_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_32_1_]], [[VAR_26_2_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_32_1_]] : tensor<256xf32>) {
 // CHECK:             ^bb0([[IN_32_:%.+]]: f32, [[IN_33_:%.+]]: f32, [[IN_34_:%.+]]: f32):
-// CHECK:               [[VAR_63_3_:%.+]] = arith.addf [[IN_32_]], [[IN_33_]] : f32
-// CHECK:               linalg.yield [[VAR_63_3_]] : f32
+// CHECK:               [[VAR_34_4_:%.+]] = arith.addf [[IN_32_]], [[IN_33_]] : f32
+// CHECK:               linalg.yield [[VAR_34_4_]] : f32
 // CHECK:             } -> tensor<256xf32>
-// CHECK:             [[VAR_54_:%.+]] = arith.index_cast [[VAR_arg15_1_]] : i32 to index
-// CHECK:             [[VAR_55_:%.+]] = arith.addi [[VAR_4_]], [[VAR_54_]] : index
-// CHECK-DAG:         [[VAR_reinterpret_cast_15_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_55_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
-// CHECK-DAG:         [[VAR_56_:%.+]] = arith.index_cast [[VAR_arg15_1_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_57_:%.+]] = arith.addi [[VAR_56_]], [[CST_256_1_]] : index
-// CHECK-DAG:         [[VAR_58_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
-// CHECK:             [[VAR_59_:%.+]] = arith.minsi [[VAR_57_]], [[VAR_58_]] : index
-// CHECK:             [[VAR_60_:%.+]] = arith.subi [[VAR_59_]], [[VAR_56_]] : index
-// CHECK-DAG:         [[VAR_extracted_slice_:%.+]] = tensor.extract_slice [[VAR_53_]][0] {{.}}[[VAR_60_]]{{.}} [1] : tensor<256xf32> to tensor<?xf32>
-// CHECK-DAG:         [[VAR_subview_16_:%.+]] = memref.subview [[VAR_reinterpret_cast_15_]][0] {{.}}[[VAR_60_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_reinterpret_cast_15_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_27_2_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_extracted_slice_:%.+]] = tensor.extract_slice [[VAR_33_1_]][0] {{.}}[[VAR_24_2_]]{{.}} [1] : tensor<256xf32> to tensor<?xf32>
+// CHECK:             [[VAR_subview_16_:%.+]] = memref.subview [[VAR_reinterpret_cast_15_]][0] {{.}}[[VAR_24_2_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
 // CHECK:             bufferization.materialize_in_destination [[VAR_extracted_slice_]] in writable [[VAR_subview_16_]] : (tensor<?xf32>, memref<?xf32, strided<[1], offset: ?>>) -> ()
 // CHECK:           }
 // CHECK:           return

--- a/test/Conversion/StructuredToMemref/masked_ldst_1d.mlir
+++ b/test/Conversion/StructuredToMemref/masked_ldst_1d.mlir
@@ -19,7 +19,7 @@ module {
     tt.return
   }
 }
-// mlir2FileCheck.py
+
 // CHECK-LABEL:  func.func @kernel
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: memref<*xbf16>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
 // CHECK-DAG:       [[CST_128_:%.+]] = arith.constant 128 : index
@@ -37,11 +37,9 @@ module {
 // CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_1_]]{{.}} [1] : memref<128xbf16, strided<[1]>> to memref<?xbf16, strided<[1]>>
 // CHECK-DAG:       [[VAR_subview_1_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_1_]]{{.}} [1] : memref<128xbf16> to memref<?xbf16, strided<[1]>>
 // CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_1_]] : memref<?xbf16, strided<[1]>> to memref<?xbf16, strided<[1]>>
-// CHECK-DAG:       [[VAR_3_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<128xbf16>
-// CHECK-DAG:       [[VAR_4_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
-// CHECK:           [[VAR_5_:%.+]] = arith.minsi [[VAR_4_]], [[CST_128_]] : index
-// CHECK-DAG:       [[VAR_extracted_slice_:%.+]] = tensor.extract_slice [[VAR_3_]][0] {{.}}[[VAR_5_]]{{.}} [1] : tensor<128xbf16> to tensor<?xbf16>
-// CHECK-DAG:       [[VAR_subview_2_:%.+]] = memref.subview [[VAR_reinterpret_cast_0_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<128xbf16, strided<[1]>> to memref<?xbf16, strided<[1]>>
+// CHECK:           [[VAR_3_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<128xbf16>
+// CHECK-DAG:       [[VAR_extracted_slice_:%.+]] = tensor.extract_slice [[VAR_3_]][0] {{.}}[[VAR_1_]]{{.}} [1] : tensor<128xbf16> to tensor<?xbf16>
+// CHECK-DAG:       [[VAR_subview_2_:%.+]] = memref.subview [[VAR_reinterpret_cast_0_]][0] {{.}}[[VAR_1_]]{{.}} [1] : memref<128xbf16, strided<[1]>> to memref<?xbf16, strided<[1]>>
 // CHECK:           bufferization.materialize_in_destination [[VAR_extracted_slice_]] in writable [[VAR_subview_2_]] : (tensor<?xbf16>, memref<?xbf16, strided<[1]>>) -> ()
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/StructuredToMemref/masked_ldst_2d.mlir
+++ b/test/Conversion/StructuredToMemref/masked_ldst_2d.mlir
@@ -61,7 +61,7 @@ module {
     tt.return
   }
 }
-// mlir2FileCheck.py
+
 // CHECK-LABEL:  func.func @kernel
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: memref<*xbf16>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32) {
 // CHECK-DAG:       [[CST_1024_:%.+]] = arith.constant 1024 : index
@@ -95,17 +95,9 @@ module {
 // CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0, 0] {{.}}[[VAR_6_]], [[VAR_7_]]{{.}} [1, 1] : memref<128x256xbf16, strided<[1, ?], offset: ?>> to memref<?x?xbf16, strided<[1, ?], offset: ?>>
 // CHECK-DAG:       [[VAR_subview_1_:%.+]] = memref.subview [[RES_]][0, 0] {{.}}[[VAR_6_]], [[VAR_7_]]{{.}} [1, 1] : memref<128x256xbf16> to memref<?x?xbf16, strided<[256, 1]>>
 // CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_1_]] : memref<?x?xbf16, strided<[1, ?], offset: ?>> to memref<?x?xbf16, strided<[256, 1]>>
-// CHECK-DAG:       [[VAR_11_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<128x256xbf16>
-// CHECK-DAG:       [[VAR_12_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
-// CHECK:           [[VAR_13_:%.+]] = arith.minsi [[VAR_12_]], [[CST_130_]] : index
-// CHECK-DAG:       [[VAR_14_:%.+]] = arith.subi [[VAR_13_]], [[CST_2_]] : index
-// CHECK-DAG:       [[VAR_15_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
-// CHECK:           [[VAR_16_:%.+]] = arith.minsi [[VAR_15_]], [[CST_259_]] : index
-// CHECK-DAG:       [[VAR_17_:%.+]] = arith.subi [[VAR_16_]], [[CST_3_]] : index
-// CHECK-DAG:       [[VAR_18_:%.+]] = arith.minsi [[VAR_14_]], [[CST_128_]] : index
-// CHECK:           [[VAR_19_:%.+]] = arith.minsi [[VAR_17_]], [[CST_256_]] : index
-// CHECK-DAG:       [[VAR_extracted_slice_:%.+]] = tensor.extract_slice [[VAR_11_]][0, 0] {{.}}[[VAR_18_]], [[VAR_19_]]{{.}} [1, 1] : tensor<128x256xbf16> to tensor<?x?xbf16>
-// CHECK-DAG:       [[VAR_subview_2_:%.+]] = memref.subview [[VAR_reinterpret_cast_0_]][0, 0] {{.}}[[VAR_18_]], [[VAR_19_]]{{.}} [1, 1] : memref<128x256xbf16, strided<[1, ?], offset: ?>> to memref<?x?xbf16, strided<[1, ?], offset: ?>>
+// CHECK:           [[VAR_11_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<128x256xbf16>
+// CHECK-DAG:       [[VAR_extracted_slice_:%.+]] = tensor.extract_slice [[VAR_11_]][0, 0] {{.}}[[VAR_6_]], [[VAR_7_]]{{.}} [1, 1] : tensor<128x256xbf16> to tensor<?x?xbf16>
+// CHECK-DAG:       [[VAR_subview_2_:%.+]] = memref.subview [[VAR_reinterpret_cast_0_]][0, 0] {{.}}[[VAR_6_]], [[VAR_7_]]{{.}} [1, 1] : memref<128x256xbf16, strided<[1, ?], offset: ?>> to memref<?x?xbf16, strided<[1, ?], offset: ?>>
 // CHECK:           bufferization.materialize_in_destination [[VAR_extracted_slice_]] in writable [[VAR_subview_2_]] : (tensor<?x?xbf16>, memref<?x?xbf16, strided<[1, ?], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/StructuredToMemref/masked_ldst_sitofp_other.mlir
+++ b/test/Conversion/StructuredToMemref/masked_ldst_sitofp_other.mlir
@@ -21,7 +21,7 @@ module {
     tt.return
   }
 }
-// mlir2FileCheck.py
+
 // CHECK-LABEL:  func.func @kernel
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: memref<*xbf16>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
 // CHECK-DAG:       [[CST_128_:%.+]] = arith.constant 128 : index
@@ -39,11 +39,9 @@ module {
 // CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_1_]]{{.}} [1] : memref<128xbf16, strided<[1]>> to memref<?xbf16, strided<[1]>>
 // CHECK-DAG:       [[VAR_subview_1_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_1_]]{{.}} [1] : memref<128xbf16> to memref<?xbf16, strided<[1]>>
 // CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_1_]] : memref<?xbf16, strided<[1]>> to memref<?xbf16, strided<[1]>>
-// CHECK-DAG:       [[VAR_3_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<128xbf16>
-// CHECK-DAG:       [[VAR_4_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
-// CHECK:           [[VAR_5_:%.+]] = arith.minsi [[VAR_4_]], [[CST_128_]] : index
-// CHECK-DAG:       [[VAR_extracted_slice_:%.+]] = tensor.extract_slice [[VAR_3_]][0] {{.}}[[VAR_5_]]{{.}} [1] : tensor<128xbf16> to tensor<?xbf16>
-// CHECK-DAG:       [[VAR_subview_2_:%.+]] = memref.subview [[VAR_reinterpret_cast_0_]][0] {{.}}[[VAR_5_]]{{.}} [1] : memref<128xbf16, strided<[1]>> to memref<?xbf16, strided<[1]>>
+// CHECK:           [[VAR_3_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<128xbf16>
+// CHECK-DAG:       [[VAR_extracted_slice_:%.+]] = tensor.extract_slice [[VAR_3_]][0] {{.}}[[VAR_1_]]{{.}} [1] : tensor<128xbf16> to tensor<?xbf16>
+// CHECK-DAG:       [[VAR_subview_2_:%.+]] = memref.subview [[VAR_reinterpret_cast_0_]][0] {{.}}[[VAR_1_]]{{.}} [1] : memref<128xbf16, strided<[1]>> to memref<?xbf16, strided<[1]>>
 // CHECK:           bufferization.materialize_in_destination [[VAR_extracted_slice_]] in writable [[VAR_subview_2_]] : (tensor<?xbf16>, memref<?xbf16, strided<[1]>>) -> ()
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/StructuredToMemref/scalar_store_loop_iterargs.mlir
+++ b/test/Conversion/StructuredToMemref/scalar_store_loop_iterargs.mlir
@@ -25,23 +25,18 @@ module {
 // CHECK-DAG:       [[CST_5_:%.+]] = arith.constant 5 : i32
 // CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : i32
 // CHECK-DAG:       [[VAR_0_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
-// CHECK-DAG:       [[VAR_1_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
-// CHECK-DAG:       [[VAR_2_:%.+]] = arith.sitofp [[PARAM_7_]] : i32 to f32
-// CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
-// CHECK:           [[VAR_4_:%.+]]:3 = scf.for [[VAR_arg10_:%.+]] = [[CST_0_]] to [[CST_5_]] step [[CST_1_]] iter_args([[VAR_arg11_:%.+]] = [[VAR_reinterpret_cast_]], [[VAR_arg12_:%.+]] = [[VAR_0_]], [[VAR_arg13_:%.+]] = [[VAR_3_]]) -> (memref<1xf32, strided<[1], offset: ?>>, index, index)  : i32 {
-// CHECK:             affine.store [[VAR_2_]], [[VAR_arg11_]][0] : memref<1xf32, strided<[1], offset: ?>>
-// CHECK:             [[VAR_5_:%.+]] = arith.index_cast [[VAR_arg10_]] : i32 to index
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_0_]]{{.}}, sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_1_:%.+]] = arith.sitofp [[PARAM_7_]] : i32 to f32
+// CHECK:           [[VAR_2_:%.+]]:3 = scf.for [[VAR_arg10_:%.+]] = [[CST_0_]] to [[CST_5_]] step [[CST_1_]] iter_args([[VAR_arg11_:%.+]] = [[VAR_reinterpret_cast_]], [[VAR_arg12_:%.+]] = [[VAR_0_]], [[VAR_arg13_:%.+]] = [[VAR_0_]]) -> (memref<1xf32, strided<[1], offset: ?>>, index, index)  : i32 {
+// CHECK:             affine.store [[VAR_1_]], [[VAR_arg11_]][0] : memref<1xf32, strided<[1], offset: ?>>
+// CHECK:             [[VAR_3_:%.+]] = arith.index_cast [[VAR_arg10_]] : i32 to index
 // CHECK:             [[base_buffer_:%.+]], [[offset_:%.+]], [[sizes_:%.+]], [[VAR_strides_:%.+]] = memref.extract_strided_metadata [[VAR_arg11_]] : memref<1xf32, strided<[1], offset: ?>> -> memref<f32>, index, index, index
-// CHECK:             [[VAR_6_:%.+]] = arith.addi [[offset_]], [[VAR_5_]] : index
-// CHECK-DAG:         [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[base_buffer_]] to offset: {{.}}[[VAR_6_]]{{.}}, sizes: [1], strides: [1] : memref<f32> to memref<1xf32, strided<[1], offset: ?>>
-// CHECK-DAG:         [[VAR_7_:%.+]] = arith.index_cast [[VAR_arg10_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_8_:%.+]] = arith.addi [[VAR_arg12_]], [[VAR_7_]] : index
-// CHECK-DAG:         [[VAR_9_:%.+]] = arith.index_cast [[VAR_arg10_]] : i32 to index
-// CHECK:             [[VAR_10_:%.+]] = arith.addi [[VAR_arg13_]], [[VAR_9_]] : index
-// CHECK:             scf.yield [[VAR_reinterpret_cast_0_]], [[VAR_8_]], [[VAR_10_]] : memref<1xf32, strided<[1], offset: ?>>, index, index
+// CHECK:             [[VAR_4_:%.+]] = arith.addi [[offset_]], [[VAR_3_]] : index
+// CHECK-DAG:         [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[base_buffer_]] to offset: {{.}}[[VAR_4_]]{{.}}, sizes: [1], strides: [1] : memref<f32> to memref<1xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_5_:%.+]] = arith.addi [[VAR_arg12_]], [[VAR_3_]] : index
+// CHECK-DAG:         [[VAR_6_:%.+]] = arith.addi [[VAR_arg13_]], [[VAR_3_]] : index
+// CHECK:             scf.yield [[VAR_reinterpret_cast_0_]], [[VAR_5_]], [[VAR_6_]] : memref<1xf32, strided<[1], offset: ?>>, index, index
 // CHECK:           }
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/StructuredToMemref/use_dot_opc.mlir
+++ b/test/Conversion/StructuredToMemref/use_dot_opc.mlir
@@ -50,7 +50,6 @@ module {
   }
 }
 
-// mlir2FileCheck.py
 // CHECK-LABEL:  func.func @kernel
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: memref<*xbf16>, [[PARAM_2_:%.+]]: memref<*xbf16>, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
 // CHECK-DAG:       [[CST_256_:%.+]] = arith.constant 256 : index
@@ -68,10 +67,8 @@ module {
 // CHECK:           memref.copy [[VAR_reinterpret_cast_0_]], [[RES_1_]] : memref<64x256xbf16, strided<[?, 1]>> to memref<64x256xbf16>
 // CHECK-DAG:       [[VAR_3_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<64x256xbf16>
 // CHECK-DAG:       [[VAR_reinterpret_cast_2_:%.+]] = memref.reinterpret_cast [[PARAM_2_]] to offset: [0], sizes: [128, 256], strides: {{.}}[[CST_256_]], 1] : memref<*xbf16> to memref<128x256xbf16, strided<[?, 1]>>
-// CHECK-DAG:       [[VAR_4_:%.+]] = tensor.empty() : tensor<128x256xbf16>
-// CHECK:           [[VAR_5_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : bf16) outs([[VAR_4_]] : tensor<128x256xbf16>) -> tensor<128x256xbf16>
-// CHECK:           [[VAR_6_:%.+]] = linalg.matmul ins([[VAR_2_]], [[VAR_3_]] : tensor<128x64xbf16>, tensor<64x256xbf16>) outs([[VAR_5_]] : tensor<128x256xbf16>) -> tensor<128x256xbf16>
-// CHECK:           bufferization.materialize_in_destination [[VAR_6_]] in writable [[VAR_reinterpret_cast_2_]] : (tensor<128x256xbf16>, memref<128x256xbf16, strided<[?, 1]>>) -> ()
+// CHECK:           [[VAR_4_:%.+]] = linalg.matmul ins([[VAR_2_]], [[VAR_3_]] : tensor<128x64xbf16>, tensor<64x256xbf16>) outs([[VAR_1_]] : tensor<128x256xbf16>) -> tensor<128x256xbf16>
+// CHECK:           bufferization.materialize_in_destination [[VAR_4_]] in writable [[VAR_reinterpret_cast_2_]] : (tensor<128x256xbf16>, memref<128x256xbf16, strided<[?, 1]>>) -> ()
 // CHECK:           bufferization.materialize_in_destination [[VAR_1_]] in writable [[VAR_reinterpret_cast_2_]] : (tensor<128x256xbf16>, memref<128x256xbf16, strided<[?, 1]>>) -> ()
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/StructuredToMemref/use_end_chain.mlir
+++ b/test/Conversion/StructuredToMemref/use_end_chain.mlir
@@ -33,7 +33,7 @@ module {
   tt.return
   }
 }
-// mlir2FileCheck.py
+
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
 // CHECK-DAG:   [[MAP_1_:#.+]] = affine_map<(d0, d1) -> (d0, 0)>
 // CHECK-DAG:   [[MAP_2_:#.+]] = affine_map<(d0, d1) -> (d0, d1)>
@@ -49,50 +49,48 @@ module {
 // CHECK-DAG:       [[VAR_2_:%.+]] = tensor.empty() : tensor<256xi32>
 // CHECK:           [[VAR_3_:%.+]] = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel"]} outs([[VAR_2_]] : tensor<256xi32>) {
 // CHECK:           ^bb0([[IN_0_:%.+]]: i32):
-// CHECK:             [[VAR_15_:%.+]] = linalg.index 0 : index
-// CHECK:             [[VAR_16_:%.+]] = arith.index_cast [[VAR_15_]] : index to i32
-// CHECK:             linalg.yield [[VAR_16_]] : i32
+// CHECK:             [[VAR_13_:%.+]] = linalg.index 0 : index
+// CHECK:             [[VAR_14_:%.+]] = arith.index_cast [[VAR_13_]] : index to i32
+// CHECK:             linalg.yield [[VAR_14_]] : i32
 // CHECK:           } -> tensor<256xi32>
-// CHECK-DAG:       [[VAR_expanded_:%.+]] = tensor.expand_shape [[VAR_3_]] {{.}}[0, 1]{{.}} : tensor<256xi32> into tensor<256x1xi32>
-// CHECK-DAG:       [[VAR_4_:%.+]] = tensor.empty() : tensor<256x128xi32>
-// CHECK:           [[VAR_5_:%.+]] = linalg.generic {indexing_maps = [#map1, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_]] : tensor<256x1xi32>) outs([[VAR_4_]] : tensor<256x128xi32>) attrs =  {broadcastDims = array<i64: 1>} {
+// CHECK:           [[VAR_expanded_:%.+]] = tensor.expand_shape [[VAR_3_]] {{.}}[0, 1]{{.}} : tensor<256xi32> into tensor<256x1xi32>
+// CHECK:           [[VAR_4_:%.+]] = linalg.generic {indexing_maps = [#map1, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_]] : tensor<256x1xi32>) outs([[VAR_0_]] : tensor<256x128xi32>) attrs =  {broadcastDims = array<i64: 1>} {
 // CHECK:           ^bb0([[IN_1_:%.+]]: i32, [[IN_2_:%.+]]: i32):
 // CHECK:             linalg.yield [[IN_1_]] : i32
 // CHECK:           } -> tensor<256x128xi32>
-// CHECK:           [[VAR_6_:%.+]] = tensor.empty() : tensor<128xi32>
-// CHECK:           [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel"]} outs([[VAR_6_]] : tensor<128xi32>) {
+// CHECK:           [[VAR_5_:%.+]] = tensor.empty() : tensor<128xi32>
+// CHECK:           [[VAR_6_:%.+]] = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel"]} outs([[VAR_5_]] : tensor<128xi32>) {
 // CHECK:           ^bb0([[IN_3_:%.+]]: i32):
-// CHECK:             [[VAR_15_1_:%.+]] = linalg.index 0 : index
-// CHECK:             [[VAR_16_1_:%.+]] = arith.index_cast [[VAR_15_1_]] : index to i32
-// CHECK:             linalg.yield [[VAR_16_1_]] : i32
+// CHECK:             [[VAR_13_1_:%.+]] = linalg.index 0 : index
+// CHECK:             [[VAR_14_1_:%.+]] = arith.index_cast [[VAR_13_1_]] : index to i32
+// CHECK:             linalg.yield [[VAR_14_1_]] : i32
 // CHECK:           } -> tensor<128xi32>
-// CHECK-DAG:       [[VAR_expanded_0_:%.+]] = tensor.expand_shape [[VAR_7_]] {{.}}[0, 1]{{.}} : tensor<128xi32> into tensor<1x128xi32>
-// CHECK-DAG:       [[VAR_8_:%.+]] = tensor.empty() : tensor<256x128xi32>
-// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map3, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_0_]] : tensor<1x128xi32>) outs([[VAR_8_]] : tensor<256x128xi32>) attrs =  {broadcastDims = array<i64: 0>} {
+// CHECK:           [[VAR_expanded_0_:%.+]] = tensor.expand_shape [[VAR_6_]] {{.}}[0, 1]{{.}} : tensor<128xi32> into tensor<1x128xi32>
+// CHECK:           [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map3, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_0_]] : tensor<1x128xi32>) outs([[VAR_0_]] : tensor<256x128xi32>) attrs =  {broadcastDims = array<i64: 0>} {
 // CHECK:           ^bb0([[IN_4_:%.+]]: i32, [[IN_5_:%.+]]: i32):
 // CHECK:             linalg.yield [[IN_4_]] : i32
 // CHECK:           } -> tensor<256x128xi32>
-// CHECK:           [[VAR_10_:%.+]] = linalg.generic {indexing_maps = [#map2, #map2, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_9_]], [[VAR_1_]] : tensor<256x128xi32>, tensor<256x128xi32>) outs([[VAR_9_]] : tensor<256x128xi32>) {
+// CHECK:           [[VAR_8_:%.+]] = linalg.generic {indexing_maps = [#map2, #map2, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_7_]], [[VAR_1_]] : tensor<256x128xi32>, tensor<256x128xi32>) outs([[VAR_7_]] : tensor<256x128xi32>) {
 // CHECK:           ^bb0([[IN_6_:%.+]]: i32, [[IN_7_:%.+]]: i32, [[IN_8_:%.+]]: i32):
-// CHECK:             [[VAR_15_2_:%.+]] = arith.muli [[IN_6_]], [[IN_7_]] : i32
-// CHECK:             linalg.yield [[VAR_15_2_]] : i32
+// CHECK:             [[VAR_13_2_:%.+]] = arith.muli [[IN_6_]], [[IN_7_]] : i32
+// CHECK:             linalg.yield [[VAR_13_2_]] : i32
 // CHECK:           } -> tensor<256x128xi32>
-// CHECK:           [[VAR_11_:%.+]] = linalg.generic {indexing_maps = [#map2, #map2, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_5_]], [[VAR_10_]] : tensor<256x128xi32>, tensor<256x128xi32>) outs([[VAR_5_]] : tensor<256x128xi32>) {
+// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map2, #map2, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_4_]], [[VAR_8_]] : tensor<256x128xi32>, tensor<256x128xi32>) outs([[VAR_4_]] : tensor<256x128xi32>) {
 // CHECK:           ^bb0([[IN_9_:%.+]]: i32, [[IN_10_:%.+]]: i32, [[IN_11_:%.+]]: i32):
-// CHECK:             [[VAR_15_3_:%.+]] = arith.addi [[IN_9_]], [[IN_10_]] : i32
-// CHECK:             linalg.yield [[VAR_15_3_]] : i32
+// CHECK:             [[VAR_13_3_:%.+]] = arith.addi [[IN_9_]], [[IN_10_]] : i32
+// CHECK:             linalg.yield [[VAR_13_3_]] : i32
 // CHECK:           } -> tensor<256x128xi32>
 // CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[CST_6656_]]{{.}}, sizes: [256, 128], strides: [1, [[CST_6_]]{{.}} : memref<*xbf16> to memref<256x128xbf16, strided<[1, ?], offset: ?>>
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<256x128xbf16>
 // CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<256x128xbf16, strided<[1, ?], offset: ?>> to memref<256x128xbf16>
-// CHECK:           [[VAR_12_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<256x128xbf16>
-// CHECK:           bufferization.materialize_in_destination [[VAR_12_]] in writable [[VAR_reinterpret_cast_]] : (tensor<256x128xbf16>, memref<256x128xbf16, strided<[1, ?], offset: ?>>) -> ()
-// CHECK:           [[VAR_13_:%.+]] = tensor.empty() : tensor<256x128xbf16>
-// CHECK:           [[VAR_14_:%.+]] = linalg.generic {indexing_maps = [#map2, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_11_]] : tensor<256x128xi32>) outs([[VAR_13_]] : tensor<256x128xbf16>) {
+// CHECK:           [[VAR_10_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<256x128xbf16>
+// CHECK:           bufferization.materialize_in_destination [[VAR_10_]] in writable [[VAR_reinterpret_cast_]] : (tensor<256x128xbf16>, memref<256x128xbf16, strided<[1, ?], offset: ?>>) -> ()
+// CHECK:           [[VAR_11_:%.+]] = tensor.empty() : tensor<256x128xbf16>
+// CHECK:           [[VAR_12_:%.+]] = linalg.generic {indexing_maps = [#map2, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_9_]] : tensor<256x128xi32>) outs([[VAR_11_]] : tensor<256x128xbf16>) {
 // CHECK:           ^bb0([[IN_12_:%.+]]: i32, [[IN_13_:%.+]]: bf16):
-// CHECK:             [[VAR_15_4_:%.+]] = arith.sitofp [[IN_12_]] : i32 to bf16
-// CHECK:             linalg.yield [[VAR_15_4_]] : bf16
+// CHECK:             [[VAR_13_4_:%.+]] = arith.sitofp [[IN_12_]] : i32 to bf16
+// CHECK:             linalg.yield [[VAR_13_4_]] : bf16
 // CHECK:           } -> tensor<256x128xbf16>
-// CHECK:           bufferization.materialize_in_destination [[VAR_14_]] in writable [[VAR_reinterpret_cast_]] : (tensor<256x128xbf16>, memref<256x128xbf16, strided<[1, ?], offset: ?>>) -> ()
+// CHECK:           bufferization.materialize_in_destination [[VAR_12_]] in writable [[VAR_reinterpret_cast_]] : (tensor<256x128xbf16>, memref<256x128xbf16, strided<[1, ?], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/StructuredToMemref/wraparound_stacked.mlir
+++ b/test/Conversion/StructuredToMemref/wraparound_stacked.mlir
@@ -52,7 +52,6 @@ module {
   }
 }
 
-// mlir2FileCheck.py
 // CHECK-LABEL:  func.func @wrap_stacked_masked_loop_01234567
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32, [[PARAM_10_:%.+]]: i32, [[PARAM_11_:%.+]]: i32, [[PARAM_12_:%.+]]: i32, [[PARAM_13_:%.+]]: i32) {
 // CHECK-DAG:       [[CST_4_:%.+]] = arith.constant 4 : index
@@ -77,34 +76,33 @@ module {
 // CHECK-DAG:       [[VAR_8_:%.+]] = arith.muli [[PARAM_5_]], [[CST_4_1_]] : i32
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_9_:%.+]] = arith.index_cast [[VAR_8_]] : i32 to index
-// CHECK-DAG:       [[VAR_10_:%.+]] = arith.index_cast [[VAR_8_]] : i32 to index
-// CHECK-DAG:       [[VAR_11_:%.+]]:2 = scf.for [[VAR_arg14_:%.+]] = [[CST_0_]] to [[CST_2_]] step [[CST_1_]] iter_args([[VAR_arg15_:%.+]] = [[VAR_2_]], [[VAR_arg16_:%.+]] = [[CST_0_1_]]) -> (index, index)  : i32 {
+// CHECK-DAG:       [[VAR_10_:%.+]]:2 = scf.for [[VAR_arg14_:%.+]] = [[CST_0_]] to [[CST_2_]] step [[CST_1_]] iter_args([[VAR_arg15_:%.+]] = [[VAR_2_]], [[VAR_arg16_:%.+]] = [[CST_0_1_]]) -> (index, index)  : i32 {
 // CHECK-DAG:         [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_arg16_]]{{.}}, sizes: [4, 4], strides: {{.}}[[VAR_6_]], [[VAR_7_]]{{.}} : memref<*xf32> to memref<4x4xf32, strided<[?, ?], offset: ?>>
-// CHECK-DAG:         [[VAR_12_:%.+]] = arith.addi [[VAR_arg15_]], [[VAR_5_]] : index
-// CHECK:             [[VAR_13_:%.+]] = arith.remsi [[VAR_12_]], [[VAR_1_]] : index
-// CHECK:             [[VAR_14_:%.+]] = arith.addi [[VAR_3_]], [[VAR_13_]] : index
-// CHECK:             [[VAR_15_:%.+]] = arith.subi [[VAR_14_]], [[VAR_12_]] : index
-// CHECK:             [[VAR_16_:%.+]] = arith.divsi [[VAR_15_]], [[VAR_1_]] : index
-// CHECK-DAG:         [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_12_]]{{.}}, sizes: {{.}}[[VAR_16_]], [[CST_4_]]{{.}}, strides: {{.}}[[VAR_1_]], [[VAR_4_]]{{.}} : memref<*xf32> to memref<?x4xf32, strided<[?, ?], offset: ?>>
-// CHECK-DAG:         [[VAR_17_:%.+]] = arith.subi [[CST_4_]], [[VAR_16_]] : index
+// CHECK-DAG:         [[VAR_11_:%.+]] = arith.addi [[VAR_arg15_]], [[VAR_5_]] : index
+// CHECK:             [[VAR_12_:%.+]] = arith.remsi [[VAR_11_]], [[VAR_1_]] : index
+// CHECK:             [[VAR_13_:%.+]] = arith.addi [[VAR_3_]], [[VAR_12_]] : index
+// CHECK:             [[VAR_14_:%.+]] = arith.subi [[VAR_13_]], [[VAR_11_]] : index
+// CHECK:             [[VAR_15_:%.+]] = arith.divsi [[VAR_14_]], [[VAR_1_]] : index
+// CHECK-DAG:         [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_11_]]{{.}}, sizes: {{.}}[[VAR_15_]], [[CST_4_]]{{.}}, strides: {{.}}[[VAR_1_]], [[VAR_4_]]{{.}} : memref<*xf32> to memref<?x4xf32, strided<[?, ?], offset: ?>>
+// CHECK-DAG:         [[VAR_16_:%.+]] = arith.subi [[CST_4_]], [[VAR_15_]] : index
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_13_]]{{.}}, sizes: {{.}}[[VAR_17_]], [[CST_4_]]{{.}}, strides: {{.}}[[VAR_1_]], [[VAR_4_]]{{.}} : memref<*xf32> to memref<?x4xf32, strided<[?, ?], offset: ?>>
+// CHECK-DAG:         [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_12_]]{{.}}, sizes: {{.}}[[VAR_16_]], [[CST_4_]]{{.}}, strides: {{.}}[[VAR_1_]], [[VAR_4_]]{{.}} : memref<*xf32> to memref<?x4xf32, strided<[?, ?], offset: ?>>
 // CHECK-DAG:         [[RES_:%.+]] = memref.alloc() : memref<4x4xf32>
 // CHECK:             linalg.fill ins([[CST_minus_9_dot_900000_]] : f32) outs([[RES_]] : memref<4x4xf32>)
-// CHECK:             [[VAR_18_:%.+]] = arith.minsi [[VAR_16_]], [[CST_4_]] : index
-// CHECK-DAG:         [[VAR_19_:%.+]] = arith.subi [[CST_4_]], [[VAR_18_]] : index
-// CHECK-DAG:         [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_0_]][0, 0] {{.}}[[VAR_18_]], 3] [1, 1] : memref<?x4xf32, strided<[?, ?], offset: ?>> to memref<?x3xf32, strided<[?, ?], offset: ?>>
+// CHECK:             [[VAR_17_:%.+]] = arith.minsi [[VAR_15_]], [[CST_4_]] : index
+// CHECK-DAG:         [[VAR_18_:%.+]] = arith.subi [[CST_4_]], [[VAR_17_]] : index
+// CHECK-DAG:         [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_0_]][0, 0] {{.}}[[VAR_17_]], 3] [1, 1] : memref<?x4xf32, strided<[?, ?], offset: ?>> to memref<?x3xf32, strided<[?, ?], offset: ?>>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_subview_2_:%.+]] = memref.subview [[VAR_reinterpret_cast_1_]][0, 0] {{.}}[[VAR_19_]], 3] [1, 1] : memref<?x4xf32, strided<[?, ?], offset: ?>> to memref<?x3xf32, strided<[?, ?], offset: ?>>
-// CHECK-DAG:         [[VAR_subview_3_:%.+]] = memref.subview [[RES_]][0, 0] {{.}}[[VAR_18_]], 3] [1, 1] : memref<4x4xf32> to memref<?x3xf32, strided<[4, 1]>>
-// CHECK-DAG:         [[VAR_subview_4_:%.+]] = memref.subview [[RES_]]{{.}}[[VAR_18_]], 0] {{.}}[[VAR_19_]], 3] [1, 1] : memref<4x4xf32> to memref<?x3xf32, strided<[4, 1], offset: ?>>
+// CHECK-DAG:         [[VAR_subview_2_:%.+]] = memref.subview [[VAR_reinterpret_cast_1_]][0, 0] {{.}}[[VAR_18_]], 3] [1, 1] : memref<?x4xf32, strided<[?, ?], offset: ?>> to memref<?x3xf32, strided<[?, ?], offset: ?>>
+// CHECK-DAG:         [[VAR_subview_3_:%.+]] = memref.subview [[RES_]][0, 0] {{.}}[[VAR_17_]], 3] [1, 1] : memref<4x4xf32> to memref<?x3xf32, strided<[4, 1]>>
+// CHECK-DAG:         [[VAR_subview_4_:%.+]] = memref.subview [[RES_]]{{.}}[[VAR_17_]], 0] {{.}}[[VAR_18_]], 3] [1, 1] : memref<4x4xf32> to memref<?x3xf32, strided<[4, 1], offset: ?>>
 // CHECK:             memref.copy [[VAR_subview_]], [[VAR_subview_3_]] : memref<?x3xf32, strided<[?, ?], offset: ?>> to memref<?x3xf32, strided<[4, 1]>>
 // CHECK:             memref.copy [[VAR_subview_2_]], [[VAR_subview_4_]] : memref<?x3xf32, strided<[?, ?], offset: ?>> to memref<?x3xf32, strided<[4, 1], offset: ?>>
-// CHECK:             [[VAR_20_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<4x4xf32>
-// CHECK:             bufferization.materialize_in_destination [[VAR_20_]] in writable [[VAR_reinterpret_cast_]] : (tensor<4x4xf32>, memref<4x4xf32, strided<[?, ?], offset: ?>>) -> ()
-// CHECK-DAG:         [[VAR_21_:%.+]] = arith.addi [[VAR_arg15_]], [[VAR_10_]] : index
-// CHECK-DAG:         [[VAR_22_:%.+]] = arith.addi [[VAR_arg16_]], [[VAR_9_]] : index
-// CHECK:             scf.yield [[VAR_21_]], [[VAR_22_]] : index, index
+// CHECK:             [[VAR_19_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<4x4xf32>
+// CHECK:             bufferization.materialize_in_destination [[VAR_19_]] in writable [[VAR_reinterpret_cast_]] : (tensor<4x4xf32>, memref<4x4xf32, strided<[?, ?], offset: ?>>) -> ()
+// CHECK-DAG:         [[VAR_20_:%.+]] = arith.addi [[VAR_arg15_]], [[VAR_9_]] : index
+// CHECK-DAG:         [[VAR_21_:%.+]] = arith.addi [[VAR_arg16_]], [[VAR_9_]] : index
+// CHECK:             scf.yield [[VAR_20_]], [[VAR_21_]] : index, index
 // CHECK:           }
 // CHECK:           return
 // CHECK:         }


### PR DESCRIPTION
This PR fixes missing build dependencies when using `triton-to-linalg-experimental` that was exposed when integrating internally. Also place CSE and canonicalization in strategic places to make the resulting IRs cleaner.