### PR TITLE
Do not strip locations for better debugging experience

### DIFF
--- a/backend/compiler.py
+++ b/backend/compiler.py
@@ -33,7 +33,8 @@ def _ttir_to_ttsharedir(mod):
         dst_path = os.path.join(tmpdir, "ttshared.mlir")
         Path(src_path).write_text(ttir_code)
         triton_shared_opt_path = _get_triton_shared_opt_path()
-        subprocess.check_call([triton_shared_opt_path, src_path, "--triton-to-linalg-experimental", "-o", dst_path])
+        subprocess.check_call([triton_shared_opt_path, src_path,
+            "--triton-to-linalg-experimental", "--mlir-print-debuginfo", "-o", dst_path])
         return Path(dst_path).read_text()
 
 
@@ -80,6 +81,7 @@ def _ttsharedir_to_llir(ttsharedir: str):
             "--convert-arith-to-llvm",
             # Remove all unrealized casts created
             "--reconcile-unrealized-casts",
+            "--mlir-print-debuginfo",
             "-o",
             llmlir_path])
 


### PR DESCRIPTION
We getting locations as a part of Triton IR and from the inductor, however we strip them because that is the default behavior of mlir-opt. This information is useful and I think the overhead is tolerable, especially because any subsequent run is cached.