### PR TITLE
Support mask analysis against 0, and between two scalars

### DIFF
--- a/include/triton-shared/Analysis/MaskAnalysis.h
+++ b/include/triton-shared/Analysis/MaskAnalysis.h
@@ -120,14 +120,14 @@ private:
                          OpBuilder &builder);
 
   // Operand is the result of cmpi
-  // Assume only one of the dimensions has size > 1. Only support slt and sge
-  // against 0 for now. For that dimension, we have three cases:
+  // Assume only one of the dimensions has size > 1. Only support slt/ult, and
+  // sge against 0 for now. For that dimension, we have three cases:
   //  1. Constant comparison with both left and right-hand sides being scalars.
   //     Calculate this new dim as a compare and select.
   //      I.e. dim = lhs < rhs ? end : 0
   //  2. Left-hand side is not a scalar, and the right-hand side is.
-  //      2.a. Predicate is slt. Calculate this new dim as:
-  //            dim = min(end, value) - start
+  //      2.a. Predicate is slt/ult. Calculate this new dim as:
+  //            dim = max(min(end, value), start) - start
   //      2.b. Predicate is sge against 0. Mask analysis already has an
   //            assumption that the mask starts at 0, so evaluate this to true
   //            and calculate this new dim as: dim = end

--- a/include/triton-shared/Analysis/OpFoldResultUtils.h
+++ b/include/triton-shared/Analysis/OpFoldResultUtils.h
@@ -10,6 +10,7 @@
 
 #include "mlir/IR/Location.h"
 #include "mlir/IR/OpDefinition.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 
 #include <optional>
 
@@ -57,6 +58,10 @@ OpFoldResult minOFRs(const OpFoldResult lhs, const OpFoldResult rhs,
 
 OpFoldResult maxOFRs(const OpFoldResult lhs, const OpFoldResult rhs,
                      const Location loc, OpBuilder &b);
+
+OpFoldResult compareOFRs(const OpFoldResult lhs, const OpFoldResult rhs,
+                    const arith::CmpIPredicate pred, const OpFoldResult trueVal,
+                    const OpFoldResult falseVal, const Location loc, OpBuilder &b);
 } // namespace mlir
 
 #endif

