### PR TITLE
Update triton

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "triton"]
 	path = triton
-	url = git@github.com:openai/triton.git
+	url = git@github.com:triton-lang/triton.git

--- a/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
+++ b/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
@@ -365,10 +365,9 @@ public:
           auto block1 = memrefs[0];
           auto block2 = memrefs[1];
 
-          if (wrapType.getValue().equals(ModuloState::WraparoundSideBySide)) {
+          if (wrapType.getValue() == ModuloState::WraparoundSideBySide) {
             createSideBySideCopies(block1, block2, alloc, loc, rewriter);
-          } else if (wrapType.getValue().equals(
-                         ModuloState::WraparoundStacked)) {
+          } else if (wrapType.getValue() == ModuloState::WraparoundStacked) {
             createStackedCopies(block1, block2, alloc, loc, rewriter);
           } else {
             llvm_unreachable("unexpected wraparound type");
@@ -445,12 +444,12 @@ public:
         auto block1 = memrefs[0];
         auto block2 = memrefs[1];
 
-        if (wrapType.getValue().equals(ModuloState::WraparoundSideBySide)) {
+        if (wrapType.getValue() == ModuloState::WraparoundSideBySide) {
           auto [subview1, subview2] =
               mstate.getSideBySideSubviews(block1, block2, loc, rewriter);
 
           createSideBySideCopies(subview1, subview2, alloc, loc, rewriter);
-        } else if (wrapType.getValue().equals(ModuloState::WraparoundStacked)) {
+        } else if (wrapType.getValue() == ModuloState::WraparoundStacked) {
           auto [subview1, subview2] =
               mstate.getStackedSubviews(block1, block2, loc, rewriter);
 

--- a/include/triton-shared/Dialect/TritonTilingExt/IR/TritonTilingExtOps.td
+++ b/include/triton-shared/Dialect/TritonTilingExt/IR/TritonTilingExtOps.td
@@ -224,7 +224,7 @@ def TritonTilingExt_CumSumOp : TritonTilingExt_TilingOp<"cumsum"> {
 
   let extraClassDeclaration = baseClassDecls # [{
     int64_t getRank() {
-      return getInput().getType().cast<ShapedType>().getRank();
+      return cast<ShapedType>(getInput().getType()).getRank();
     }
 
     Value getInput() {

--- a/lib/Analysis/OpFoldResultUtils.cpp
+++ b/lib/Analysis/OpFoldResultUtils.cpp
@@ -94,7 +94,7 @@ OpFoldResult addOFRs(const OpFoldResult lhs, const OpFoldResult rhs,
     assert(isa<IndexType>(lhsValue.getType()));
   }
 
-  auto rhsValue dyn_cast<Value>(= rhs);
+  auto rhsValue = dyn_cast<Value>(rhs);
   if (rhsIntAttr) {
     auto rhsOp =
         b.create<arith::ConstantOp>(loc, b.getIndexAttr(rhsIntAttr.value()));

--- a/lib/Analysis/OpFoldResultUtils.cpp
+++ b/lib/Analysis/OpFoldResultUtils.cpp
@@ -14,8 +14,8 @@
 namespace mlir {
 
 std::optional<int64_t> getIntAttr(const OpFoldResult ofr) {
-  if (ofr.is<Attribute>() && ofr.get<Attribute>().isa<IntegerAttr>())
-    return ofr.get<Attribute>().dyn_cast<IntegerAttr>().getInt();
+  if (ofr.is<Attribute>() && isa<IntegerAttr>(ofr.get<Attribute>()))
+    return dyn_cast<IntegerAttr>(ofr.get<Attribute>()).getInt();
 
   return std::nullopt;
 }
@@ -29,7 +29,7 @@ bool hasConstZero(const OpFoldResult ofr) {
     return false;
   }
 
-  auto val = ofr.dyn_cast<Value>();
+  auto val = dyn_cast<Value>(ofr);
   assert(val);
   auto constOp = val.getDefiningOp<arith::ConstantOp>();
   if (!constOp)
@@ -48,7 +48,7 @@ bool hasConstZero(const OpFoldResult ofr) {
 
 Value ofrToIndexValue(const OpFoldResult ofr, const Location loc,
                       OpBuilder &b) {
-  if (Value val = ofr.dyn_cast<Value>()) {
+  if (Value val = dyn_cast<Value>(ofr)) {
     assert(val.getType().isIndex() && "Provided ofr is of type index");
     return val;
   }
@@ -85,22 +85,22 @@ OpFoldResult addOFRs(const OpFoldResult lhs, const OpFoldResult rhs,
     return b.getIndexAttr(lhsIntAttr.value() + rhsIntAttr.value());
 
   // otherwise, need to create instructions to calculate new attribute value
-  auto lhsValue = lhs.dyn_cast<Value>();
+  auto lhsValue = dyn_cast<Value>(lhs);
   if (lhsIntAttr) {
     auto lhsOp =
         b.create<arith::ConstantOp>(loc, b.getIndexAttr(lhsIntAttr.value()));
     lhsValue = lhsOp.getResult();
   } else {
-    assert(lhsValue.getType().isa<IndexType>());
+    assert(isa<IndexType>(lhsValue.getType()));
   }
 
-  auto rhsValue = rhs.dyn_cast<Value>();
+  auto rhsValue dyn_cast<Value>(= rhs);
   if (rhsIntAttr) {
     auto rhsOp =
         b.create<arith::ConstantOp>(loc, b.getIndexAttr(rhsIntAttr.value()));
     rhsValue = rhsOp.getResult();
   } else {
-    assert(lhsValue.getType().isa<IndexType>());
+    assert(isa<IndexType>(lhsValue.getType()));
   }
 
   return b.create<arith::AddIOp>(loc, lhsValue, rhsValue).getResult();
@@ -120,14 +120,14 @@ OpFoldResult subOFRs(const OpFoldResult lhs, const OpFoldResult rhs,
     return b.getIndexAttr(lhsIntAttr.value() - rhsIntAttr.value());
 
   // otherwise, need to create instructions to calculate new attribute value
-  auto lhsValue = lhs.dyn_cast<Value>();
+  auto lhsValue = dyn_cast<Value>(lhs);
   if (lhsIntAttr) {
     auto lhsOp =
         b.create<arith::ConstantOp>(loc, b.getIndexAttr(lhsIntAttr.value()));
     lhsValue = lhsOp.getResult();
   }
 
-  auto rhsValue = rhs.dyn_cast<Value>();
+  auto rhsValue = dyn_cast<Value>(rhs);
   if (rhsIntAttr) {
     auto rhsOp =
         b.create<arith::ConstantOp>(loc, b.getIndexAttr(rhsIntAttr.value()));
@@ -149,7 +149,7 @@ OpFoldResult mulOFRValue(const OpFoldResult lhs, const Value rhs,
   auto rhsOp = rhs.getDefiningOp<arith::ConstantOp>();
   if (rhsOp) {
     rhsIsConst = true;
-    rhsConstValue = rhsOp.getValue().cast<IntegerAttr>().getInt();
+    rhsConstValue = cast<IntegerAttr>(rhsOp.getValue()).getInt();
   }
 
   // shortcuts for special cases
@@ -194,14 +194,14 @@ OpFoldResult minOFRs(const OpFoldResult lhs, const OpFoldResult rhs,
     return b.getIndexAttr(std::min(lhsIntAttr.value(), rhsIntAttr.value()));
 
   // otherwise, need to create instructions to calculate new attribute value
-  auto lhsValue = lhs.dyn_cast<Value>();
+  auto lhsValue = dyn_cast<Value>(lhs);
   if (lhsIntAttr) {
     auto lhsOp =
         b.create<arith::ConstantOp>(loc, b.getIndexAttr(lhsIntAttr.value()));
     lhsValue = lhsOp.getResult();
   }
 
-  auto rhsValue = rhs.dyn_cast<Value>();
+  auto rhsValue = dyn_cast<Value>(rhs);
   if (rhsIntAttr) {
     auto rhsOp =
         b.create<arith::ConstantOp>(loc, b.getIndexAttr(rhsIntAttr.value()));

--- a/lib/Analysis/PtrAnalysis.cpp
+++ b/lib/Analysis/PtrAnalysis.cpp
@@ -654,7 +654,7 @@ void PtrAnalysis::visitOperand(
     return;
   }
 
-  if (isa<triton::operand.getType() PointerType>()) {
+  if (isa<triton::PointerType>(operand.getType())) {
     auto remappedPtr = rewriter.getRemappedValue(operand);
     assert(remappedPtr);
 

--- a/lib/Analysis/UseAnalysis.cpp
+++ b/lib/Analysis/UseAnalysis.cpp
@@ -33,7 +33,7 @@ void triton::UseAnalysis::visitOperation(Operation *op,
   // yielded. In this case, if the loop returns data tensors, addptr will be
   // marked correctly as meta use.
   if (op->getResults().size() == 1) {
-    auto resultType = op->getResult(0).getType().dyn_cast<ShapedType>();
+    auto resultType = dyn_cast<ShapedType>(op->getResult(0).getType());
     if (resultType && isa<triton::PointerType>(resultType.getElementType())) {
       for (auto opnd : operands)
         propagateUse(opnd, UseType::MetaUse);
@@ -122,7 +122,7 @@ LogicalResult triton::runUseAnalysis(triton::FuncOp &funcOp) {
       assert(op->getNumResults() == 1 &&
              "Ops used for meta computation are expected to have one result");
       // Only set the tag if the operation uses tensors
-      if (op->getResult(0).getType().isa<ShapedType>()) {
+      if (isa<ShapedType>(op->getResult(0).getType())) {
         // Setting tag for erasing op later
         op->setAttr("MetaUse", UnitAttr::get(context));
       }
@@ -137,7 +137,7 @@ LogicalResult triton::runUseAnalysis(triton::FuncOp &funcOp) {
     // If the operation only produces scalars, no need to clone it
     bool shapedResult = true;
     for (auto result : op->getResults())
-      shapedResult &= result.getType().isa<ShapedType>();
+      shapedResult &= isa<ShapedType>(result.getType());
     if (!shapedResult) {
       LLVM_DEBUG({ op->setAttr("MixUse", UnitAttr::get(context)); });
       return;

--- a/lib/Conversion/StructuredToMemref/StructuredToMemref.cpp
+++ b/lib/Conversion/StructuredToMemref/StructuredToMemref.cpp
@@ -624,7 +624,7 @@ private:
         auto shapei = rewriter.create<arith::ConstantOp>(
             loc, rewriter.getIndexAttr(shape[i]));
 
-        Value dimi = mixedDims[i].dyn_cast<Value>();
+        Value dimi = dyn_cast<Value>(mixedDims[i]);
         if (!dimi) {
           dimi = rewriter.create<arith::ConstantOp>(
               loc, rewriter.getIndexAttr(op.getStaticMaskDims()[i]));
@@ -698,7 +698,7 @@ private:
   static tensor::ExtractSliceOp
   getExtractSlice(int rank, ArrayRef<OpFoldResult> dims, Value source,
                   const Location loc, OpBuilder &b) {
-    auto sourceType = source.getType().cast<RankedTensorType>();
+    auto sourceType = cast<RankedTensorType>(source.getType());
     SmallVector<OpFoldResult> offsets(rank, b.getIndexAttr(0));
     SmallVector<OpFoldResult> strides(rank, b.getIndexAttr(1));
 

--- a/lib/Conversion/TritonArithToLinalg/TritonArithToLinalgPass.cpp
+++ b/lib/Conversion/TritonArithToLinalg/TritonArithToLinalgPass.cpp
@@ -126,7 +126,7 @@ public:
 
           bool operateOnTensors =
               llvm::all_of(op->getOperandTypes(), [](Type type) {
-                return type.isa<RankedTensorType>();
+                return isa<RankedTensorType>(type);
               });
 
           return !operateOnTensors;
@@ -138,7 +138,7 @@ public:
 
     if (addptrToLinalg) {
       target.addDynamicallyLegalOp<triton::AddPtrOp>([](triton::AddPtrOp op) {
-        return !op.getResult().getType().isa<ShapedType>();
+        return !isa<ShapedType>(op.getResult().getType());
       });
     }
 

--- a/lib/Conversion/TritonToLinalg/TritonToLinalgPass.cpp
+++ b/lib/Conversion/TritonToLinalg/TritonToLinalgPass.cpp
@@ -41,7 +41,7 @@ public:
     });
     addConversion([](TensorType tensorType) -> Type {
       auto elemType = tensorType.getElementType();
-      if (auto ptrType = elemType.dyn_cast<triton::PointerType>()) {
+      if (auto ptrType = dyn_cast<triton::PointerType>(elemType)) {
         elemType = ptrType.getPointeeType();
       }
       return MemRefType::get(tensorType.getShape(), elemType);
@@ -169,7 +169,7 @@ public:
 
           bool operateOnTensors =
               llvm::all_of(op->getOperandTypes(), [](Type type) {
-                return type.isa<RankedTensorType>();
+                return isa<RankedTensorType>(type);
               });
 
           return !operateOnTensors;

--- a/lib/Dialect/TritonTilingExt/IR/CumSum.cpp
+++ b/lib/Dialect/TritonTilingExt/IR/CumSum.cpp
@@ -43,19 +43,19 @@ void ttx::CumSumOp::build(OpBuilder &odsBuilder, OperationState &odsState,
 
 mlir::LogicalResult ttx::CumSumOp::verify() {
   auto inputType = getInput().getType();
-  if (!inputType.isa<RankedTensorType>() && !inputType.isa<MemRefType>()) {
+  if (!isa<RankedTensorType>(inputType) && !isa<MemRefType>(inputType)) {
     return emitOpError(
         "CumSum op expects input to be either tensor or memref.");
   }
 
   auto outputType = getOutput().getType();
-  if (!outputType.isa<RankedTensorType>() && !outputType.isa<MemRefType>()) {
+  if (!isa<RankedTensorType>(outputType) && !isa<MemRefType>(outputType)) {
     return emitOpError(
         "CumSum op expects output to be either tensor or memref.");
   }
 
-  if (inputType.dyn_cast<ShapedType>().getShape() !=
-      outputType.dyn_cast<ShapedType>().getShape()) {
+  if (dyn_cast<ShapedType>(inputType).getShape() !=
+      dyn_cast<ShapedType>(outputType).getShape()) {
     return emitOpError("Input and output types must be the same.");
   }
 

--- a/lib/Dialect/TritonTilingExt/IR/TritonTilingExtDialect.cpp
+++ b/lib/Dialect/TritonTilingExt/IR/TritonTilingExtDialect.cpp
@@ -154,7 +154,7 @@ FailureOr<TilingResult> getTiledImplementation(TritonTilingExtOpTy op,
   for (OpOperand &opOperand : op->getOpOperands()) {
     unsigned int index = opOperand.getOperandNumber();
     auto val = valuesToTile[index];
-    auto type = val.getType().dyn_cast<ShapedType>();
+    auto type = dyn_cast<ShapedType>(val.getType());
 
     if (!type) {
       tiledValues.push_back(val);
@@ -226,7 +226,7 @@ LogicalResult getResultTilePosition(TritonTilingExtOpTy op, OpBuilder &b,
       op.getOutputIndexingMap(b.getContext(), resultNumber, sizes);
 
   Value result = op.getDpsInitOperand(resultNumber)->get();
-  auto rank = result.getType().dyn_cast<ShapedType>().getRank();
+  auto rank = dyn_cast<ShapedType>(result.getType()).getRank();
 
   llvm::SmallVector<mlir::OpFoldResult> composedTileSizes =
       linalg::computeTileSizes(b, loc, sizes, {});

--- a/python/examples/test_layernorm.py
+++ b/python/examples/test_layernorm.py
@@ -1,5 +1,5 @@
 # This is the Layer Norm forward pass from the Triton tutorial found here:
-# https://github.com/openai/triton/blob/main/python/tutorials/05-layer-norm.py
+# https://github.com/triton-lang/triton/blob/main/python/tutorials/05-layer-norm.py
 
 # %%
 # Motivations

--- a/test/Conversion/StructuredToMemref/convert_argmin_argmax_2d.mlir
+++ b/test/Conversion/StructuredToMemref/convert_argmin_argmax_2d.mlir
@@ -66,7 +66,7 @@ module {
 // CHECK:             [[VAR_12_:%.+]] = arith.index_cast [[VAR_11_]] : index to i32
 // CHECK:             linalg.yield [[VAR_12_]] : i32
 // CHECK:           } -> tensor<4xi32>
-// CHECK-DAG:       [[VAR_expanded_:%.+]] = tensor.expand_shape [[VAR_1_]] {{.}}[0, 1]{{.}} : tensor<4xi32> into tensor<1x4xi32>
+// CHECK-DAG:       [[VAR_expanded_:%.+]] = tensor.expand_shape [[VAR_1_]] {{.}}[0, 1]{{.}} output_shape [1, 4] : tensor<4xi32> into tensor<1x4xi32>
 // CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
 // CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
 // CHECK-NOT: separator of consecutive DAGs
@@ -173,7 +173,7 @@ module {
 // CHECK:             [[VAR_12_:%.+]] = arith.index_cast [[VAR_11_]] : index to i32
 // CHECK:             linalg.yield [[VAR_12_]] : i32
 // CHECK:           } -> tensor<4xi32>
-// CHECK-DAG:       [[VAR_expanded_:%.+]] = tensor.expand_shape [[VAR_1_]] {{.}}[0, 1]{{.}} : tensor<4xi32> into tensor<1x4xi32>
+// CHECK-DAG:       [[VAR_expanded_:%.+]] = tensor.expand_shape [[VAR_1_]] {{.}}[0, 1]{{.}} output_shape [1, 4] : tensor<4xi32> into tensor<1x4xi32>
 // CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
 // CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
 // CHECK-NOT: separator of consecutive DAGs

--- a/test/Conversion/StructuredToMemref/use_end_chain.mlir
+++ b/test/Conversion/StructuredToMemref/use_end_chain.mlir
@@ -53,7 +53,7 @@ module {
 // CHECK:             [[VAR_14_:%.+]] = arith.index_cast [[VAR_13_]] : index to i32
 // CHECK:             linalg.yield [[VAR_14_]] : i32
 // CHECK:           } -> tensor<256xi32>
-// CHECK:           [[VAR_expanded_:%.+]] = tensor.expand_shape [[VAR_3_]] {{.}}[0, 1]{{.}} : tensor<256xi32> into tensor<256x1xi32>
+// CHECK:           [[VAR_expanded_:%.+]] = tensor.expand_shape [[VAR_3_]] {{.}}[0, 1]{{.}} output_shape [256, 1] : tensor<256xi32> into tensor<256x1xi32>
 // CHECK:           [[VAR_4_:%.+]] = linalg.generic {indexing_maps = [#map1, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_]] : tensor<256x1xi32>) outs([[VAR_0_]] : tensor<256x128xi32>) attrs =  {broadcastDims = array<i64: 1>} {
 // CHECK:           ^bb0([[IN_1_:%.+]]: i32, [[IN_2_:%.+]]: i32):
 // CHECK:             linalg.yield [[IN_1_]] : i32
@@ -65,7 +65,7 @@ module {
 // CHECK:             [[VAR_14_1_:%.+]] = arith.index_cast [[VAR_13_1_]] : index to i32
 // CHECK:             linalg.yield [[VAR_14_1_]] : i32
 // CHECK:           } -> tensor<128xi32>
-// CHECK:           [[VAR_expanded_0_:%.+]] = tensor.expand_shape [[VAR_6_]] {{.}}[0, 1]{{.}} : tensor<128xi32> into tensor<1x128xi32>
+// CHECK:           [[VAR_expanded_0_:%.+]] = tensor.expand_shape [[VAR_6_]] {{.}}[0, 1]{{.}} output_shape [1, 128] : tensor<128xi32> into tensor<1x128xi32>
 // CHECK:           [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map3, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_0_]] : tensor<1x128xi32>) outs([[VAR_0_]] : tensor<256x128xi32>) attrs =  {broadcastDims = array<i64: 0>} {
 // CHECK:           ^bb0([[IN_4_:%.+]]: i32, [[IN_5_:%.+]]: i32):
 // CHECK:             linalg.yield [[IN_4_]] : i32

--- a/test/Conversion/StructuredToMemref/use_mid_chain.mlir
+++ b/test/Conversion/StructuredToMemref/use_mid_chain.mlir
@@ -50,7 +50,7 @@ module {
 // CHECK:             [[VAR_6_:%.+]] = arith.index_cast [[VAR_5_]] : index to i32
 // CHECK:             linalg.yield [[VAR_6_]] : i32
 // CHECK:           } -> tensor<256xi32>
-// CHECK-DAG:       [[VAR_expanded_:%.+]] = tensor.expand_shape [[VAR_1_]] {{.}}[0, 1]{{.}} : tensor<256xi32> into tensor<256x1xi32>
+// CHECK-DAG:       [[VAR_expanded_:%.+]] = tensor.expand_shape [[VAR_1_]] {{.}}[0, 1]{{.}} output_shape [256, 1] : tensor<256xi32> into tensor<256x1xi32>
 // CHECK-DAG:       [[VAR_2_:%.+]] = tensor.empty() : tensor<256x128xi32>
 // CHECK:           [[VAR_3_:%.+]] = linalg.generic {indexing_maps = [#map1, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_]] : tensor<256x1xi32>) outs([[VAR_2_]] : tensor<256x128xi32>) attrs =  {broadcastDims = array<i64: 1>} {
 // CHECK:           ^bb0([[IN_1_:%.+]]: i32, [[IN_2_:%.+]]: i32):

--- a/test/Conversion/TritonArithToLinalg/convert_2d_elemwise_arith_binary.mlir
+++ b/test/Conversion/TritonArithToLinalg/convert_2d_elemwise_arith_binary.mlir
@@ -42,7 +42,7 @@ module {
 // CHECK:             [[VAR_20_:%.+]] = arith.index_cast [[VAR_19_]] : index to i32
 // CHECK:             linalg.yield [[VAR_20_]] : i32
 // CHECK:           } -> tensor<128xi32>
-// CHECK-DAG:       [[VAR_expanded_:%.+]] = tensor.expand_shape [[VAR_1_]] {{.}}[0, 1]{{.}} : tensor<128xi32> into tensor<128x1xi32>
+// CHECK-DAG:       [[VAR_expanded_:%.+]] = tensor.expand_shape [[VAR_1_]] {{.}}[0, 1]{{.}} output_shape [128, 1] : tensor<128xi32> into tensor<128x1xi32>
 // CHECK-DAG:       [[VAR_2_:%.+]] = tensor.empty() : tensor<128x128xi32>
 // CHECK:           [[VAR_3_:%.+]] = linalg.generic {indexing_maps = [#map1, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_]] : tensor<128x1xi32>) outs([[VAR_2_]] : tensor<128x128xi32>) attrs =  {broadcastDims = array<i64: 1>} {
 // CHECK:           ^bb0([[in_:%.+]]: i32, [[out_]]: i32):
@@ -55,7 +55,7 @@ module {
 // CHECK:             [[VAR_20_1_:%.+]] = arith.index_cast [[VAR_19_1_]] : index to i32
 // CHECK:             linalg.yield [[VAR_20_1_]] : i32
 // CHECK:           } -> tensor<128xi32>
-// CHECK-DAG:       [[VAR_expanded_0_:%.+]] = tensor.expand_shape [[VAR_5_]] {{.}}[0, 1]{{.}} : tensor<128xi32> into tensor<1x128xi32>
+// CHECK-DAG:       [[VAR_expanded_0_:%.+]] = tensor.expand_shape [[VAR_5_]] {{.}}[0, 1]{{.}} output_shape [1, 128] : tensor<128xi32> into tensor<1x128xi32>
 // CHECK-DAG:       [[VAR_6_:%.+]] = tensor.empty() : tensor<128x128xi32>
 // CHECK:           [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map3, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_0_]] : tensor<1x128xi32>) outs([[VAR_6_]] : tensor<128x128xi32>) attrs =  {broadcastDims = array<i64: 0>} {
 // CHECK:           ^bb0([[in_]]: i32, [[out_]]: i32):

--- a/test/Conversion/TritonArithToLinalg/convert_2d_elemwise_arith_ternary.mlir
+++ b/test/Conversion/TritonArithToLinalg/convert_2d_elemwise_arith_ternary.mlir
@@ -44,7 +44,7 @@ module {
 // CHECK:             [[VAR_23_:%.+]] = arith.index_cast [[VAR_22_]] : index to i32
 // CHECK:             linalg.yield [[VAR_23_]] : i32
 // CHECK:           } -> tensor<128xi32>
-// CHECK-DAG:       [[VAR_expanded_:%.+]] = tensor.expand_shape [[VAR_1_]] {{.}}[0, 1]{{.}} : tensor<128xi32> into tensor<128x1xi32>
+// CHECK-DAG:       [[VAR_expanded_:%.+]] = tensor.expand_shape [[VAR_1_]] {{.}}[0, 1]{{.}} output_shape [128, 1] : tensor<128xi32> into tensor<128x1xi32>
 // CHECK-DAG:       [[VAR_2_:%.+]] = tensor.empty() : tensor<128x128xi32>
 // CHECK:           [[VAR_3_:%.+]] = linalg.generic {indexing_maps = [#map1, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_]] : tensor<128x1xi32>) outs([[VAR_2_]] : tensor<128x128xi32>) attrs =  {broadcastDims = array<i64: 1>} {
 // CHECK:           ^bb0([[in_:%.+]]: i32, [[out_]]: i32):
@@ -57,7 +57,7 @@ module {
 // CHECK:             [[VAR_23_1_:%.+]] = arith.index_cast [[VAR_22_1_]] : index to i32
 // CHECK:             linalg.yield [[VAR_23_1_]] : i32
 // CHECK:           } -> tensor<128xi32>
-// CHECK-DAG:       [[VAR_expanded_0_:%.+]] = tensor.expand_shape [[VAR_5_]] {{.}}[0, 1]{{.}} : tensor<128xi32> into tensor<1x128xi32>
+// CHECK-DAG:       [[VAR_expanded_0_:%.+]] = tensor.expand_shape [[VAR_5_]] {{.}}[0, 1]{{.}} output_shape [1, 128] : tensor<128xi32> into tensor<1x128xi32>
 // CHECK-DAG:       [[VAR_6_:%.+]] = tensor.empty() : tensor<128x128xi32>
 // CHECK:           [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map3, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_0_]] : tensor<1x128xi32>) outs([[VAR_6_]] : tensor<128x128xi32>) attrs =  {broadcastDims = array<i64: 0>} {
 // CHECK:           ^bb0([[in_]]: i32, [[out_]]: i32):

--- a/test/Conversion/TritonArithToLinalg/convert_2d_elemwise_arith_unary.mlir
+++ b/test/Conversion/TritonArithToLinalg/convert_2d_elemwise_arith_unary.mlir
@@ -56,7 +56,7 @@ module {
 // CHECK:             [[VAR_30_:%.+]] = arith.index_cast [[VAR_29_]] : index to i32
 // CHECK:             linalg.yield [[VAR_30_]] : i32
 // CHECK:           } -> tensor<128xi32>
-// CHECK-DAG:       [[VAR_expanded_:%.+]] = tensor.expand_shape [[VAR_1_]] {{.}}[0, 1]{{.}} : tensor<128xi32> into tensor<128x1xi32>
+// CHECK-DAG:       [[VAR_expanded_:%.+]] = tensor.expand_shape [[VAR_1_]] {{.}}[0, 1]{{.}} output_shape [128, 1] : tensor<128xi32> into tensor<128x1xi32>
 // CHECK-DAG:       [[VAR_2_:%.+]] = tensor.empty() : tensor<128x128xi32>
 // CHECK:           [[VAR_3_:%.+]] = linalg.generic {indexing_maps = [#map1, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_]] : tensor<128x1xi32>) outs([[VAR_2_]] : tensor<128x128xi32>) attrs =  {broadcastDims = array<i64: 1>} {
 // CHECK:           ^bb0([[in_:%.+]]: i32, [[out_]]: i32):
@@ -69,7 +69,7 @@ module {
 // CHECK:             [[VAR_30_1_:%.+]] = arith.index_cast [[VAR_29_1_]] : index to i32
 // CHECK:             linalg.yield [[VAR_30_1_]] : i32
 // CHECK:           } -> tensor<128xi32>
-// CHECK-DAG:       [[VAR_expanded_0_:%.+]] = tensor.expand_shape [[VAR_5_]] {{.}}[0, 1]{{.}} : tensor<128xi32> into tensor<1x128xi32>
+// CHECK-DAG:       [[VAR_expanded_0_:%.+]] = tensor.expand_shape [[VAR_5_]] {{.}}[0, 1]{{.}} output_shape [1, 128] : tensor<128xi32> into tensor<1x128xi32>
 // CHECK-DAG:       [[VAR_6_:%.+]] = tensor.empty() : tensor<128x128xi32>
 // CHECK:           [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map3, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_0_]] : tensor<1x128xi32>) outs([[VAR_6_]] : tensor<128x128xi32>) attrs =  {broadcastDims = array<i64: 0>} {
 // CHECK:           ^bb0([[in_]]: i32, [[out_]]: i32):

--- a/test/Conversion/TritonArithToLinalg/convert_argmin_argmax_2d.mlir
+++ b/test/Conversion/TritonArithToLinalg/convert_argmin_argmax_2d.mlir
@@ -120,7 +120,7 @@ module {
 // CHECK:             [[VAR_29_:%.+]] = arith.index_cast [[VAR_28_]] : index to i32
 // CHECK:             linalg.yield [[VAR_29_]] : i32
 // CHECK:           } -> tensor<4xi32>
-// CHECK-DAG:       [[VAR_expanded_:%.+]] = tensor.expand_shape [[VAR_1_]] {{.}}[0, 1]{{.}} : tensor<4xi32> into tensor<4x1xi32>
+// CHECK-DAG:       [[VAR_expanded_:%.+]] = tensor.expand_shape [[VAR_1_]] {{.}}[0, 1]{{.}} output_shape [4, 1] : tensor<4xi32> into tensor<4x1xi32>
 // CHECK-DAG:       [[VAR_2_:%.+]] = tensor.empty() : tensor<4x1xi32>
 // CHECK:           [[VAR_3_:%.+]] = linalg.fill ins([[PARAM_2_]] : i32) outs([[VAR_2_]] : tensor<4x1xi32>) -> tensor<4x1xi32>
 // CHECK:           [[VAR_4_:%.+]] = linalg.generic {indexing_maps = [#map1, #map1, #map1], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_]], [[VAR_3_]] : tensor<4x1xi32>, tensor<4x1xi32>) outs([[VAR_expanded_]] : tensor<4x1xi32>) {
@@ -128,7 +128,7 @@ module {
 // CHECK:             [[VAR_28_1_:%.+]] = arith.muli [[in_]], [[in_]]_1 : i32
 // CHECK:             linalg.yield [[VAR_28_1_]] : i32
 // CHECK:           } -> tensor<4x1xi32>
-// CHECK-DAG:       [[VAR_expanded_0_:%.+]] = tensor.expand_shape [[VAR_1_]] {{.}}[0, 1]{{.}} : tensor<4xi32> into tensor<1x4xi32>
+// CHECK-DAG:       [[VAR_expanded_0_:%.+]] = tensor.expand_shape [[VAR_1_]] {{.}}[0, 1]{{.}} output_shape [1, 4] : tensor<4xi32> into tensor<1x4xi32>
 // CHECK-DAG:       [[VAR_5_:%.+]] = tensor.empty() : tensor<1x4xi32>
 // CHECK:           [[VAR_6_:%.+]] = linalg.fill ins([[PARAM_3_]] : i32) outs([[VAR_5_]] : tensor<1x4xi32>) -> tensor<1x4xi32>
 // CHECK:           [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map1, #map1, #map1], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_0_]], [[VAR_6_]] : tensor<1x4xi32>, tensor<1x4xi32>) outs([[VAR_expanded_0_]] : tensor<1x4xi32>) {
@@ -212,7 +212,7 @@ module {
 // CHECK:             [[VAR_29_:%.+]] = arith.index_cast [[VAR_28_]] : index to i32
 // CHECK:             linalg.yield [[VAR_29_]] : i32
 // CHECK:           } -> tensor<4xi32>
-// CHECK-DAG:       [[VAR_expanded_:%.+]] = tensor.expand_shape [[VAR_1_]] {{.}}[0, 1]{{.}} : tensor<4xi32> into tensor<4x1xi32>
+// CHECK-DAG:       [[VAR_expanded_:%.+]] = tensor.expand_shape [[VAR_1_]] {{.}}[0, 1]{{.}} output_shape [4, 1] : tensor<4xi32> into tensor<4x1xi32>
 // CHECK-DAG:       [[VAR_2_:%.+]] = tensor.empty() : tensor<4x1xi32>
 // CHECK:           [[VAR_3_:%.+]] = linalg.fill ins([[PARAM_2_]] : i32) outs([[VAR_2_]] : tensor<4x1xi32>) -> tensor<4x1xi32>
 // CHECK:           [[VAR_4_:%.+]] = linalg.generic {indexing_maps = [#map1, #map1, #map1], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_]], [[VAR_3_]] : tensor<4x1xi32>, tensor<4x1xi32>) outs([[VAR_expanded_]] : tensor<4x1xi32>) {
@@ -220,7 +220,7 @@ module {
 // CHECK:             [[VAR_28_1_:%.+]] = arith.muli [[in_]], [[in_]]_1 : i32
 // CHECK:             linalg.yield [[VAR_28_1_]] : i32
 // CHECK:           } -> tensor<4x1xi32>
-// CHECK-DAG:       [[VAR_expanded_0_:%.+]] = tensor.expand_shape [[VAR_1_]] {{.}}[0, 1]{{.}} : tensor<4xi32> into tensor<1x4xi32>
+// CHECK-DAG:       [[VAR_expanded_0_:%.+]] = tensor.expand_shape [[VAR_1_]] {{.}}[0, 1]{{.}} output_shape [1, 4] : tensor<4xi32> into tensor<1x4xi32>
 // CHECK-DAG:       [[VAR_5_:%.+]] = tensor.empty() : tensor<1x4xi32>
 // CHECK:           [[VAR_6_:%.+]] = linalg.fill ins([[PARAM_3_]] : i32) outs([[VAR_5_]] : tensor<1x4xi32>) -> tensor<1x4xi32>
 // CHECK:           [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map1, #map1, #map1], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_0_]], [[VAR_6_]] : tensor<1x4xi32>, tensor<1x4xi32>) outs([[VAR_expanded_0_]] : tensor<1x4xi32>) {

--- a/test/Conversion/TritonArithToLinalg/dot.mlir
+++ b/test/Conversion/TritonArithToLinalg/dot.mlir
@@ -79,7 +79,7 @@ module {
 // CHECK:             [[VAR_49_1_:%.+]] = arith.muli [[in_]], [[in_1:.+]] : i32
 // CHECK:             linalg.yield [[VAR_49_1_]] : i32
 // CHECK:           } -> tensor<128xi32>
-// CHECK-DAG:       [[VAR_expanded_:%.+]] = tensor.expand_shape [[VAR_8_]] {{.}}[0, 1]{{.}} : tensor<128xi32> into tensor<128x1xi32>
+// CHECK-DAG:       [[VAR_expanded_:%.+]] = tensor.expand_shape [[VAR_8_]] {{.}}[0, 1]{{.}} output_shape [128, 1] : tensor<128xi32> into tensor<128x1xi32>
 // CHECK-DAG:       [[VAR_9_:%.+]] = tensor.empty() : tensor<128x64xi32>
 // CHECK:           [[VAR_10_:%.+]] = linalg.generic {indexing_maps = [#map1, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_]] : tensor<128x1xi32>) outs([[VAR_9_]] : tensor<128x64xi32>) attrs =  {broadcastDims = array<i64: 1>} {
 // CHECK:           ^bb0([[in_:.+]]: i32, [[out_:.+]]: i32):
@@ -92,7 +92,7 @@ module {
 // CHECK:             [[VAR_50_1_:%.+]] = arith.index_cast [[VAR_49_2_]] : index to i32
 // CHECK:             linalg.yield [[VAR_50_1_]] : i32
 // CHECK:           } -> tensor<64xi32>
-// CHECK-DAG:       [[VAR_expanded_1_:%.+]] = tensor.expand_shape [[VAR_12_]] {{.}}[0, 1]{{.}} : tensor<64xi32> into tensor<1x64xi32>
+// CHECK-DAG:       [[VAR_expanded_1_:%.+]] = tensor.expand_shape [[VAR_12_]] {{.}}[0, 1]{{.}} output_shape [1, 64] : tensor<64xi32> into tensor<1x64xi32>
 // CHECK-DAG:       [[VAR_13_:%.+]] = tensor.empty() : tensor<128x64xi32>
 // CHECK:           [[VAR_14_:%.+]] = linalg.generic {indexing_maps = [#map3, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_1_]] : tensor<1x64xi32>) outs([[VAR_13_]] : tensor<128x64xi32>) attrs =  {broadcastDims = array<i64: 0>} {
 // CHECK:           ^bb0([[in_:.+]]: i32, [[out_:.+]]: i32):
@@ -110,7 +110,7 @@ module {
 // CHECK:             [[VAR_50_2_:%.+]] = arith.index_cast [[VAR_49_4_]] : index to i32
 // CHECK:             linalg.yield [[VAR_50_2_]] : i32
 // CHECK:           } -> tensor<256xi32>
-// CHECK-DAG:       [[VAR_expanded_2_:%.+]] = tensor.expand_shape [[VAR_17_]] {{.}}[0, 1]{{.}} : tensor<256xi32> into tensor<256x1xi32>
+// CHECK-DAG:       [[VAR_expanded_2_:%.+]] = tensor.expand_shape [[VAR_17_]] {{.}}[0, 1]{{.}} output_shape [256, 1] : tensor<256xi32> into tensor<256x1xi32>
 // CHECK-DAG:       [[VAR_18_:%.+]] = tensor.empty() : tensor<256x64xi32>
 // CHECK:           [[VAR_19_:%.+]] = linalg.generic {indexing_maps = [#map1, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_2_]] : tensor<256x1xi32>) outs([[VAR_18_]] : tensor<256x64xi32>) attrs =  {broadcastDims = array<i64: 1>} {
 // CHECK:           ^bb0([[in_:.+]]: i32, [[out_:.+]]: i32):
@@ -128,7 +128,7 @@ module {
 // CHECK:             [[VAR_49_6_:%.+]] = arith.muli [[in_]], [[in_1:.+]] : i32
 // CHECK:             linalg.yield [[VAR_49_6_]] : i32
 // CHECK:           } -> tensor<64xi32>
-// CHECK-DAG:       [[VAR_expanded_3_:%.+]] = tensor.expand_shape [[VAR_22_]] {{.}}[0, 1]{{.}} : tensor<64xi32> into tensor<1x64xi32>
+// CHECK-DAG:       [[VAR_expanded_3_:%.+]] = tensor.expand_shape [[VAR_22_]] {{.}}[0, 1]{{.}} output_shape [1, 64] : tensor<64xi32> into tensor<1x64xi32>
 // CHECK-DAG:       [[VAR_23_:%.+]] = tensor.empty() : tensor<256x64xi32>
 // CHECK:           [[VAR_24_:%.+]] = linalg.generic {indexing_maps = [#map3, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_3_]] : tensor<1x64xi32>) outs([[VAR_23_]] : tensor<256x64xi32>) attrs =  {broadcastDims = array<i64: 0>} {
 // CHECK:           ^bb0([[in_:.+]]: i32, [[out_:.+]]: i32):
@@ -144,13 +144,13 @@ module {
 // CHECK:             [[VAR_49_8_:%.+]] = arith.muli [[in_]], [[in_1:.+]] : i32
 // CHECK:             linalg.yield [[VAR_49_8_]] : i32
 // CHECK:           } -> tensor<128xi32>
-// CHECK-DAG:       [[VAR_expanded_4_:%.+]] = tensor.expand_shape [[VAR_26_]] {{.}}[0, 1]{{.}} : tensor<128xi32> into tensor<128x1xi32>
+// CHECK-DAG:       [[VAR_expanded_4_:%.+]] = tensor.expand_shape [[VAR_26_]] {{.}}[0, 1]{{.}} output_shape [128, 1] : tensor<128xi32> into tensor<128x1xi32>
 // CHECK-DAG:       [[VAR_27_:%.+]] = tensor.empty() : tensor<128x256xi32>
 // CHECK:           [[VAR_28_:%.+]] = linalg.generic {indexing_maps = [#map1, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_4_]] : tensor<128x1xi32>) outs([[VAR_27_]] : tensor<128x256xi32>) attrs =  {broadcastDims = array<i64: 1>} {
 // CHECK:           ^bb0([[in_:.+]]: i32, [[out_:.+]]: i32):
 // CHECK:             linalg.yield [[in_]] : i32
 // CHECK:           } -> tensor<128x256xi32>
-// CHECK-DAG:       [[VAR_expanded_5_:%.+]] = tensor.expand_shape [[VAR_17_]] {{.}}[0, 1]{{.}} : tensor<256xi32> into tensor<1x256xi32>
+// CHECK-DAG:       [[VAR_expanded_5_:%.+]] = tensor.expand_shape [[VAR_17_]] {{.}}[0, 1]{{.}} output_shape [1, 256] : tensor<256xi32> into tensor<1x256xi32>
 // CHECK-DAG:       [[VAR_29_:%.+]] = tensor.empty() : tensor<128x256xi32>
 // CHECK:           [[VAR_30_:%.+]] = linalg.generic {indexing_maps = [#map3, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_5_]] : tensor<1x256xi32>) outs([[VAR_29_]] : tensor<128x256xi32>) attrs =  {broadcastDims = array<i64: 0>} {
 // CHECK:           ^bb0([[in_:.+]]: i32, [[out_:.+]]: i32):

--- a/test/Conversion/TritonArithToLinalg/reducemax_32_256_bf16.mlir
+++ b/test/Conversion/TritonArithToLinalg/reducemax_32_256_bf16.mlir
@@ -63,13 +63,13 @@ module {
 // CHECK:             [[VAR_29_1_:%.+]] = arith.muli [[in_]], [[in_]]_5 : i32
 // CHECK:             linalg.yield [[VAR_29_1_]] : i32
 // CHECK:           } -> tensor<32xi32>
-// CHECK-DAG:       [[VAR_expanded_:%.+]] = tensor.expand_shape [[VAR_4_]] {{.}}[0, 1]{{.}} : tensor<32xi32> into tensor<32x1xi32>
+// CHECK-DAG:       [[VAR_expanded_:%.+]] = tensor.expand_shape [[VAR_4_]] {{.}}[0, 1]{{.}} output_shape [32, 1] : tensor<32xi32> into tensor<32x1xi32>
 // CHECK-DAG:       [[VAR_5_:%.+]] = tensor.empty() : tensor<32x256xi32>
 // CHECK:           [[VAR_6_:%.+]] = linalg.generic {indexing_maps = [#map1, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_]] : tensor<32x1xi32>) outs([[VAR_5_]] : tensor<32x256xi32>) attrs =  {broadcastDims = array<i64: 1>} {
 // CHECK:           ^bb0([[in_]]: i32, [[out_]]: i32):
 // CHECK:             linalg.yield [[in_]] : i32
 // CHECK:           } -> tensor<32x256xi32>
-// CHECK-DAG:       [[VAR_expanded_0_:%.+]] = tensor.expand_shape [[VAR_6_]] {{.}}[0], [1, 2]{{.}} : tensor<32x256xi32> into tensor<32x256x1xi32>
+// CHECK-DAG:       [[VAR_expanded_0_:%.+]] = tensor.expand_shape [[VAR_6_]] {{.}}[0], [1, 2]{{.}} output_shape [32, 256, 1] : tensor<32x256xi32> into tensor<32x256x1xi32>
 // CHECK-DAG:       [[VAR_7_:%.+]] = tensor.empty() : tensor<32x256x16xi32>
 // CHECK:           [[VAR_8_:%.+]] = linalg.generic {indexing_maps = [#map3, #map4], iterator_types = ["parallel", "parallel", "parallel"]} ins([[VAR_expanded_0_]] : tensor<32x256x1xi32>) outs([[VAR_7_]] : tensor<32x256x16xi32>) attrs =  {broadcastDims = array<i64: 2>} {
 // CHECK:           ^bb0([[in_]]: i32, [[out_]]: i32):
@@ -82,13 +82,13 @@ module {
 // CHECK:             [[VAR_30_1_:%.+]] = arith.index_cast [[VAR_29_2_]] : index to i32
 // CHECK:             linalg.yield [[VAR_30_1_]] : i32
 // CHECK:           } -> tensor<256xi32>
-// CHECK-DAG:       [[VAR_expanded_1_:%.+]] = tensor.expand_shape [[VAR_10_]] {{.}}[0, 1]{{.}} : tensor<256xi32> into tensor<1x256xi32>
+// CHECK-DAG:       [[VAR_expanded_1_:%.+]] = tensor.expand_shape [[VAR_10_]] {{.}}[0, 1]{{.}} output_shape [1, 256] : tensor<256xi32> into tensor<1x256xi32>
 // CHECK-DAG:       [[VAR_11_:%.+]] = tensor.empty() : tensor<32x256xi32>
 // CHECK:           [[VAR_12_:%.+]] = linalg.generic {indexing_maps = [#map5, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_1_]] : tensor<1x256xi32>) outs([[VAR_11_]] : tensor<32x256xi32>) attrs =  {broadcastDims = array<i64: 0>} {
 // CHECK:           ^bb0([[in_]]: i32, [[out_]]: i32):
 // CHECK:             linalg.yield [[in_]] : i32
 // CHECK:           } -> tensor<32x256xi32>
-// CHECK-DAG:       [[VAR_expanded_2_:%.+]] = tensor.expand_shape [[VAR_12_]] {{.}}[0], [1, 2]{{.}} : tensor<32x256xi32> into tensor<32x256x1xi32>
+// CHECK-DAG:       [[VAR_expanded_2_:%.+]] = tensor.expand_shape [[VAR_12_]] {{.}}[0], [1, 2]{{.}} output_shape [32, 256, 1] : tensor<32x256xi32> into tensor<32x256x1xi32>
 // CHECK-DAG:       [[VAR_13_:%.+]] = tensor.empty() : tensor<32x256x16xi32>
 // CHECK:           [[VAR_14_:%.+]] = linalg.generic {indexing_maps = [#map3, #map4], iterator_types = ["parallel", "parallel", "parallel"]} ins([[VAR_expanded_2_]] : tensor<32x256x1xi32>) outs([[VAR_13_]] : tensor<32x256x16xi32>) attrs =  {broadcastDims = array<i64: 2>} {
 // CHECK:           ^bb0([[in_]]: i32, [[out_]]: i32):
@@ -101,13 +101,13 @@ module {
 // CHECK:             [[VAR_30_2_:%.+]] = arith.index_cast [[VAR_29_3_]] : index to i32
 // CHECK:             linalg.yield [[VAR_30_2_]] : i32
 // CHECK:           } -> tensor<16xi32>
-// CHECK-DAG:       [[VAR_expanded_3_:%.+]] = tensor.expand_shape [[VAR_16_]] {{.}}[0, 1]{{.}} : tensor<16xi32> into tensor<1x16xi32>
+// CHECK-DAG:       [[VAR_expanded_3_:%.+]] = tensor.expand_shape [[VAR_16_]] {{.}}[0, 1]{{.}} output_shape [1, 16] : tensor<16xi32> into tensor<1x16xi32>
 // CHECK-DAG:       [[VAR_17_:%.+]] = tensor.empty() : tensor<256x16xi32>
 // CHECK:           [[VAR_18_:%.+]] = linalg.generic {indexing_maps = [#map5, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_3_]] : tensor<1x16xi32>) outs([[VAR_17_]] : tensor<256x16xi32>) attrs =  {broadcastDims = array<i64: 0>} {
 // CHECK:           ^bb0([[in_]]: i32, [[out_]]: i32):
 // CHECK:             linalg.yield [[in_]] : i32
 // CHECK:           } -> tensor<256x16xi32>
-// CHECK-DAG:       [[VAR_expanded_4_:%.+]] = tensor.expand_shape [[VAR_18_]] {{.}}[0, 1], [2]{{.}} : tensor<256x16xi32> into tensor<1x256x16xi32>
+// CHECK-DAG:       [[VAR_expanded_4_:%.+]] = tensor.expand_shape [[VAR_18_]] {{.}}[0, 1], [2]{{.}} output_shape [1, 256, 16] : tensor<256x16xi32> into tensor<1x256x16xi32>
 // CHECK-DAG:       [[VAR_19_:%.+]] = tensor.empty() : tensor<32x256x16xi32>
 // CHECK:           [[VAR_20_:%.+]] = linalg.generic {indexing_maps = [#map6, #map4], iterator_types = ["parallel", "parallel", "parallel"]} ins([[VAR_expanded_4_]] : tensor<1x256x16xi32>) outs([[VAR_19_]] : tensor<32x256x16xi32>) attrs =  {broadcastDims = array<i64: 0>} {
 // CHECK:           ^bb0([[in_]]: i32, [[out_]]: i32):

--- a/test/Conversion/TritonArithToLinalg/reducesum_512_256_bf16_axis0.mlir
+++ b/test/Conversion/TritonArithToLinalg/reducesum_512_256_bf16_axis0.mlir
@@ -52,7 +52,7 @@ module {
 // CHECK:             [[VAR_21_1_:%.+]] = arith.muli [[in_]], [[in_]]_1 : i32
 // CHECK:             linalg.yield [[VAR_21_1_]] : i32
 // CHECK:           } -> tensor<512xi32>
-// CHECK-DAG:       [[VAR_expanded_:%.+]] = tensor.expand_shape [[VAR_4_]] {{.}}[0, 1]{{.}} : tensor<512xi32> into tensor<512x1xi32>
+// CHECK-DAG:       [[VAR_expanded_:%.+]] = tensor.expand_shape [[VAR_4_]] {{.}}[0, 1]{{.}} output_shape [512, 1] : tensor<512xi32> into tensor<512x1xi32>
 // CHECK-DAG:       [[VAR_5_:%.+]] = tensor.empty() : tensor<512x256xi32>
 // CHECK:           [[VAR_6_:%.+]] = linalg.generic {indexing_maps = [#map1, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_]] : tensor<512x1xi32>) outs([[VAR_5_]] : tensor<512x256xi32>) attrs =  {broadcastDims = array<i64: 1>} {
 // CHECK:           ^bb0([[in_]]: i32, [[out_]]: i32):
@@ -65,7 +65,7 @@ module {
 // CHECK:             [[VAR_22_1_:%.+]] = arith.index_cast [[VAR_21_2_]] : index to i32
 // CHECK:             linalg.yield [[VAR_22_1_]] : i32
 // CHECK:           } -> tensor<256xi32>
-// CHECK-DAG:       [[VAR_expanded_0_:%.+]] = tensor.expand_shape [[VAR_8_]] {{.}}[0, 1]{{.}} : tensor<256xi32> into tensor<1x256xi32>
+// CHECK-DAG:       [[VAR_expanded_0_:%.+]] = tensor.expand_shape [[VAR_8_]] {{.}}[0, 1]{{.}} output_shape [1, 256] : tensor<256xi32> into tensor<1x256xi32>
 // CHECK-DAG:       [[VAR_9_:%.+]] = tensor.empty() : tensor<512x256xi32>
 // CHECK:           [[VAR_10_:%.+]] = linalg.generic {indexing_maps = [#map3, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_0_]] : tensor<1x256xi32>) outs([[VAR_9_]] : tensor<512x256xi32>) attrs =  {broadcastDims = array<i64: 0>} {
 // CHECK:           ^bb0([[in_]]: i32, [[out_]]: i32):

--- a/test/Conversion/TritonArithToLinalg/reducesum_512_256_bf16_axis1.mlir
+++ b/test/Conversion/TritonArithToLinalg/reducesum_512_256_bf16_axis1.mlir
@@ -52,7 +52,7 @@ module {
 // CHECK:             [[VAR_22_1_:%.+]] = arith.muli [[in_]], [[in_]]_1 : i32
 // CHECK:             linalg.yield [[VAR_22_1_]] : i32
 // CHECK:           } -> tensor<512xi32>
-// CHECK-DAG:       [[VAR_expanded_:%.+]] = tensor.expand_shape [[VAR_4_]] {{.}}[0, 1]{{.}} : tensor<512xi32> into tensor<512x1xi32>
+// CHECK-DAG:       [[VAR_expanded_:%.+]] = tensor.expand_shape [[VAR_4_]] {{.}}[0, 1]{{.}} output_shape [512, 1] : tensor<512xi32> into tensor<512x1xi32>
 // CHECK-DAG:       [[VAR_5_:%.+]] = tensor.empty() : tensor<512x256xi32>
 // CHECK:           [[VAR_6_:%.+]] = linalg.generic {indexing_maps = [#map1, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_]] : tensor<512x1xi32>) outs([[VAR_5_]] : tensor<512x256xi32>) attrs =  {broadcastDims = array<i64: 1>} {
 // CHECK:           ^bb0([[in_]]: i32, [[out_]]: i32):
@@ -65,7 +65,7 @@ module {
 // CHECK:             [[VAR_23_1_:%.+]] = arith.index_cast [[VAR_22_2_]] : index to i32
 // CHECK:             linalg.yield [[VAR_23_1_]] : i32
 // CHECK:           } -> tensor<256xi32>
-// CHECK-DAG:       [[VAR_expanded_0_:%.+]] = tensor.expand_shape [[VAR_8_]] {{.}}[0, 1]{{.}} : tensor<256xi32> into tensor<1x256xi32>
+// CHECK-DAG:       [[VAR_expanded_0_:%.+]] = tensor.expand_shape [[VAR_8_]] {{.}}[0, 1]{{.}} output_shape [1, 256] : tensor<256xi32> into tensor<1x256xi32>
 // CHECK-DAG:       [[VAR_9_:%.+]] = tensor.empty() : tensor<512x256xi32>
 // CHECK:           [[VAR_10_:%.+]] = linalg.generic {indexing_maps = [#map3, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_0_]] : tensor<1x256xi32>) outs([[VAR_9_]] : tensor<512x256xi32>) attrs =  {broadcastDims = array<i64: 0>} {
 // CHECK:           ^bb0([[in_]]: i32, [[out_]]: i32):

--- a/test/Conversion/TritonArithToLinalg/reducesum_512_256_f32_axis0.mlir
+++ b/test/Conversion/TritonArithToLinalg/reducesum_512_256_f32_axis0.mlir
@@ -52,7 +52,7 @@ module {
 // CHECK:             [[VAR_21_1_:%.+]] = arith.muli [[in_]], [[in_]]_1 : i32
 // CHECK:             linalg.yield [[VAR_21_1_]] : i32
 // CHECK:           } -> tensor<512xi32>
-// CHECK-DAG:       [[VAR_expanded_:%.+]] = tensor.expand_shape [[VAR_4_]] {{.}}[0, 1]{{.}} : tensor<512xi32> into tensor<512x1xi32>
+// CHECK-DAG:       [[VAR_expanded_:%.+]] = tensor.expand_shape [[VAR_4_]] {{.}}[0, 1]{{.}} output_shape [512, 1] : tensor<512xi32> into tensor<512x1xi32>
 // CHECK-DAG:       [[VAR_5_:%.+]] = tensor.empty() : tensor<512x256xi32>
 // CHECK:           [[VAR_6_:%.+]] = linalg.generic {indexing_maps = [#map1, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_]] : tensor<512x1xi32>) outs([[VAR_5_]] : tensor<512x256xi32>) attrs =  {broadcastDims = array<i64: 1>} {
 // CHECK:           ^bb0([[in_]]: i32, [[out_]]: i32):
@@ -65,7 +65,7 @@ module {
 // CHECK:             [[VAR_22_1_:%.+]] = arith.index_cast [[VAR_21_2_]] : index to i32
 // CHECK:             linalg.yield [[VAR_22_1_]] : i32
 // CHECK:           } -> tensor<256xi32>
-// CHECK-DAG:       [[VAR_expanded_0_:%.+]] = tensor.expand_shape [[VAR_8_]] {{.}}[0, 1]{{.}} : tensor<256xi32> into tensor<1x256xi32>
+// CHECK-DAG:       [[VAR_expanded_0_:%.+]] = tensor.expand_shape [[VAR_8_]] {{.}}[0, 1]{{.}} output_shape [1, 256] : tensor<256xi32> into tensor<1x256xi32>
 // CHECK-DAG:       [[VAR_9_:%.+]] = tensor.empty() : tensor<512x256xi32>
 // CHECK:           [[VAR_10_:%.+]] = linalg.generic {indexing_maps = [#map3, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_0_]] : tensor<1x256xi32>) outs([[VAR_9_]] : tensor<512x256xi32>) attrs =  {broadcastDims = array<i64: 0>} {
 // CHECK:           ^bb0([[in_]]: i32, [[out_]]: i32):

--- a/test/Conversion/TritonArithToLinalg/reducesum_512_256_f32_axis1.mlir
+++ b/test/Conversion/TritonArithToLinalg/reducesum_512_256_f32_axis1.mlir
@@ -52,7 +52,7 @@ module {
 // CHECK:             [[VAR_22_1_:%.+]] = arith.muli [[in_]], [[in_]]_1 : i32
 // CHECK:             linalg.yield [[VAR_22_1_]] : i32
 // CHECK:           } -> tensor<512xi32>
-// CHECK-DAG:       [[VAR_expanded_:%.+]] = tensor.expand_shape [[VAR_4_]] {{.}}[0, 1]{{.}} : tensor<512xi32> into tensor<512x1xi32>
+// CHECK-DAG:       [[VAR_expanded_:%.+]] = tensor.expand_shape [[VAR_4_]] {{.}}[0, 1]{{.}} output_shape [512, 1] : tensor<512xi32> into tensor<512x1xi32>
 // CHECK-DAG:       [[VAR_5_:%.+]] = tensor.empty() : tensor<512x256xi32>
 // CHECK:           [[VAR_6_:%.+]] = linalg.generic {indexing_maps = [#map1, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_]] : tensor<512x1xi32>) outs([[VAR_5_]] : tensor<512x256xi32>) attrs =  {broadcastDims = array<i64: 1>} {
 // CHECK:           ^bb0([[in_]]: i32, [[out_]]: i32):
@@ -65,7 +65,7 @@ module {
 // CHECK:             [[VAR_23_1_:%.+]] = arith.index_cast [[VAR_22_2_]] : index to i32
 // CHECK:             linalg.yield [[VAR_23_1_]] : i32
 // CHECK:           } -> tensor<256xi32>
-// CHECK-DAG:       [[VAR_expanded_0_:%.+]] = tensor.expand_shape [[VAR_8_]] {{.}}[0, 1]{{.}} : tensor<256xi32> into tensor<1x256xi32>
+// CHECK-DAG:       [[VAR_expanded_0_:%.+]] = tensor.expand_shape [[VAR_8_]] {{.}}[0, 1]{{.}} output_shape [1, 256] : tensor<256xi32> into tensor<1x256xi32>
 // CHECK-DAG:       [[VAR_9_:%.+]] = tensor.empty() : tensor<512x256xi32>
 // CHECK:           [[VAR_10_:%.+]] = linalg.generic {indexing_maps = [#map3, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_0_]] : tensor<1x256xi32>) outs([[VAR_9_]] : tensor<512x256xi32>) attrs =  {broadcastDims = array<i64: 0>} {
 // CHECK:           ^bb0([[in_]]: i32, [[out_]]: i32):

--- a/test/Conversion/TritonArithToLinalg/reducesum_middle_dim.mlir
+++ b/test/Conversion/TritonArithToLinalg/reducesum_middle_dim.mlir
@@ -63,13 +63,13 @@ module {
 // CHECK:             [[VAR_29_1_:%.+]] = arith.muli [[in_]], [[in_]]_5 : i32
 // CHECK:             linalg.yield [[VAR_29_1_]] : i32
 // CHECK:           } -> tensor<32xi32>
-// CHECK-DAG:       [[VAR_expanded_:%.+]] = tensor.expand_shape [[VAR_4_]] {{.}}[0, 1]{{.}} : tensor<32xi32> into tensor<32x1xi32>
+// CHECK-DAG:       [[VAR_expanded_:%.+]] = tensor.expand_shape [[VAR_4_]] {{.}}[0, 1]{{.}} output_shape [32, 1] : tensor<32xi32> into tensor<32x1xi32>
 // CHECK-DAG:       [[VAR_5_:%.+]] = tensor.empty() : tensor<32x256xi32>
 // CHECK:           [[VAR_6_:%.+]] = linalg.generic {indexing_maps = [#map1, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_]] : tensor<32x1xi32>) outs([[VAR_5_]] : tensor<32x256xi32>) attrs =  {broadcastDims = array<i64: 1>} {
 // CHECK:           ^bb0([[in_]]: i32, [[out_]]: i32):
 // CHECK:             linalg.yield [[in_]] : i32
 // CHECK:           } -> tensor<32x256xi32>
-// CHECK-DAG:       [[VAR_expanded_0_:%.+]] = tensor.expand_shape [[VAR_6_]] {{.}}[0], [1, 2]{{.}} : tensor<32x256xi32> into tensor<32x256x1xi32>
+// CHECK-DAG:       [[VAR_expanded_0_:%.+]] = tensor.expand_shape [[VAR_6_]] {{.}}[0], [1, 2]{{.}} output_shape [32, 256, 1] : tensor<32x256xi32> into tensor<32x256x1xi32>
 // CHECK-DAG:       [[VAR_7_:%.+]] = tensor.empty() : tensor<32x256x16xi32>
 // CHECK:           [[VAR_8_:%.+]] = linalg.generic {indexing_maps = [#map3, #map4], iterator_types = ["parallel", "parallel", "parallel"]} ins([[VAR_expanded_0_]] : tensor<32x256x1xi32>) outs([[VAR_7_]] : tensor<32x256x16xi32>) attrs =  {broadcastDims = array<i64: 2>} {
 // CHECK:           ^bb0([[in_]]: i32, [[out_]]: i32):
@@ -82,13 +82,13 @@ module {
 // CHECK:             [[VAR_30_1_:%.+]] = arith.index_cast [[VAR_29_2_]] : index to i32
 // CHECK:             linalg.yield [[VAR_30_1_]] : i32
 // CHECK:           } -> tensor<256xi32>
-// CHECK-DAG:       [[VAR_expanded_1_:%.+]] = tensor.expand_shape [[VAR_10_]] {{.}}[0, 1]{{.}} : tensor<256xi32> into tensor<1x256xi32>
+// CHECK-DAG:       [[VAR_expanded_1_:%.+]] = tensor.expand_shape [[VAR_10_]] {{.}}[0, 1]{{.}} output_shape [1, 256] : tensor<256xi32> into tensor<1x256xi32>
 // CHECK-DAG:       [[VAR_11_:%.+]] = tensor.empty() : tensor<32x256xi32>
 // CHECK:           [[VAR_12_:%.+]] = linalg.generic {indexing_maps = [#map5, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_1_]] : tensor<1x256xi32>) outs([[VAR_11_]] : tensor<32x256xi32>) attrs =  {broadcastDims = array<i64: 0>} {
 // CHECK:           ^bb0([[in_]]: i32, [[out_]]: i32):
 // CHECK:             linalg.yield [[in_]] : i32
 // CHECK:           } -> tensor<32x256xi32>
-// CHECK-DAG:       [[VAR_expanded_2_:%.+]] = tensor.expand_shape [[VAR_12_]] {{.}}[0], [1, 2]{{.}} : tensor<32x256xi32> into tensor<32x256x1xi32>
+// CHECK-DAG:       [[VAR_expanded_2_:%.+]] = tensor.expand_shape [[VAR_12_]] {{.}}[0], [1, 2]{{.}} output_shape [32, 256, 1] : tensor<32x256xi32> into tensor<32x256x1xi32>
 // CHECK-DAG:       [[VAR_13_:%.+]] = tensor.empty() : tensor<32x256x16xi32>
 // CHECK:           [[VAR_14_:%.+]] = linalg.generic {indexing_maps = [#map3, #map4], iterator_types = ["parallel", "parallel", "parallel"]} ins([[VAR_expanded_2_]] : tensor<32x256x1xi32>) outs([[VAR_13_]] : tensor<32x256x16xi32>) attrs =  {broadcastDims = array<i64: 2>} {
 // CHECK:           ^bb0([[in_]]: i32, [[out_]]: i32):
@@ -101,13 +101,13 @@ module {
 // CHECK:             [[VAR_30_2_:%.+]] = arith.index_cast [[VAR_29_3_]] : index to i32
 // CHECK:             linalg.yield [[VAR_30_2_]] : i32
 // CHECK:           } -> tensor<16xi32>
-// CHECK-DAG:       [[VAR_expanded_3_:%.+]] = tensor.expand_shape [[VAR_16_]] {{.}}[0, 1]{{.}} : tensor<16xi32> into tensor<1x16xi32>
+// CHECK-DAG:       [[VAR_expanded_3_:%.+]] = tensor.expand_shape [[VAR_16_]] {{.}}[0, 1]{{.}} output_shape [1, 16] : tensor<16xi32> into tensor<1x16xi32>
 // CHECK-DAG:       [[VAR_17_:%.+]] = tensor.empty() : tensor<256x16xi32>
 // CHECK:           [[VAR_18_:%.+]] = linalg.generic {indexing_maps = [#map5, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_3_]] : tensor<1x16xi32>) outs([[VAR_17_]] : tensor<256x16xi32>) attrs =  {broadcastDims = array<i64: 0>} {
 // CHECK:           ^bb0([[in_]]: i32, [[out_]]: i32):
 // CHECK:             linalg.yield [[in_]] : i32
 // CHECK:           } -> tensor<256x16xi32>
-// CHECK-DAG:       [[VAR_expanded_4_:%.+]] = tensor.expand_shape [[VAR_18_]] {{.}}[0, 1], [2]{{.}} : tensor<256x16xi32> into tensor<1x256x16xi32>
+// CHECK-DAG:       [[VAR_expanded_4_:%.+]] = tensor.expand_shape [[VAR_18_]] {{.}}[0, 1], [2]{{.}} output_shape [1, 256, 16] : tensor<256x16xi32> into tensor<1x256x16xi32>
 // CHECK-DAG:       [[VAR_19_:%.+]] = tensor.empty() : tensor<32x256x16xi32>
 // CHECK:           [[VAR_20_:%.+]] = linalg.generic {indexing_maps = [#map6, #map4], iterator_types = ["parallel", "parallel", "parallel"]} ins([[VAR_expanded_4_]] : tensor<1x256x16xi32>) outs([[VAR_19_]] : tensor<32x256x16xi32>) attrs =  {broadcastDims = array<i64: 0>} {
 // CHECK:           ^bb0([[in_]]: i32, [[out_]]: i32):

--- a/test/Conversion/TritonToLinalg/convert_argmin_argmax_2d.mlir
+++ b/test/Conversion/TritonToLinalg/convert_argmin_argmax_2d.mlir
@@ -66,7 +66,7 @@ module {
 // CHECK:             [[VAR_14_:%.+]] = arith.index_cast [[VAR_13_]] : index to i32
 // CHECK:             linalg.yield [[VAR_14_]] : i32
 // CHECK:           } -> tensor<4xi32>
-// CHECK-DAG:       [[VAR_expanded_:%.+]] = tensor.expand_shape [[VAR_1_]] {{.}}[0, 1]{{.}} : tensor<4xi32> into tensor<1x4xi32>
+// CHECK-DAG:       [[VAR_expanded_:%.+]] = tensor.expand_shape [[VAR_1_]] {{.}}[0, 1]{{.}} output_shape [1, 4] : tensor<4xi32> into tensor<1x4xi32>
 // CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
 // CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
 // CHECK-NOT: separator of consecutive DAGs
@@ -174,7 +174,7 @@ module {
 // CHECK:             [[VAR_14_:%.+]] = arith.index_cast [[VAR_13_]] : index to i32
 // CHECK:             linalg.yield [[VAR_14_]] : i32
 // CHECK:           } -> tensor<4xi32>
-// CHECK-DAG:       [[VAR_expanded_:%.+]] = tensor.expand_shape [[VAR_1_]] {{.}}[0, 1]{{.}} : tensor<4xi32> into tensor<1x4xi32>
+// CHECK-DAG:       [[VAR_expanded_:%.+]] = tensor.expand_shape [[VAR_1_]] {{.}}[0, 1]{{.}} output_shape [1, 4] : tensor<4xi32> into tensor<1x4xi32>
 // CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
 // CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
 // CHECK-NOT: separator of consecutive DAGs

--- a/test/Conversion/TritonToLinalg/use_end_chain.mlir
+++ b/test/Conversion/TritonToLinalg/use_end_chain.mlir
@@ -46,7 +46,7 @@ module {
 // CHECK:             %[[VAL_12:.*]] = arith.index_cast %[[VAL_11]] : index to i32
 // CHECK:             linalg.yield %[[VAL_12]] : i32
 // CHECK:           } -> tensor<256xi32>
-// CHECK:           %[[VAL_13:.*]] = tensor.expand_shape %[[VAL_14:.*]] {{\[\[}}0, 1]] : tensor<256xi32> into tensor<256x1xi32>
+// CHECK:           %[[VAL_13:.*]] = tensor.expand_shape %[[VAL_14:.*]] {{\[\[}}0, 1]] output_shape [256, 1] : tensor<256xi32> into tensor<256x1xi32>
 // CHECK:           %[[VAL_15:.*]] = tensor.empty() : tensor<256x128xi32>
 // CHECK:           %[[VAL_16:.*]] = linalg.generic {indexing_maps = [#map1, #map2], iterator_types = ["parallel", "parallel"]} ins(%[[VAL_13]] : tensor<256x1xi32>) outs(%[[VAL_15]] : tensor<256x128xi32>) attrs =  {broadcastDims = array<i64: 1>} {
 // CHECK:           ^bb0(%[[VAL_17:.*]]: i32, %[[VAL_18:.*]]: i32):
@@ -59,7 +59,7 @@ module {
 // CHECK:             %[[VAL_23:.*]] = arith.index_cast %[[VAL_22]] : index to i32
 // CHECK:             linalg.yield %[[VAL_23]] : i32
 // CHECK:           } -> tensor<128xi32>
-// CHECK:           %[[VAL_24:.*]] = tensor.expand_shape %[[VAL_25:.*]] {{\[\[}}0, 1]] : tensor<128xi32> into tensor<1x128xi32>
+// CHECK:           %[[VAL_24:.*]] = tensor.expand_shape %[[VAL_25:.*]] {{\[\[}}0, 1]] output_shape [1, 128] : tensor<128xi32> into tensor<1x128xi32>
 // CHECK:           %[[VAL_26:.*]] = tensor.empty() : tensor<256x128xi32>
 // CHECK:           %[[VAL_27:.*]] = linalg.generic {indexing_maps = [#map3, #map2], iterator_types = ["parallel", "parallel"]} ins(%[[VAL_24]] : tensor<1x128xi32>) outs(%[[VAL_26]] : tensor<256x128xi32>) attrs =  {broadcastDims = array<i64: 0>} {
 // CHECK:           ^bb0(%[[VAL_28:.*]]: i32, %[[VAL_29:.*]]: i32):

--- a/test/Conversion/TritonToLinalg/use_mid_chain.mlir
+++ b/test/Conversion/TritonToLinalg/use_mid_chain.mlir
@@ -45,7 +45,7 @@ module {
 // CHECK:             %[[VAL_12:.*]] = arith.index_cast %[[VAL_11]] : index to i32
 // CHECK:             linalg.yield %[[VAL_12]] : i32
 // CHECK:           } -> tensor<256xi32>
-// CHECK:           %[[VAL_13:.*]] = tensor.expand_shape %[[VAL_14:.*]] {{\[\[}}0, 1]] : tensor<256xi32> into tensor<256x1xi32>
+// CHECK:           %[[VAL_13:.*]] = tensor.expand_shape %[[VAL_14:.*]] {{\[\[}}0, 1]] output_shape [256, 1] : tensor<256xi32> into tensor<256x1xi32>
 // CHECK:           %[[VAL_15:.*]] = tensor.empty() : tensor<256x128xi32>
 // CHECK:           %[[VAL_16:.*]] = linalg.generic {indexing_maps = [#map1, #map2], iterator_types = ["parallel", "parallel"]} ins(%[[VAL_13]] : tensor<256x1xi32>) outs(%[[VAL_15]] : tensor<256x128xi32>) attrs =  {broadcastDims = array<i64: 1>} {
 // CHECK:           ^bb0(%[[VAL_17:.*]]: i32, %[[VAL_18:.*]]: i32):

--- a/tools/RegisterTritonSharedDialects.h
+++ b/tools/RegisterTritonSharedDialects.h
@@ -36,7 +36,7 @@ void registerTestMembarPass();
 inline void registerTritonSharedDialects(mlir::DialectRegistry &registry) {
   mlir::registerAllPasses();
   mlir::registerTritonPasses();
-  mlir::registerTritonGPUPasses();
+  mlir::triton::gpu::registerTritonGPUPasses();
   mlir::registerLinalgPasses();
   mlir::test::registerTestAliasPass();
   mlir::test::registerTestAlignmentPass();


### PR DESCRIPTION
- instance methods `.dyn_cast`, `.cast`, `.isa` are all deprecated
- point the triton submodule from `openai/triton` to `triton-lang/triton`
- update lit tests containing `tensor.expand_shape`

Fixes #134 