### PR TITLE
Use structured data class for CPU backend target

### DIFF
--- a/backend/compiler.py
+++ b/backend/compiler.py
@@ -1,4 +1,4 @@
-from triton.backends.compiler import BaseBackend
+from triton.backends.compiler import BaseBackend, GPUTarget
 from triton._C.libtriton import ir, passes
 from dataclasses import dataclass
 from typing import Any, Tuple
@@ -134,14 +134,14 @@ class CPUBackend(BaseBackend):
     binary_ext = 'cpuasm'
 
     @staticmethod
-    def supports_target(target: str):
-        return target == 'cpu'
+    def supports_target(target: GPUTarget):
+        return target.backend == 'cpu'
 
-    def __init__(self, target: tuple) -> None:
+    def __init__(self, target: GPUTarget) -> None:
         super().__init__(target)
 
     def parse_options(self, opts) -> Any:
-        args = {'arch': self.target}
+        args = {'arch': self.target.arch}
         args.update({k: opts[k] for k in CPUOptions.__dataclass_fields__.keys() if k in opts})
         return CPUOptions(**args)
 

--- a/backend/driver.py
+++ b/backend/driver.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 from triton.runtime.cache import get_cache_manager
 from triton.backends.driver import DriverBase
-
+from triton.backends.compiler import GPUTarget
 
 # -------------------- Launcher ----------------------------
 def _ty_to_cpp(ty):
@@ -353,7 +353,7 @@ class CPUDriver(DriverBase):
         return
 
     def get_current_target(self):
-        return "cpu"
+        return GPUTarget("cpu", 0, 0)
 
     def assemble_tensormap_to_arg(self, tensormaps_info, args):
         return args

--- a/python/examples/test_reduce.py
+++ b/python/examples/test_reduce.py
@@ -1,6 +1,7 @@
 import torch
 
 import triton
+from triton.backends.compiler import GPUTarget
 from triton.backends.triton_shared.driver import CPUDriver
 import triton.language as tl
 
@@ -51,7 +52,7 @@ def test():
     )
     ret = triton.compile(
         src,
-        target="cpu"
+        target=GPUTarget("cpu", 0, 0)
     )
     print(ret.asm["ttir"])
     print(ret.asm["ttsharedir"])


### PR DESCRIPTION
Update the sample CPU backend to use structured data class (`GPUTarget`) following https://github.com/openai/triton/commit/5162346487b3e3ebc062d9697429bafad25f22f6.

Fixes #130 