--- a/include/triton-shared/AnalysisStructured/PtrAnalysis.h
+++ b/include/triton-shared/AnalysisStructured/PtrAnalysis.h
@@ -59,6 +59,8 @@ struct PtrState {
 
   bool isBlockPtr() const;
 
+  void dump() const;
+
   // Process addition of two PtrStates.
   LogicalResult addState(const PtrState &lhsState, const PtrState &rhsState,
                          Operation *op, OpBuilder &builder);

--- a/lib/Analysis/MaskAnalysis.cpp
+++ b/lib/Analysis/MaskAnalysis.cpp
@@ -372,7 +372,7 @@ LogicalResult MaskState::parseCmp(arith::CmpIOp cmpOp, const Location loc,
     newDim = compareOFRs(lhsState.scalar, rhsState.scalar, cmpOp.getPredicate(),
                   lhsState.dims[cmpDim], builder.getIndexAttr(0),
                   loc, builder);
-  } else if (cmpOp.getPredicate() == arith::CmpIPredicate::slt &&
+  } else if (cmpOp.getPredicate() == arith::CmpIPredicate::slt ||
     cmpOp.getPredicate() == arith::CmpIPredicate::ult) {
     // Important:
     // In the case where the values we are loading are entirely masked off like

--- a/test/Conversion/TritonToStructured/addptr_cmpge.mlir
+++ b/test/Conversion/TritonToStructured/addptr_cmpge.mlir
@@ -1,8 +1,8 @@
-// RUN: %triton-opt --triton-to-structured --split-input-file %s | %FileCheck %s
+// RUN: triton-shared-opt --triton-to-structured --split-input-file %s | FileCheck %s
 
 // These tests check that loads/stores that exhibit a cmp ge against 0 work correctly with the pointer analysis pass
 
-tt.func public @test_masked_load(%arg0: !tt.ptr<f16>) {
+tt.func public @test_masked_load(%arg0: !tt.ptr<f16>) -> tensor<16x16xf16> {
   %cst = arith.constant dense<0> : tensor<1x16xi64>
   %c16_i32 = arith.constant 16 : i32
   %0 = tt.get_program_id y : i32
@@ -22,10 +22,10 @@ tt.func public @test_masked_load(%arg0: !tt.ptr<f16>) {
   %14 = arith.cmpi sge, %13, %cst : tensor<1x16xi64>
   %15 = tt.broadcast %14 : tensor<1x16xi1> -> tensor<16x16xi1>
   %16 = tt.load %8, %15 evictionPolicy = evict_last : tensor<16x16x!tt.ptr<f16>>
-  tt.return
+  tt.return %16 : tensor<16x16xf16>
 }
 
-// CHECK:         tt.func public @test_masked_load([[arg0_:%.+]]: !tt.ptr<f16>) {
+// CHECK:         tt.func public @test_masked_load([[arg0_:%.+]]: !tt.ptr<f16>) -> tensor<16x16xf16> {
 // CHECK:           [[VAR_0_:%.+]] = tts.make_tptr [[arg0_]] to sizes: [16, 16], strides: [1, 0], offsets: [0, 0], shape: [0, 0], order: [] : <f16> to tensor<16x16x!tt.ptr<f16>>
 // CHECK:           [[VAR_1_:%.+]] = "tts.load"([[VAR_0_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64: 16, 16>}> : (tensor<16x16x!tt.ptr<f16>>) -> tensor<16x16xf16>
 // CHECK:         }

--- a/test/Conversion/TritonToStructured/addptr_cmpge.mlir
+++ b/test/Conversion/TritonToStructured/addptr_cmpge.mlir
@@ -1,0 +1,54 @@
+// RUN: %triton-opt --triton-to-structured --split-input-file %s | %FileCheck %s
+
+// These tests check that loads/stores that exhibit a cmp ge against 0 work correctly with the pointer analysis pass
+
+tt.func public @test_masked_load(%arg0: !tt.ptr<f16>) {
+  %cst = arith.constant dense<0> : tensor<1x16xi64>
+  %c16_i32 = arith.constant 16 : i32
+  %0 = tt.get_program_id y : i32
+  %1 = arith.muli %0, %c16_i32 : i32
+  %2 = arith.extsi %1 : i32 to i64
+  %3 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<16x16x!tt.ptr<f16>>
+  %4 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+  %5 = arith.extsi %4 : tensor<16xi32> to tensor<16xi64>
+  %6 = tt.expand_dims %5 {axis = 1 : i32} : tensor<16xi64> -> tensor<16x1xi64>
+  %7 = tt.broadcast %6 : tensor<16x1xi64> -> tensor<16x16xi64>
+  %8 = tt.addptr %3, %7 : tensor<16x16x!tt.ptr<f16>>, tensor<16x16xi64>
+  %9 = tt.splat %2 : i64 -> tensor<16xi64>
+  %10 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+  %11 = arith.extsi %10 : tensor<16xi32> to tensor<16xi64>
+  %12 = arith.addi %9, %11 : tensor<16xi64>
+  %13 = tt.expand_dims %12 {axis = 0 : i32} : tensor<16xi64> -> tensor<1x16xi64>
+  %14 = arith.cmpi sge, %13, %cst : tensor<1x16xi64>
+  %15 = tt.broadcast %14 : tensor<1x16xi1> -> tensor<16x16xi1>
+  %16 = tt.load %8, %15 evictionPolicy = evict_last : tensor<16x16x!tt.ptr<f16>>
+  tt.return
+}
+
+// CHECK:         tt.func public @test_masked_load([[arg0_:%.+]]: !tt.ptr<f16>) {
+// CHECK:           [[VAR_0_:%.+]] = tts.make_tptr [[arg0_]] to sizes: [16, 16], strides: [1, 0], offsets: [0, 0], shape: [0, 0], order: [] : <f16> to tensor<16x16x!tt.ptr<f16>>
+// CHECK:           [[VAR_1_:%.+]] = "tts.load"([[VAR_0_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64: 16, 16>}> : (tensor<16x16x!tt.ptr<f16>>) -> tensor<16x16xf16>
+// CHECK:         }
+
+// -----
+
+tt.func public @test_masked_store(%arg0: !tt.ptr<f16>) {
+  %cst = arith.constant dense<0> : tensor<16x1xi64>
+  %cst_0 = arith.constant dense<1.500000e+01> : tensor<16x16xf16>
+  %0 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<16x16x!tt.ptr<f16>>
+  %1 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+  %2 = arith.extsi %1 : tensor<16xi32> to tensor<16xi64>
+  %3 = tt.expand_dims %2 {axis = 1 : i32} : tensor<16xi64> -> tensor<16x1xi64>
+  %4 = tt.broadcast %3 : tensor<16x1xi64> -> tensor<16x16xi64>
+  %5 = tt.addptr %0, %4 : tensor<16x16x!tt.ptr<f16>>, tensor<16x16xi64>
+  %6 = arith.cmpi sge, %3, %cst : tensor<16x1xi64>
+  %7 = tt.broadcast %6 : tensor<16x1xi1> -> tensor<16x16xi1>
+  tt.store %5, %cst_0, %7 : tensor<16x16x!tt.ptr<f16>>
+  tt.return
+}
+
+// CHECK:         tt.func public @test_masked_store([[arg0_:%.+]]: !tt.ptr<f16>) {
+// CHECK-DAG:       [[VAR_cst_:%.+]] = arith.constant dense<1.500000e+01> : tensor<16x16xf16>
+// CHECK-DAG:       [[VAR_0_:%.+]] = tts.make_tptr [[arg0_]] to sizes: [16, 16], strides: [1, 0], offsets: [0, 0], shape: [0, 0], order: [] : <f16> to tensor<16x16x!tt.ptr<f16>>
+// CHECK:           "tts.store"([[VAR_0_]], [[VAR_cst_]]) <{static_mask_dims = array<i64: 16, 16>}> : (tensor<16x16x!tt.ptr<f16>>, tensor<16x16xf16>) -> ()
+// CHECK:         }


### PR DESCRIPTION
Support was added for two new scenarios:
`arith.cmpi ge %scalar, %c0`: aka offset comparison to the lower bound of 0. Mask analysis already has an implicit assumption that the beginning of a mask starts at 0, so support was added to allow this case through and assumes that this comparison evaluates to true.
`arith.cmpi slt %scalar,_1 %scalar_2`: offset comparison between two scalars. E.g.:
```
%11 = tt.expand_dims %offset
%cst_4 = arith.constant dense<324> : tensor<16x1xi64>
%23 = arith.cmpi slt, %11, %cst_4 : tensor<16x1xi64>
```
This example is notable in that we cannot take the normal approach of computing the minimum of the lhs and rhs as the new dimension (the lhs offset may be 0). To handle this, a ternary operator is inserted to evaluate the comparison at runtime. If it succeeds, we keep the existing dimensions from the lhs, otherwise we assume nothing should be loaded/stored.

This change also adds a dump method to both `MaskState` and `PtrState` as a small QOL improvement.