### PR TITLE
Fix build failure in issues #178

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,9 @@ set(TRITON_SHARED_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/include) # Tablegen'd files
+include_directories(${Python3_INCLUDE_DIR})
+include_directories(${pybind11_INCLUDE_DIR})
+
 add_subdirectory(include)
 add_subdirectory(lib)
 add_subdirectory(test)

--- a/backend/compiler.py
+++ b/backend/compiler.py
@@ -139,6 +139,7 @@ class CPUOptions:
     shared: bool = False
     allow_fp8e4nv: bool = False
     allowed_dot_input_precisions: Tuple[str] = ("ieee", )
+    sanitize_overflow: bool = True
 
     def __post_init__(self):
         pass

--- a/backend/compiler.py
+++ b/backend/compiler.py
@@ -137,6 +137,9 @@ class CPUOptions:
     extern_libs = None
     cluster_dims: tuple = (1, 1, 1)
     shared: bool = False
+    # Disable FP8 here since this is a sample CPU backend.
+    # Target specific backends can eanble it with supported types.
+    supported_fp8_dtypes: Tuple[str] = ()
     allow_fp8e4nv: bool = False
     allowed_dot_input_precisions: Tuple[str] = ("ieee", )
     sanitize_overflow: bool = True

--- a/backend/driver.py
+++ b/backend/driver.py
@@ -347,6 +347,10 @@ class CPUDriver(DriverBase):
     def is_active():
         return False
 
+    def get_benchmarker(self):
+        from triton.testing import do_bench
+        return do_bench
+
     def get_device_capability(self):
         return ("cpu", 0)
 

--- a/backend/driver.py
+++ b/backend/driver.py
@@ -369,5 +369,9 @@ class CPUDriver(DriverBase):
     def get_current_target(self):
         return GPUTarget("cpu", 0, 0)
 
+    def get_active_torch_device(self):
+        import torch
+        return torch.device("cpu")
+
     def assemble_tensormap_to_arg(self, tensormaps_info, args):
         return args

--- a/include/triton-shared/AnalysisStructured/PtrAnalysis.h
+++ b/include/triton-shared/AnalysisStructured/PtrAnalysis.h
@@ -264,6 +264,9 @@ public:
 
   LogicalResult rewriteStoreOp(triton::StoreOp op, bool useUnsafeMask = false);
 
+  // Only rewrite if a scalar ptr is splated into a tensor of ptr
+  LogicalResult rewriteSplatOp(triton::SplatOp op);
+
   LogicalResult rewriteOp(Operation *op, bool useUnsafeMask = false);
 };
 

--- a/include/triton-shared/AnalysisStructured/PtrAnalysis.h
+++ b/include/triton-shared/AnalysisStructured/PtrAnalysis.h
@@ -264,9 +264,6 @@ public:
 
   LogicalResult rewriteStoreOp(triton::StoreOp op, bool useUnsafeMask = false);
 
-  // Only rewrite if a scalar ptr is splated into a tensor of ptr
-  LogicalResult rewriteSplatOp(triton::SplatOp op);
-
   LogicalResult rewriteOp(Operation *op, bool useUnsafeMask = false);
 };
 

--- a/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
+++ b/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
@@ -837,7 +837,7 @@ struct AssertConverter : public OpConversionPattern<triton::AssertOp> {
     }
 
     auto assertMessage =
-        llvm::formatv("{0}.py:{1}: {2} Assertion `{3}` failed", op.getMessage());
+        llvm::formatv("Assertion `{0}` failed", op.getMessage());
     rewriter.create<mlir::cf::AssertOp>(op.getLoc(), condVal,
                                         assertMessage.str());
 

--- a/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
+++ b/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
@@ -837,8 +837,7 @@ struct AssertConverter : public OpConversionPattern<triton::AssertOp> {
     }
 
     auto assertMessage =
-        llvm::formatv("{0}.py:{1}: {2} Assertion `{3}` failed", op.getFile(),
-                      op.getLine(), op.getFunc(), op.getMessage());
+        llvm::formatv("{0}.py:{1}: {2} Assertion `{3}` failed", op.getMessage());
     rewriter.create<mlir::cf::AssertOp>(op.getLoc(), condVal,
                                         assertMessage.str());
 

