### PR TITLE
User-friendly way to initialize the submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "triton"]
 	path = triton
-	url = ../../triton-lang/triton.git
+	url = https://github.com/triton-lang/triton.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "triton"]
 	path = triton
-	url = git@github.com:triton-lang/triton.git
+	url = ../../triton-lang/triton.git


### PR DESCRIPTION
Original line from the documentation:

```
git clone --recurse-submodules https://github.com/microsoft/triton-shared.git triton_shared
```
uses https to clone triton_shared, while "git@" is used explicitly by the submodule configuration which makes it fail if "git@" is not configured properly, for example, no key added.

Removing the protocol and changing the url to relative resolves this issue.

Thank you!