### PR TITLE
Implement missing triton operations

### DIFF
--- a/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
+++ b/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
@@ -898,12 +898,7 @@ struct ClampConverter : public OpConversionPattern<triton::ClampFOp> {
   LogicalResult
   matchAndRewrite(triton::ClampFOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    bool propagateNan = true;
-
-    auto propagateNanAttr = op.getPropagateNan();
-    if (propagateNanAttr.has_value()) {
-      propagateNan = propagateNanAttr.value() == triton::PropagateNan::ALL;
-    }
+    bool propagateNan = op.getPropagateNan() == triton::PropagateNan::ALL;
 
     assert(propagateNan &&
            "PropagateNan=false is not supported");

--- a/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
+++ b/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
@@ -136,8 +136,13 @@ static Value getTransposedValue(Value source, const Location loc,
 
 // for IntLike and FloatLike types
 static std::optional<unsigned> getBitWidth(Type a) {
-  if (auto type = dyn_cast<TensorType>(a))
-    return type.getElementType().getIntOrFloatBitWidth();
+  if (auto type = dyn_cast<TensorType>(a)) {
+    auto elementType = type.getElementType();
+    if (elementType.isIntOrFloat()) {
+      return type.getElementType().getIntOrFloatBitWidth();
+    }
+    return std::nullopt;
+  }
 
   if (a.isIntOrFloat())
     return a.getIntOrFloatBitWidth();

--- a/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
+++ b/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
@@ -863,8 +863,9 @@ struct FpToFpConverter : public OpConversionPattern<triton::FpToFpOp> {
                   ConversionPatternRewriter &rewriter) const override {
     auto roundingMode = triton::RoundingMode::RTNE; // default
 
-    if (auto roundingModeAttr = op.getRounding()) {
-      roundingMode = roundingModeAttr.getValue();
+    auto roundingModeAttr = op.getRounding();
+    if (roundingModeAttr.has_value()) {
+      roundingMode = roundingModeAttr.value();
     }
 
     assert(roundingMode != triton::RoundingMode::RTZ &&
@@ -897,14 +898,15 @@ struct ClampConverter : public OpConversionPattern<triton::ClampFOp> {
   LogicalResult
   matchAndRewrite(triton::ClampFOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    bool propagateNan = false;
+    bool propagateNan = true;
 
-    if (auto propagateNanAttr = op.getPropagateNan()) {
-      propagateNan = propagateNanAttr.getValue() == triton::PropagateNan::ALL;
+    auto propagateNanAttr = op.getPropagateNan();
+    if (propagateNanAttr.has_value()) {
+      propagateNan = propagateNanAttr.value() == triton::PropagateNan::ALL;
     }
 
-    assert(!propagateNan &&
-           "PropagateNan is not supported");
+    assert(propagateNan &&
+           "PropagateNan=false is not supported");
 
     Location loc = op.getLoc();
     Value x = adaptor.getOperands()[0];

--- a/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
+++ b/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
@@ -900,8 +900,8 @@ struct ClampConverter : public OpConversionPattern<triton::ClampFOp> {
                   ConversionPatternRewriter &rewriter) const override {
     bool propagateNan = op.getPropagateNan() == triton::PropagateNan::ALL;
 
-    assert(propagateNan &&
-           "PropagateNan=false is not supported");
+    assert(!propagateNan &&
+           "PropagateNan is not supported");
 
     Location loc = op.getLoc();
     Value x = adaptor.getOperands()[0];

--- a/lib/Conversion/TritonArithToLinalg/TritonArithToLinalg.cpp
+++ b/lib/Conversion/TritonArithToLinalg/TritonArithToLinalg.cpp
@@ -60,6 +60,10 @@ void mlir::triton::populateTritonArithToLinalgConversionPatterns(
   patterns.add<ExpandDimsConverter>(patterns.getContext());
   patterns.add<BitcastConverter>(patterns.getContext());
   patterns.add<MulHiUIOpConverter>(patterns.getContext());
+  patterns.add<PreciseSqrtConverter>(patterns.getContext());
+  patterns.add<PreciseDivConverter>(patterns.getContext());
+  patterns.add<FpToFpConverter>(patterns.getContext());
+  patterns.add<ClampConverter>(patterns.getContext());
   patterns.add<MatmulConverter>(patterns.getContext());
   patterns.add<SplatConverter>(patterns.getContext());
   patterns.add<DenseConstantConverter>(patterns.getContext());

--- a/lib/Conversion/TritonToLinalg/TritonToLinalg.cpp
+++ b/lib/Conversion/TritonToLinalg/TritonToLinalg.cpp
@@ -50,6 +50,10 @@ void mlir::triton::populateTritonToLinalgConversionPatterns(
   patterns.add<ExpandDimsConverter>(patterns.getContext());
   patterns.add<BitcastConverter>(patterns.getContext());
   patterns.add<MulHiUIOpConverter>(patterns.getContext());
+  patterns.add<PreciseSqrtConverter>(patterns.getContext());
+  patterns.add<PreciseDivConverter>(patterns.getContext());
+  patterns.add<FpToFpConverter>(patterns.getContext());
+  patterns.add<ClampConverter>(patterns.getContext());
   patterns.add<AssertConverter>(patterns.getContext());
   patterns.add<MatmulConverter>(patterns.getContext());
   patterns.add<SplatConverter>(patterns.getContext());

--- a/python/examples/conftest.py
+++ b/python/examples/conftest.py
@@ -41,7 +41,6 @@ tests_not_supported = {
     "test_slice",
     "test_where",
     "test_math_erf_op",
-    "test_precise_math",
     "test_abs_fp8",
     "test_shapes_as_params",
     "test_transpose",
@@ -79,7 +78,6 @@ tests_not_supported = {
     "test_convertmma2mma",
     "test_dot_max_num_imprecise_acc",
     "test_propagate_nan",
-    "test_clamp",
     "test_clamp_symmetric",
     "test_temp_var_in_loop",
     "test_math_extern"


### PR DESCRIPTION
Tests depend on https://github.com/microsoft/triton-shared/pull/158, once it is merged, I will remove test_precise_math and test_clamp from unsupported list.