### PR TITLE
Lower cumsum on integer types

### DIFF
--- a/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
+++ b/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
@@ -1741,10 +1741,6 @@ struct DenseConstantConverter : public OpConversionPattern<arith::ConstantOp> {
 class CumSumConverter : public OpConversionPattern<triton::ScanOp> {
   using OpConversionPattern<triton::ScanOp>::OpConversionPattern;
 
-  bool isAddOp(Operation *op) const {
-    return isa<arith::AddFOp, arith::AddIOp>(op);
-  }
-
   // CumSum is a specific instance of Scan that looks like the following:
   //       %1 = "tt.scan"(%0) <{axis = 1 : i32}> ({
   //       ^bb0(%arg0: f32, %arg1: f32):
@@ -1761,7 +1757,7 @@ class CumSumConverter : public OpConversionPattern<triton::ScanOp> {
     }
 
     auto addOp = ops.front();
-    if (isAddOp(addOp)) {
+    if (isa<arith::AddFOp, arith::AddIOp>(addOp)) {
       if (addOp->getResult(0) != scanBlock->getTerminator()->getOperand(0)) {
         return false;
       }


### PR DESCRIPTION
We previously only pattern match `tt.scan` op containing an `arith.addf`. Add support for `arith.addi` as well.