### PR TITLE
Add preliminary support for sign-extend ops in `PtrAnalysis` and `MaskAnalysis`

### DIFF
--- a/include/triton-shared/Analysis/MaskAnalysis.h
+++ b/include/triton-shared/Analysis/MaskAnalysis.h
@@ -12,6 +12,7 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 
+#include "mlir/Support/LogicalResult.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 
 #include <utility>
@@ -58,9 +59,8 @@ struct MaskState {
   // defining operation and Value type
   LogicalResult parse(Value operand, const Location loc, OpBuilder &builder);
 
-  tensor::ExtractSliceOp
-  getExtractSlice(Value source, const Location loc,
-                  OpBuilder &builder) const;
+  tensor::ExtractSliceOp getExtractSlice(Value source, const Location loc,
+                                         OpBuilder &builder) const;
 
   memref::SubViewOp getSubview(Value source, const Location loc,
                                OpBuilder &builder) const;
@@ -89,6 +89,9 @@ private:
   // -------
   // Helper functions to parse values to populate MaskState
   // -------
+
+  LogicalResult parseExtSI(arith::ExtSIOp op, const Location loc,
+                           OpBuilder &builder);
 
   // Operand is the result of a constant
   // Get the value of the constant and assign it to scalar.

--- a/include/triton-shared/AnalysisStructured/PtrAnalysis.h
+++ b/include/triton-shared/AnalysisStructured/PtrAnalysis.h
@@ -194,6 +194,9 @@ public:
   LogicalResult visitOperandConstSplat(arith::ConstantOp op, PtrState &state,
                                        const Location loc, OpBuilder &builder);
 
+  LogicalResult visitOperandExtSI(arith::ExtSIOp, PtrState &state,
+                                  const Location loc, OpBuilder &builder);
+
   // Operand is the result of addptr.
   // Main assumptions:
   //  The ptr field should populate the source field

--- a/lib/Analysis/OpFoldResultUtils.cpp
+++ b/lib/Analysis/OpFoldResultUtils.cpp
@@ -8,6 +8,8 @@
 #include "triton-shared/Analysis/OpFoldResultUtils.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/Transforms/DialectConversion.h"
 
@@ -49,7 +51,10 @@ bool hasConstZero(const OpFoldResult ofr) {
 Value ofrToIndexValue(const OpFoldResult ofr, const Location loc,
                       OpBuilder &b) {
   if (Value val = dyn_cast<Value>(ofr)) {
-    assert(val.getType().isIndex() && "Provided ofr is of type index");
+    assert(val.getType().isIntOrIndex());
+    if (!val.getType().isIndex()) {
+      val = b.create<arith::IndexCastOp>(loc, b.getIndexType(), val);
+    }
     return val;
   }
 

--- a/lib/AnalysisStructured/PtrAnalysis.cpp
+++ b/lib/AnalysisStructured/PtrAnalysis.cpp
@@ -6,6 +6,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "triton-shared/AnalysisStructured/PtrAnalysis.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -419,6 +420,14 @@ LogicalResult PtrAnalysis::visitOperandRem(arith::RemSIOp remOp,
   return success();
 }
 
+LogicalResult PtrAnalysis::visitOperandExtSI(arith::ExtSIOp extOp,
+                                             PtrState &state,
+                                             const Location loc,
+                                             OpBuilder &builder) {
+  assert(state.isEmpty());
+  return visitOperand(extOp.getIn(), state, loc, builder);
+}
+
 LogicalResult PtrAnalysis::visitOperandMakeRange(triton::MakeRangeOp rangeOp,
                                                  PtrState &state, Location loc,
                                                  OpBuilder &builder) {
@@ -746,6 +755,8 @@ LogicalResult PtrAnalysis::visitOperand(Value operand, PtrState &state,
     return visitOperandConstSplat(op, state, loc, builder);
   } else if (auto op = operand.getDefiningOp<arith::RemSIOp>()) {
     return visitOperandRem(op, state, loc, builder);
+  } else if (auto op = operand.getDefiningOp<arith::ExtSIOp>()) {
+    return visitOperandExtSI(op, state, loc, builder);
   } else if (auto op = operand.getDefiningOp<scf::ForOp>()) {
     return visitOperandForOp(op, operand, state, loc, builder);
   } else if (!operand.getDefiningOp()) {

--- a/python/examples/test_sign_extend.py
+++ b/python/examples/test_sign_extend.py
@@ -1,0 +1,39 @@
+import torch
+
+import triton
+
+import triton.language as tl
+
+from triton.backends.triton_shared.driver import CPUDriver
+
+@triton.jit
+def sign_extend(off, in0, out0, in0_size):
+    offset = tl.load(off).to(tl.int64)
+    offsets = offset + tl.arange(0, 4)
+    a = tl.load(in0 + offsets, mask=offsets < in0_size, other=11)
+    tl.store(out0 + tl.arange(0, 4), a)
+
+def compile():
+    src = triton.compiler.ASTSource(
+        fn=sign_extend,
+        signature="*i32,*fp32,*fp32,i32",
+    )
+    ret = triton.compile(
+        src,
+    )
+    print(ret.asm["ttir"])
+
+def test_sign_extend(device):
+    if device == 'cpu':
+        triton.runtime.driver.set_active(CPUDriver())
+
+    SIZE = 4
+    offsets = torch.full((1, ), 1, device=device, dtype=torch.int32)
+    input = torch.arange(0, SIZE, device=device, dtype=torch.int32)
+    output = torch.full((SIZE,), -1, device=device, dtype=torch.int32)
+    grid = lambda meta: (1,)
+    print(output)
+    sign_extend[grid](offsets, input, output, SIZE)
+    print(input)
+    print(output)
+    torch.testing.assert_close(torch.tensor([1, 2, 3, 11], device=device, dtype=torch.int32), output)

--- a/test/Conversion/TritonToStructured/sign_extend_i32_to_i64.mlir
+++ b/test/Conversion/TritonToStructured/sign_extend_i32_to_i64.mlir
@@ -1,0 +1,39 @@
+// RUN: triton-shared-opt --triton-to-structured --canonicalize --cse %s | FileCheck %s
+// IR from python/examples/sign_extend.py
+module {
+  tt.func public @sign_extend(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<f32>, %arg2: !tt.ptr<f32>, %arg3: i32) attributes {noinline = false} {
+    %cst = arith.constant dense<1.100000e+01> : tensor<4xf32>
+    %0 = tt.load %arg0 : !tt.ptr<i32>
+    %1 = arith.extsi %0 : i32 to i64
+    %2 = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32>
+    %3 = arith.extsi %2 : tensor<4xi32> to tensor<4xi64>
+    %4 = tt.splat %1 : i64 -> tensor<4xi64>
+    %5 = arith.addi %4, %3 : tensor<4xi64>
+    %6 = arith.extsi %arg3 : i32 to i64
+    %7 = tt.splat %6 : i64 -> tensor<4xi64>
+    %8 = arith.cmpi slt, %5, %7 : tensor<4xi64>
+    %9 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %10 = tt.addptr %9, %5 : tensor<4x!tt.ptr<f32>>, tensor<4xi64>
+    %11 = tt.load %10, %8, %cst : tensor<4x!tt.ptr<f32>>
+    %12 = tt.splat %arg2 : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+    %13 = tt.addptr %12, %2 : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
+    tt.store %13, %11 : tensor<4x!tt.ptr<f32>>
+    tt.return
+  }
+}
+
+// CHECK:         tt.func public @sign_extend([[arg0_:.+]]: !tt.ptr<i32>, [[arg1_:.+]]: !tt.ptr<f32>, [[arg2_:.+]]: !tt.ptr<f32>, [[arg3_:.+]]: i32) attributes {noinline = false} {
+// CHECK-DAG:       [[CST_1_dot_100000_:%.+]] = arith.constant 1.100000e+01 : f32
+// CHECK-DAG:       [[CST_4_:%.+]] = arith.constant 4 : index
+// CHECK-DAG:       [[LOAD_arg0_MEM_:%.+]] = tt.load [[arg0_]] : !tt.ptr<i32>
+// CHECK:           [[VAR_1_:%.+]] = arith.index_cast [[LOAD_arg0_MEM_]] : i32 to index
+// CHECK-DAG:       [[VAR_2_:%.+]] = tts.make_tptr [[arg1_]] to sizes: [4], strides: [1], offsets: {{.}}[[VAR_1_]]{{.}}, shape: [0], order: [] : <f32> to tensor<4x!tt.ptr<f32>>
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.addi [[VAR_1_]], [[CST_4_]] : index
+// CHECK-DAG:       [[VAR_4_:%.+]] = arith.index_cast [[arg3_]] : i32 to index
+// CHECK:           [[VAR_5_:%.+]] = arith.minsi [[VAR_3_]], [[VAR_4_]] : index
+// CHECK:           [[VAR_6_:%.+]] = arith.subi [[VAR_5_]], [[VAR_1_]] : index
+// CHECK-DAG:       [[VAR_7_:%.+]] = "tts.load"([[VAR_2_]], [[VAR_6_]], [[CST_1_dot_100000_]]) <{operandSegmentSizes = array<i32: 1, 1, 1>, static_mask_dims = array<i64: -9223372036854775808>}> : (tensor<4x!tt.ptr<f32>>, index, f32) -> tensor<4xf32>
+// CHECK-DAG:       [[VAR_8_:%.+]] = tts.make_tptr [[arg2_]] to sizes: [4], strides: [1], offsets: [0], shape: [0], order: [] : <f32> to tensor<4x!tt.ptr<f32>>
+// CHECK:           "tts.store"([[VAR_8_]], [[VAR_7_]]) <{static_mask_dims = array<i64>}> : (tensor<4x!tt.ptr<f32>>, tensor<4xf32>) -> ()
+// CHECK:           tt.return
+// CHECK:         }


### PR DESCRIPTION
This PR adds limited support for sign-extend ops in `PtrAnalysis` and `MaskAnalysis`.

For simplicity, we assume results of the pointer arithmetic operations do not overflow the current platform's native bit-width. This assumption is necessary because most of the memref and tensor related operands use the `index` type whose width, according to the mlir documentation, is platform specific.

Then, we simply need to compute the pointer and mask states using the value whose sign is being extended (i.e.: the visitor of the sign-extend op is just simply forwarding the input operand to its appropriate visitor).

We will revisit the possibility of overflow in the future.