--- a/lib/AnalysisStructured/PtrAnalysis.cpp
+++ b/lib/AnalysisStructured/PtrAnalysis.cpp
@@ -1058,7 +1058,7 @@ LogicalResult PtrAnalysis::rewriteLoadOp(triton::LoadOp op,
   auto loc = op.getLoc();
 
   if (!ptr) {
-    op->emitRemark("PtrAnalysis: pointer is not replace with tts.make_tptr so "
+    op->emitRemark("PtrAnalysis: pointer is not replaced with tts.make_tptr so "
                    "loadOp cannot be rewritten");
     return failure();
   }
@@ -1195,7 +1195,7 @@ LogicalResult PtrAnalysis::rewriteStoreOp(triton::StoreOp op,
   auto loc = op.getLoc();
 
   if (!ptr) {
-    op->emitRemark("PtrAnalysis: pointer is not replace with tts.make_tptr so "
+    op->emitRemark("PtrAnalysis: pointer is not replaced with tts.make_tptr so "
                    "storeOp cannot be rewritten");
     return failure();
   }
@@ -1229,6 +1229,30 @@ LogicalResult PtrAnalysis::rewriteStoreOp(triton::StoreOp op,
   });
 
   op->erase();
+  return success();
+}
+
+LogicalResult PtrAnalysis::rewriteSplatOp(triton::SplatOp op) {
+  if (isa<triton::PointerType>(op.getSrc().getType())) {
+    LLVM_DEBUG({
+      llvm::dbgs() << "SplatOp has ptr-typed src: " << op.getSrc()
+	           << "\nsplatted into type: " << op.getType() << "\n";
+    });
+
+    OpBuilder builder(op);
+    PtrState state;
+    if (visitOperandSplat(op, state, op.getLoc(), builder).failed())
+      return failure();
+
+    knownPtrs[op.getResult()] = state;
+
+    if (isa<RankedTensorType>(op.getResult().getType())) {
+      auto maketptrOp = state.createTTSMakeTensorPtrOp(builder, op.getLoc());
+      ptrMap.map(op.getResult(), maketptrOp.getResult());
+    } else {
+      ptrMap.map(op.getResult(), op.getResult());
+    }
+  }
   return success();
 }
 
@@ -1276,6 +1300,13 @@ LogicalResult PtrAnalysis::rewriteOp(Operation *rootOp, bool useUnsafeMask) {
           }
           return WalkResult::skip();
         })
+	.Case<triton::SplatOp>([&](auto splat) {
+          if (rewriteSplatOp(splat).failed()) {
+            splat->emitRemark("PtrAnalysis: Failed rewrite SplatOp");
+            return WalkResult::advance();
+	  }
+          return WalkResult::skip();
+	})
         .Case<scf::ForOp>([&](auto forOp) {
           // `rewriteForOp` recursively visits its children, so regardless
           // whether the rewrite succeeds or not, we need to return "skip" so

--- a/lib/Conversion/StructuredToMemref/StructuredToMemref.cpp
+++ b/lib/Conversion/StructuredToMemref/StructuredToMemref.cpp
@@ -177,8 +177,9 @@ private:
         /* result shape */
         SmallVector<int64_t>{
 
-            // Row stays the same
-            resultShape[0],
+            // Row stays the same, but mlir doesn't allow this anymore. Put
+            // dynamic.
+            ShapedType::kDynamic,
 
             // Column is dynamic, in most cases, this
             // should be the same as the original column.
@@ -286,9 +287,9 @@ private:
             // around.
             ShapedType::kDynamic,
 
-            // Col stays the same.
-            resultShape[1],
-        });
+            // Col stays the same, which is resultShape[1], but mlir doesn't
+            // allow this anymore. So we put dynamic instead.
+            ShapedType::kDynamic});
 
     Value rowSize = rewriter.create<arith::ConstantOp>(
         loc, rewriter.getIndexAttr(op.getSizes()[0]));

--- a/lib/Conversion/StructuredToMemref/StructuredToMemrefPass.cpp
+++ b/lib/Conversion/StructuredToMemref/StructuredToMemrefPass.cpp
@@ -99,14 +99,14 @@ public:
 
     addSourceMaterialization([&](OpBuilder &builder, Type resultType,
                                  ValueRange inputs,
-                                 Location loc) -> std::optional<Value> {
+                                 Location loc) -> Value {
       return builder.create<UnrealizedConversionCastOp>(loc, resultType, inputs)
           .getResult(0);
     });
 
     addArgumentMaterialization([&](OpBuilder &builder, Type resultType,
                                    ValueRange inputs,
-                                   Location loc) -> std::optional<Value> {
+                                   Location loc) -> Value {
       return builder.create<UnrealizedConversionCastOp>(loc, resultType, inputs)
           .getResult(0);
     });
@@ -123,7 +123,7 @@ public:
     addTargetMaterialization([&](OpBuilder &builder,
                                  UnrankedMemRefType resultType,
                                  ValueRange inputs,
-                                 Location loc) -> std::optional<Value> {
+                                 Location loc) -> Value {
       return builder.create<UnrealizedConversionCastOp>(loc, resultType, inputs)
           .getResult(0);
     });

