### PR TITLE
Set PtrState scalar to 0 for pointers from kernel arguments

### DIFF
--- a/lib/AnalysisStructured/PtrAnalysis.cpp
+++ b/lib/AnalysisStructured/PtrAnalysis.cpp
@@ -738,7 +738,11 @@ LogicalResult PtrAnalysis::visitOperand(Value operand, PtrState &state,
         llvm_unreachable("Unexpected operand defining operation");
       }
     } else {
+      // This operand is a pointer directly from the kernel arguments.
+      // Set the scalar to 0 to indicate that we're using offset 0.
       state.source = operand;
+      state.scalar =
+          builder.create<arith::ConstantOp>(loc, builder.getIndexAttr(0));
       return success();
     }
   }


### PR DESCRIPTION
When rewriting `tts.get_structured_state` operating on scalar pointers, we need to use the offset from `state.scalar`. Pointers directly from the kernel arguments unfortunately is missing the `scalar` field, causing a crash when creating offset from this `scalar` field.