### PR TITLE
Fix wrongly reversed args in calls

### DIFF
--- a/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
+++ b/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
@@ -884,7 +884,7 @@ struct CallConverter : public OpConversionPattern<triton::CallOp> {
           if (argsNeed > args.size()) {
             int missing = argsNeed - args.size();
             for (int i = 0; i < missing; i++) {
-              args.push_back(parentInputs[parentInputs.size() - i - 1]);
+              args.push_back(parentInputs[args.size()]);
             }
           }
         }

--- a/test/Conversion/TritonToLinalg/call.mlir
+++ b/test/Conversion/TritonToLinalg/call.mlir
@@ -17,7 +17,7 @@ module {
 // CHECK:     return [[CST_]] : f32
 // CHECK:   }
 // CHECK:   func.func @test(%arg0: i32, %arg1: i32, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32) -> f32 {
-// CHECK:     [[VAR_0_:%.+]] = call @_sum_combine__fp32(%arg5, %arg4, %arg3, %arg2, %arg1, %arg0) : (i32, i32, i32, i32, i32, i32) -> f32
+// CHECK:     [[VAR_0_:%.+]] = call @_sum_combine__fp32(%arg0, %arg1, %arg2, %arg3, %arg4, %arg5) : (i32, i32, i32, i32, i32, i32) -> f32
 // CHECK:     return [[VAR_0_]] : f32
 // CHECK:   }
 // CHECK: }


### PR DESCRIPTION
As @Bolzano983 noticed, the args were reversed with no good reason, fixing the ordering, thank you!