--- a/lib/Conversion/StructuredToMemref/StructuredToMemrefPass.cpp
+++ b/lib/Conversion/StructuredToMemref/StructuredToMemrefPass.cpp
@@ -84,7 +84,7 @@ public:
     // reinterpret_cast.
     addTargetMaterialization([&](OpBuilder &builder, MemRefType memrefType,
                                  ValueRange inputs,
-                                 Location loc) -> std::optional<Value> {
+                                 Location loc) -> Value {
       auto reinterpretCast =
           inputs[0].getDefiningOp<memref::ReinterpretCastOp>();
       if (!reinterpretCast) {

--- a/lib/Conversion/TritonPtrToMemref/TritonPtrToMemrefPass.cpp
+++ b/lib/Conversion/TritonPtrToMemref/TritonPtrToMemrefPass.cpp
@@ -61,7 +61,7 @@ public:
 
     auto createUnrealizedCast = [&](OpBuilder &builder, Type resultType,
                                     ValueRange inputs,
-                                    Location loc) -> std::optional<Value> {
+                                    Location loc) -> Value {
       return builder.create<UnrealizedConversionCastOp>(loc, resultType, inputs)
           .getResult(0);
     };

--- a/lib/Conversion/TritonToStructured/TritonToStructuredPass.cpp
+++ b/lib/Conversion/TritonToStructured/TritonToStructuredPass.cpp
@@ -74,7 +74,7 @@ public:
     RewritePatternSet patterns(&getContext());
 
     auto context = &getContext();
-    OneToNTypeConverter converter;
+    TypeConverter converter;
     converter.addConversion([](Type type) { return type; });
 
     // We are doing a 1->1 type conversion here, where a triton pointer type
@@ -145,10 +145,10 @@ public:
     // Compute the target materialization, given a value with the pointer type,
     // convert that value to a tuple type.
     converter.addTargetMaterialization(
-        [](OpBuilder &builder, TypeRange resultTypes, Value input,
-           Location loc) -> std::optional<SmallVector<Value>> {
+        [](OpBuilder &builder, TypeRange resultTypes, ValueRange inputs,
+           Location loc) -> SmallVector<Value> {
           return builder
-              .create<UnrealizedConversionCastOp>(loc, resultTypes, input)
+              .create<UnrealizedConversionCastOp>(loc, resultTypes, inputs.front())
               ->getResults();
         });
 
@@ -172,7 +172,7 @@ public:
     auto moduleOp = getOperation();
 
     auto context = &getContext();
-    OneToNTypeConverter converter;
+    TypeConverter converter;
     converter.addConversion([](Type type) { return type; });
 
     // We are doing a 1->N type conversion here, where a pointer tuple type
@@ -208,10 +208,10 @@ public:
     // At the end of pointer analysis, we will use the PtrState to create the
     // correct offsets, strides, and remove these ops.
     converter.addTargetMaterialization([](OpBuilder &builder,
-                                          TypeRange resultTypes, Value input,
+                                          TypeRange resultTypes, ValueRange inputs,
                                           Location loc) {
       auto placeholder = builder.create<tts::GetStructuredStateOp>(
-          loc, input.getDefiningOp()->getOperand(0));
+          loc, inputs.front().getDefiningOp()->getOperand(0));
       assert(llvm::equal(placeholder.getResultTypes(), resultTypes));
       return placeholder.getResults();
     });

--- a/lib/Conversion/UnstructuredToMemref/UnstructuredToMemrefPass.cpp
+++ b/lib/Conversion/UnstructuredToMemref/UnstructuredToMemrefPass.cpp
@@ -53,7 +53,7 @@ public:
     addTargetMaterialization([&](OpBuilder &builder,
                                  UnrankedMemRefType resultType,
                                  ValueRange inputs,
-                                 Location loc) -> std::optional<Value> {
+                                 Location loc) -> Value {
       return builder.create<UnrealizedConversionCastOp>(loc, resultType, inputs)
           .getResult(0);
     });

--- a/python/examples/conftest.py
+++ b/python/examples/conftest.py
@@ -71,12 +71,32 @@ tests_not_supported = {
     "test_if",
     "test_if_call",
     "test_convert2d",
-    "test_convertmma2mma",
     "test_dot_max_num_imprecise_acc",
     "test_propagate_nan",
     "test_clamp_symmetric",
     "test_temp_var_in_loop",
-    "test_math_extern"
+    "test_math_extern",
+    # attribute 'launch_cooperative_grid' not supported
+    "test_load_scope_sem_coop_grid_cta_one",
+    # fp8 support on CPUs is unclear
+    "test_scaled_dot",
+    # triton-shared-opt failures:
+    # PtrAnalysis: encountered addptr operand produced by an unsupported operation
+    "test_chained_reductions",
+    # failed to legalize unresolved materialization
+    "test_constexpr_if_return",
+    "test_unroll_attr",
+    # Dialect `ub' not found for custom op 'ub.poison'
+    "test_poison_return",
+    # tt.gather not supported yet
+    "test_gather",
+    "test_gather_warp_shuffle",
+    # device 'cpu' does not have 'index
+    "test_zero_strided_tensors",
+    # hard-coded with 'ttg' attributes
+    "test_convert_mma2mma",
+    "test_local_load_store",
+    "test_local_load_store_mma"
 }
 
 # probably different version of MLIR on the nightly build machine is complaining

--- a/python/examples/test_reduce.py
+++ b/python/examples/test_reduce.py
@@ -44,8 +44,12 @@ def test(device):
     # TODO: need to check some conditions otherwise the code below does not make any difference for the test
     src = triton.compiler.ASTSource(
         fn=reduce_kernel_2d,
-        signature="*fp32,*fp32,i32,i32",
-        constants={"BLOCK_SIZE": 32}
+        signature={"x_ptr": "*fp32",
+                   "output_ptr": "*fp32",
+                   "stride": "i32",
+                   "n_elements": "i32",
+                   "BLOCK_SIZE": "constexpr"},
+        constexprs={"BLOCK_SIZE": 32}
     )
     ret = triton.compile(
         src,

--- a/test/Conversion/StructuredToMemref/convert_tensor_reshape.mlir
+++ b/test/Conversion/StructuredToMemref/convert_tensor_reshape.mlir
@@ -13,9 +13,9 @@ module {
     %8 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<32x!tt.ptr<f32>>
     %9 = tt.addptr %8, %4 : tensor<32x!tt.ptr<f32>>, tensor<32xi32>
     %10 = tt.load %9 : tensor<32x!tt.ptr<f32>>
-    %11 = tt.reshape %10 {allow_reorder = false} : tensor<32xf32> -> tensor<1x32xf32>
+    %11 = tt.reshape %10 allow_reorder : tensor<32xf32> -> tensor<1x32xf32>
     %12 = tt.broadcast %11 : tensor<1x32xf32> -> tensor<64x32xf32>
-    %13 = tt.reshape %12 {allow_reorder = false} : tensor<64x32xf32> -> tensor<2048xf32>
+    %13 = tt.reshape %12 allow_reorder : tensor<64x32xf32> -> tensor<2048xf32>
     %14 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<2048x!tt.ptr<f32>>
     %15 = tt.addptr %14, %7 : tensor<2048x!tt.ptr<f32>>, tensor<2048xi32>
     tt.store %15, %13 : tensor<2048x!tt.ptr<f32>>

--- a/test/Conversion/StructuredToMemref/get_num_programs.mlir
+++ b/test/Conversion/StructuredToMemref/get_num_programs.mlir
@@ -24,14 +24,13 @@ module {
 
 // CHECK-LABEL:  func.func @num_programs
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xi32>, [[PARAM_1_:%.+]]: i32, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32) {
-// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
 // CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : index
 // CHECK-DAG:       [[CST_2_:%.+]] = arith.constant 2 : index
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[CST_0_]]{{.}}, sizes: [1], strides: [1] : memref<*xi32> to memref<1xi32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [1], strides: [1] : memref<*xi32> to memref<1xi32, strided<[1]>>
 // CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<1xi32>
 // CHECK:           [[VAR_1_:%.+]] = linalg.fill ins([[PARAM_1_]] : i32) outs([[VAR_0_]] : tensor<1xi32>) -> tensor<1xi32>
-// CHECK:           bufferization.materialize_in_destination [[VAR_1_]] in writable [[VAR_reinterpret_cast_]] : (tensor<1xi32>, memref<1xi32, strided<[1], offset: ?>>) -> ()
+// CHECK:           bufferization.materialize_in_destination [[VAR_1_]] in writable [[VAR_reinterpret_cast_]] : (tensor<1xi32>, memref<1xi32, strided<[1]>>) -> ()
 // CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[CST_1_]]{{.}}, sizes: [1], strides: [1] : memref<*xi32> to memref<1xi32, strided<[1], offset: ?>>
 // CHECK-DAG:       [[VAR_2_:%.+]] = linalg.fill ins([[PARAM_2_]] : i32) outs([[VAR_0_]] : tensor<1xi32>) -> tensor<1xi32>
 // CHECK:           bufferization.materialize_in_destination [[VAR_2_]] in writable [[VAR_reinterpret_cast_0_]] : (tensor<1xi32>, memref<1xi32, strided<[1], offset: ?>>) -> ()

--- a/test/Conversion/StructuredToMemref/get_num_programs.mlir
+++ b/test/Conversion/StructuredToMemref/get_num_programs.mlir
@@ -1,4 +1,11 @@
 // XFAIL: *
+// Note: PtrAnalysis pass can create a tts.makeptr for below pattern:
+//         %3 = arith.constant 0 : index
+//         %6 = tt.splat %arg0 : !tt.ptr<i32> -> tensor<1x!tt.ptr<i32>>
+//         %7 = tt.addptr %6, %3 : tensor<1x!tt.ptr<i32>>, tensor<1xi32>
+//       But not if creating constant 0 and add it to a pointer is optimized away:
+//         %6 = tt.splat %arg0 : !tt.ptr<i32> -> tensor<1x!tt.ptr<i32>>
+//       A patch that rewrites tt.splat in such case will be sent separately.
 // RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 
 module {

--- a/test/Conversion/StructuredToMemref/get_num_programs.mlir
+++ b/test/Conversion/StructuredToMemref/get_num_programs.mlir
@@ -1,3 +1,4 @@
+// XFAIL: *
 // RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 
 module {
@@ -24,13 +25,14 @@ module {
 
 // CHECK-LABEL:  func.func @num_programs
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xi32>, [[PARAM_1_:%.+]]: i32, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
 // CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : index
 // CHECK-DAG:       [[CST_2_:%.+]] = arith.constant 2 : index
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [1], strides: [1] : memref<*xi32> to memref<1xi32, strided<[1]>>
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[CST_0_]]{{.}}, sizes: [1], strides: [1] : memref<*xi32> to memref<1xi32, strided<[1], offset: ?>>
 // CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<1xi32>
 // CHECK:           [[VAR_1_:%.+]] = linalg.fill ins([[PARAM_1_]] : i32) outs([[VAR_0_]] : tensor<1xi32>) -> tensor<1xi32>
-// CHECK:           bufferization.materialize_in_destination [[VAR_1_]] in writable [[VAR_reinterpret_cast_]] : (tensor<1xi32>, memref<1xi32, strided<[1]>>) -> ()
+// CHECK:           bufferization.materialize_in_destination [[VAR_1_]] in writable [[VAR_reinterpret_cast_]] : (tensor<1xi32>, memref<1xi32, strided<[1], offset: ?>>) -> ()
 // CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[CST_1_]]{{.}}, sizes: [1], strides: [1] : memref<*xi32> to memref<1xi32, strided<[1], offset: ?>>
 // CHECK-DAG:       [[VAR_2_:%.+]] = linalg.fill ins([[PARAM_2_]] : i32) outs([[VAR_0_]] : tensor<1xi32>) -> tensor<1xi32>
 // CHECK:           bufferization.materialize_in_destination [[VAR_2_]] in writable [[VAR_reinterpret_cast_0_]] : (tensor<1xi32>, memref<1xi32, strided<[1], offset: ?>>) -> ()

--- a/test/Conversion/StructuredToMemref/triton_assert.mlir
+++ b/test/Conversion/StructuredToMemref/triton_assert.mlir
@@ -3,7 +3,7 @@ tt.func public @assert_lol(%arg0: i32) {
   %c0_i32 = arith.constant 0 : i32
   %0 = arith.cmpi sgt, %arg0, %c0_i32 : i32
   %1 = tt.splat %0 : i1 -> tensor<1xi1>
-  tt.assert %1, "lol", "", "", 0 : tensor<1xi1>
+  tt.assert %1, "lol" : tensor<1xi1>
   tt.return
 }
 
@@ -12,6 +12,6 @@ tt.func public @assert_lol(%arg0: i32) {
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: i32, [[PARAM_1_:%.+]]: i32, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32) {
 // CHECK:           [[CST_0_:%.+]] = arith.constant 0 : i32
 // CHECK:           [[VAR_0_:%.+]] = arith.cmpi sgt, [[PARAM_0_]], [[CST_0_]] : i32
-// CHECK:           cf.assert [[VAR_0_]], ".py:0:  Assertion `lol` failed"
+// CHECK:           cf.assert [[VAR_0_]], "Assertion `lol` failed"
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/StructuredToMemref/wraparound_side_by_side.mlir
+++ b/test/Conversion/StructuredToMemref/wraparound_side_by_side.mlir
@@ -1,6 +1,3 @@
-// XFAIL: *
-// Note: LLVM commit 889b67c9d30e3024a1317431d66c22599f6c2011 asserts that dynamic shapes like
-// <?x?> and <2x?> are mismatch.
 // RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 
 module {
@@ -93,17 +90,17 @@ module {
 // CHECK-DAG:         [[VAR_16_:%.+]] = arith.addi [[VAR_14_]], [[CST_4_]] : index
 // CHECK:             [[VAR_17_:%.+]] = arith.minsi [[VAR_16_]], [[VAR_5_]] : index
 // CHECK:             [[VAR_18_:%.+]] = arith.subi [[VAR_17_]], [[VAR_14_]] : index
-// CHECK-DAG:         [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_13_]]{{.}}, sizes: {{.}}[[CST_4_]], [[VAR_18_]]{{.}}, strides: {{.}}[[VAR_0_]], [[VAR_3_]]{{.}} : memref<*xf32> to memref<4x?xf32, strided<[?, ?], offset: ?>>
+// CHECK-DAG:         [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_13_]]{{.}}, sizes: {{.}}[[CST_4_]], [[VAR_18_]]{{.}}, strides: {{.}}[[VAR_0_]], [[VAR_3_]]{{.}} : memref<*xf32> to memref<?x?xf32, strided<[?, ?], offset: ?>>
 // CHECK-DAG:         [[VAR_19_:%.+]] = arith.subi [[CST_4_]], [[VAR_18_]] : index
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_15_]]{{.}}, sizes: {{.}}[[CST_4_]], [[VAR_19_]]{{.}}, strides: {{.}}[[VAR_0_]], [[VAR_3_]]{{.}} : memref<*xf32> to memref<4x?xf32, strided<[?, ?], offset: ?>>
+// CHECK-DAG:         [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_15_]]{{.}}, sizes: {{.}}[[CST_4_]], [[VAR_19_]]{{.}}, strides: {{.}}[[VAR_0_]], [[VAR_3_]]{{.}} : memref<*xf32> to memref<?x?xf32, strided<[?, ?], offset: ?>>
 // CHECK-DAG:         [[RES_:%.+]] = memref.alloc() : memref<4x4xf32>
 // CHECK:             linalg.fill ins([[CST_minus_9_dot_900000_]] : f32) outs([[RES_]] : memref<4x4xf32>)
 // CHECK:             [[VAR_20_:%.+]] = arith.minsi [[VAR_18_]], [[CST_4_]] : index
 // CHECK-DAG:         [[VAR_21_:%.+]] = arith.subi [[CST_4_]], [[VAR_20_]] : index
-// CHECK-DAG:         [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_0_]][0, 0] [2, [[VAR_20_]]{{.}} [1, 1] : memref<4x?xf32, strided<[?, ?], offset: ?>> to memref<2x?xf32, strided<[?, ?], offset: ?>>
+// CHECK-DAG:         [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_0_]][0, 0] [2, [[VAR_20_]]{{.}} [1, 1] : memref<?x?xf32, strided<[?, ?], offset: ?>> to memref<2x?xf32, strided<[?, ?], offset: ?>>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_subview_2_:%.+]] = memref.subview [[VAR_reinterpret_cast_1_]][0, 0] [2, [[VAR_21_]]{{.}} [1, 1] : memref<4x?xf32, strided<[?, ?], offset: ?>> to memref<2x?xf32, strided<[?, ?], offset: ?>>
+// CHECK-DAG:         [[VAR_subview_2_:%.+]] = memref.subview [[VAR_reinterpret_cast_1_]][0, 0] [2, [[VAR_21_]]{{.}} [1, 1] : memref<?x?xf32, strided<[?, ?], offset: ?>> to memref<2x?xf32, strided<[?, ?], offset: ?>>
 // CHECK-DAG:         [[VAR_subview_3_:%.+]] = memref.subview [[RES_]][0, 0] [2, [[VAR_20_]]{{.}} [1, 1] : memref<4x4xf32> to memref<2x?xf32, strided<[4, 1]>>
 // CHECK-DAG:         [[VAR_subview_4_:%.+]] = memref.subview [[RES_]][0, [[VAR_20_]]{{.}} [2, [[VAR_21_]]{{.}} [1, 1] : memref<4x4xf32> to memref<2x?xf32, strided<[4, 1], offset: ?>>
 // CHECK:             memref.copy [[VAR_subview_]], [[VAR_subview_3_]] : memref<2x?xf32, strided<[?, ?], offset: ?>> to memref<2x?xf32, strided<[4, 1]>>

--- a/test/Conversion/StructuredToMemref/wraparound_side_by_side.mlir
+++ b/test/Conversion/StructuredToMemref/wraparound_side_by_side.mlir
@@ -1,3 +1,6 @@
+// XFAIL: *
+// Note: LLVM commit 889b67c9d30e3024a1317431d66c22599f6c2011 asserts that dynamic shapes like
+// <?x?> and <2x?> are mismatch.
 // RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 
 module {

--- a/test/Conversion/StructuredToMemref/wraparound_stacked.mlir
+++ b/test/Conversion/StructuredToMemref/wraparound_stacked.mlir
@@ -1,6 +1,3 @@
-// XFAIL: *
-// Note: LLVM commit 889b67c9d30e3024a1317431d66c22599f6c2011 asserts that dynamic shapes like
-// <?x?> and <2x?> are mismatch.
 // RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 
 module {
@@ -86,17 +83,17 @@ module {
 // CHECK:             [[VAR_13_:%.+]] = arith.addi [[VAR_3_]], [[VAR_12_]] : index
 // CHECK:             [[VAR_14_:%.+]] = arith.subi [[VAR_13_]], [[VAR_11_]] : index
 // CHECK:             [[VAR_15_:%.+]] = arith.divsi [[VAR_14_]], [[VAR_1_]] : index
-// CHECK-DAG:         [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_11_]]{{.}}, sizes: {{.}}[[VAR_15_]], [[CST_4_]]{{.}}, strides: {{.}}[[VAR_1_]], [[VAR_4_]]{{.}} : memref<*xf32> to memref<?x4xf32, strided<[?, ?], offset: ?>>
+// CHECK-DAG:         [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_11_]]{{.}}, sizes: {{.}}[[VAR_15_]], [[CST_4_]]{{.}}, strides: {{.}}[[VAR_1_]], [[VAR_4_]]{{.}} : memref<*xf32> to memref<?x?xf32, strided<[?, ?], offset: ?>>
 // CHECK-DAG:         [[VAR_16_:%.+]] = arith.subi [[CST_4_]], [[VAR_15_]] : index
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_12_]]{{.}}, sizes: {{.}}[[VAR_16_]], [[CST_4_]]{{.}}, strides: {{.}}[[VAR_1_]], [[VAR_4_]]{{.}} : memref<*xf32> to memref<?x4xf32, strided<[?, ?], offset: ?>>
+// CHECK-DAG:         [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_12_]]{{.}}, sizes: {{.}}[[VAR_16_]], [[CST_4_]]{{.}}, strides: {{.}}[[VAR_1_]], [[VAR_4_]]{{.}} : memref<*xf32> to memref<?x?xf32, strided<[?, ?], offset: ?>>
 // CHECK-DAG:         [[RES_:%.+]] = memref.alloc() : memref<4x4xf32>
 // CHECK:             linalg.fill ins([[CST_minus_9_dot_900000_]] : f32) outs([[RES_]] : memref<4x4xf32>)
 // CHECK:             [[VAR_17_:%.+]] = arith.minsi [[VAR_15_]], [[CST_4_]] : index
 // CHECK-DAG:         [[VAR_18_:%.+]] = arith.subi [[CST_4_]], [[VAR_17_]] : index
-// CHECK-DAG:         [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_0_]][0, 0] {{.}}[[VAR_17_]], 3] [1, 1] : memref<?x4xf32, strided<[?, ?], offset: ?>> to memref<?x3xf32, strided<[?, ?], offset: ?>>
+// CHECK-DAG:         [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_0_]][0, 0] {{.}}[[VAR_17_]], 3] [1, 1] : memref<?x?xf32, strided<[?, ?], offset: ?>> to memref<?x3xf32, strided<[?, ?], offset: ?>>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_subview_2_:%.+]] = memref.subview [[VAR_reinterpret_cast_1_]][0, 0] {{.}}[[VAR_18_]], 3] [1, 1] : memref<?x4xf32, strided<[?, ?], offset: ?>> to memref<?x3xf32, strided<[?, ?], offset: ?>>
+// CHECK-DAG:         [[VAR_subview_2_:%.+]] = memref.subview [[VAR_reinterpret_cast_1_]][0, 0] {{.}}[[VAR_18_]], 3] [1, 1] : memref<?x?xf32, strided<[?, ?], offset: ?>> to memref<?x3xf32, strided<[?, ?], offset: ?>>
 // CHECK-DAG:         [[VAR_subview_3_:%.+]] = memref.subview [[RES_]][0, 0] {{.}}[[VAR_17_]], 3] [1, 1] : memref<4x4xf32> to memref<?x3xf32, strided<[4, 1]>>
 // CHECK-DAG:         [[VAR_subview_4_:%.+]] = memref.subview [[RES_]]{{.}}[[VAR_17_]], 0] {{.}}[[VAR_18_]], 3] [1, 1] : memref<4x4xf32> to memref<?x3xf32, strided<[4, 1], offset: ?>>
 // CHECK:             memref.copy [[VAR_subview_]], [[VAR_subview_3_]] : memref<?x3xf32, strided<[?, ?], offset: ?>> to memref<?x3xf32, strided<[4, 1]>>

--- a/test/Conversion/StructuredToMemref/wraparound_stacked.mlir
+++ b/test/Conversion/StructuredToMemref/wraparound_stacked.mlir
@@ -1,3 +1,6 @@
+// XFAIL: *
+// Note: LLVM commit 889b67c9d30e3024a1317431d66c22599f6c2011 asserts that dynamic shapes like
+// <?x?> and <2x?> are mismatch.
 // RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
 
 module {

--- a/test/Conversion/TritonArithToLinalg/convert_tensor_reshape.mlir
+++ b/test/Conversion/TritonArithToLinalg/convert_tensor_reshape.mlir
@@ -13,9 +13,9 @@ module {
     %8 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<32x!tt.ptr<f32>>
     %9 = tt.addptr %8, %4 : tensor<32x!tt.ptr<f32>>, tensor<32xi32>
     %10 = tt.load %9 : tensor<32x!tt.ptr<f32>>
-    %11 = tt.reshape %10 {allow_reorder = false} : tensor<32xf32> -> tensor<1x32xf32>
+    %11 = tt.reshape %10 allow_reorder : tensor<32xf32> -> tensor<1x32xf32>
     %12 = tt.broadcast %11 : tensor<1x32xf32> -> tensor<64x32xf32>
-    %13 = tt.reshape %12 {allow_reorder = false} : tensor<64x32xf32> -> tensor<2048xf32>
+    %13 = tt.reshape %12 allow_reorder : tensor<64x32xf32> -> tensor<2048xf32>
     %14 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<2048x!tt.ptr<f32>>
     %15 = tt.addptr %14, %7 : tensor<2048x!tt.ptr<f32>>, tensor<2048xi32>
     tt.store %15, %13 : tensor<2048x!tt.ptr<f32>>

--- a/test/Conversion/TritonArithToLinalg/split.mlir
+++ b/test/Conversion/TritonArithToLinalg/split.mlir
@@ -6,7 +6,7 @@ module {
     %1 = tt.splat %arg0 : !tt.ptr<i32> -> tensor<256x!tt.ptr<i32>>
     %2 = tt.addptr %1, %0 : tensor<256x!tt.ptr<i32>>, tensor<256xi32>
     %3 = tt.load %2 : tensor<256x!tt.ptr<i32>>
-    %4 = tt.reshape %3 {allow_reorder = false} : tensor<256xi32> -> tensor<128x2xi32>
+    %4 = tt.reshape %3 allow_reorder : tensor<256xi32> -> tensor<128x2xi32>
     %outLHS, %outRHS = tt.split %4 : tensor<128x2xi32> -> tensor<128xi32>
     %5 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
     %6 = tt.splat %arg1 : !tt.ptr<i32> -> tensor<128x!tt.ptr<i32>>

--- a/test/Conversion/TritonArithToLinalg/triton_assert.mlir
+++ b/test/Conversion/TritonArithToLinalg/triton_assert.mlir
@@ -3,7 +3,7 @@ tt.func public @assert_lol(%arg0: i32) {
   %c0_i32 = arith.constant 0 : i32
   %0 = arith.cmpi sgt, %arg0, %c0_i32 : i32
   %1 = tt.splat %0 : i1 -> tensor<1xi1>
-  tt.assert %1, "lol", "", "", 0 : tensor<1xi1>
+  tt.assert %1, "lol" : tensor<1xi1>
   tt.return
 }
 
@@ -11,6 +11,6 @@ tt.func public @assert_lol(%arg0: i32) {
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: i32, [[PARAM_1_:%.+]]: i32, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32) {
 // CHECK:           [[CST_0_:%.+]] = arith.constant 0 : i32
 // CHECK-DAG:       [[VAR_0_:%.+]] = arith.cmpi sgt, [[PARAM_0_]], [[CST_0_]] : i32
-// CHECK:           cf.assert [[VAR_0_]], ".py:0:  Assertion `lol` failed"
+// CHECK:           cf.assert [[VAR_0_]], "Assertion `lol` failed"
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/TritonToLinalg/convert_tensor_reshape.mlir
+++ b/test/Conversion/TritonToLinalg/convert_tensor_reshape.mlir
@@ -13,9 +13,9 @@ module {
     %8 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<32x!tt.ptr<f32>>
     %9 = tt.addptr %8, %4 : tensor<32x!tt.ptr<f32>>, tensor<32xi32>
     %10 = tt.load %9 : tensor<32x!tt.ptr<f32>>
-    %11 = tt.reshape %10 {allow_reorder = false} : tensor<32xf32> -> tensor<1x32xf32>
+    %11 = tt.reshape %10 allow_reorder : tensor<32xf32> -> tensor<1x32xf32>
     %12 = tt.broadcast %11 : tensor<1x32xf32> -> tensor<64x32xf32>
-    %13 = tt.reshape %12 {allow_reorder = false} : tensor<64x32xf32> -> tensor<2048xf32>
+    %13 = tt.reshape %12 allow_reorder : tensor<64x32xf32> -> tensor<2048xf32>
     %14 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<2048x!tt.ptr<f32>>
     %15 = tt.addptr %14, %7 : tensor<2048x!tt.ptr<f32>>, tensor<2048xi32>
     tt.store %15, %13 : tensor<2048x!tt.ptr<f32>>

--- a/test/Conversion/TritonToLinalg/get_num_programs.mlir
+++ b/test/Conversion/TritonToLinalg/get_num_programs.mlir
@@ -1,3 +1,5 @@
+// XFAIL: *
+// triton-to-linalg to be retired
 // RUN: triton-shared-opt --triton-to-linalg %s | FileCheck %s
 
 module {

--- a/test/Conversion/TritonToLinalg/get_num_programs.mlir
+++ b/test/Conversion/TritonToLinalg/get_num_programs.mlir
@@ -1,5 +1,4 @@
 // XFAIL: *
-// triton-to-linalg to be retired
 // RUN: triton-shared-opt --triton-to-linalg %s | FileCheck %s
 
 module {

--- a/test/Conversion/TritonToLinalg/triton_assert.mlir
+++ b/test/Conversion/TritonToLinalg/triton_assert.mlir
@@ -3,13 +3,13 @@ tt.func public @assert_lol(%arg0: i32) {
   %c0_i32 = arith.constant 0 : i32
   %0 = arith.cmpi sgt, %arg0, %c0_i32 : i32
   %1 = tt.splat %0 : i1 -> tensor<1xi1>
-  tt.assert %1, "lol", "", "", 0 : tensor<1xi1>
+  tt.assert %1, "lol": tensor<1xi1>
   tt.return
 }
 
 // CHECK: func.func @assert_lol(%arg0: i32, %arg1: i32, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32, %arg6: i32) {
 // CHECK:   %c0_i32 = arith.constant 0 : i32
 // CHECK:   %0 = arith.cmpi sgt, %arg0, %c0_i32 : i32
-// CHECK:   cf.assert %0, ".py:0:  Assertion `lol` failed"
+// CHECK:   cf.assert %0, "Assertion `lol` failed"
 // CHECK:   return
 // CHECK: }

--- a/test/Conversion/TritonToLinalg/wraparound_side_by_side.mlir
+++ b/test/Conversion/TritonToLinalg/wraparound_side_by_side.mlir
@@ -1,4 +1,5 @@
 // XFAIL: *
+// triton-to-linalg to be retired
 // RUN: triton-shared-opt --triton-to-linalg %s | FileCheck %s
 
 module {

--- a/test/Conversion/TritonToLinalg/wraparound_side_by_side.mlir
+++ b/test/Conversion/TritonToLinalg/wraparound_side_by_side.mlir
@@ -1,5 +1,4 @@
 // XFAIL: *
-// triton-to-linalg to be retired
 // RUN: triton-shared-opt --triton-to-linalg %s | FileCheck %s
 
 module {

--- a/test/Conversion/TritonToLinalg/wraparound_side_by_side.mlir
+++ b/test/Conversion/TritonToLinalg/wraparound_side_by_side.mlir
@@ -1,3 +1,4 @@
+// XFAIL: *
 // RUN: triton-shared-opt --triton-to-linalg %s | FileCheck %s
 
 module {

--- a/test/Conversion/TritonToLinalg/wraparound_stacked.mlir
+++ b/test/Conversion/TritonToLinalg/wraparound_stacked.mlir
@@ -1,4 +1,5 @@
 // XFAIL: *
+// triton-to-linalg to be retired
 // RUN: triton-shared-opt --triton-to-linalg %s | FileCheck %s
 
 module {

--- a/test/Conversion/TritonToLinalg/wraparound_stacked.mlir
+++ b/test/Conversion/TritonToLinalg/wraparound_stacked.mlir
@@ -1,5 +1,4 @@
 // XFAIL: *
-// triton-to-linalg to be retired
 // RUN: triton-shared-opt --triton-to-linalg %s | FileCheck %s
 
 module {

--- a/test/Conversion/TritonToLinalg/wraparound_stacked.mlir
+++ b/test/Conversion/TritonToLinalg/wraparound_stacked.mlir
@@ -1,3 +1,4 @@
+// XFAIL: *
 // RUN: triton-shared-opt --triton-to-linalg %s | FileCheck %s
 
 module {


### PR DESCRIPTION
Fixing below compilation errors in include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp:

  /home/runner/work/triton-shared/triton-shared/triton_shared/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp:839:68: error: no member named 'getFile' in 'mlir::triton::AssertOp'
          llvm::formatv("{0}.py:{1}: {2} Assertion `{3}` failed", op.getFile(),
                                                                  ~~ ^
  /home/runner/work/triton-shared/triton-shared/triton_shared/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp:840:26: error: no member named 'getLine' in 'mlir::triton::AssertOp'
                        op.getLine(), op.getFunc(), op.getMessage());
                        ~~ ^
  /home/runner/work/triton-shared/triton-shared/triton_shared/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp:840:40: error: no member named 'getFunc' in 'mlir::triton::AssertOp'
                        op.getLine(), op.getFunc(), op.getMessage());
                                      ~~ ^
  3 errors generated.

This fix builds with triton @ab07e5472bcb414a0c8dd7ecab80f84370c4894e, and llvm @cfd3289a1f9a87e220737a634904a886a82d424a.