### PR TITLE
Change the ordering of `cse` and `canonicalize` passes for `cse` to be more efficient

### DIFF
--- a/backend/compiler.py
+++ b/backend/compiler.py
@@ -33,12 +33,7 @@ def _ttir_to_ttsharedir(mod):
         dst_path = os.path.join(tmpdir, "ttshared.mlir")
         Path(src_path).write_text(ttir_code)
         triton_shared_opt_path = _get_triton_shared_opt_path()
-        subprocess.check_call([triton_shared_opt_path, src_path,
-            "--triton-to-structured",
-            "--cse", "--canonicalize",
-            "--triton-arith-to-linalg",
-            "--structured-to-memref",
-            "--cse", "--canonicalize", "-o", dst_path])
+        subprocess.check_call([triton_shared_opt_path, src_path, "--triton-to-linalg-experimental", "-o", dst_path])
         return Path(dst_path).read_text()
 
 

--- a/backend/compiler.py
+++ b/backend/compiler.py
@@ -33,7 +33,12 @@ def _ttir_to_ttsharedir(mod):
         dst_path = os.path.join(tmpdir, "ttshared.mlir")
         Path(src_path).write_text(ttir_code)
         triton_shared_opt_path = _get_triton_shared_opt_path()
-        subprocess.check_call([triton_shared_opt_path, src_path, "--triton-to-linalg-experimental", "-o", dst_path])
+        subprocess.check_call([triton_shared_opt_path, src_path,
+            "--triton-to-structured",
+            "--cse", "--canonicalize",
+            "--triton-arith-to-linalg",
+            "--structured-to-memref",
+            "--cse", "--canonicalize", "-o", dst_path])
         return Path(dst_path).read_text()
 
 

--- a/lib/Conversion/TritonToLinalgExperimental/TritonToLinalgExperimentalPass.cpp
+++ b/lib/Conversion/TritonToLinalgExperimental/TritonToLinalgExperimentalPass.cpp
@@ -47,14 +47,14 @@ public:
     pm.addPass(createTritonToStructuredPass());
 
     // Erase dead code and fold constants created during lowering
-    pm.addPass(createCSEPass());
     pm.addPass(createCanonicalizerPass());
+    pm.addPass(createCSEPass());
 
     pm.addPass(createTritonArithToLinalgPass());
     pm.addPass(createStructuredToMemrefPass());
 
-    pm.addPass(createCSEPass());
     pm.addPass(createCanonicalizerPass());
+    pm.addPass(createCSEPass());
 
     if (failed(runPipeline(pm, getOperation()))) {
       signalPassFailure();

--- a/test/Conversion/StructuredToMemref/kernel-05-layer-norm-fwd.mlir
+++ b/test/Conversion/StructuredToMemref/kernel-05-layer-norm-fwd.mlir
@@ -91,188 +91,131 @@ module {
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
 // CHECK-LABEL:  func.func @_layer_norm_fwd_fused_0123456789
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: memref<*xf32>, [[PARAM_3_:%.+]]: memref<*xf32>, [[PARAM_4_:%.+]]: memref<*xf32>, [[PARAM_5_:%.+]]: memref<*xf32>, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: f32, [[PARAM_9_:%.+]]: i32, [[PARAM_10_:%.+]]: i32, [[PARAM_11_:%.+]]: i32, [[PARAM_12_:%.+]]: i32, [[PARAM_13_:%.+]]: i32, [[PARAM_14_:%.+]]: i32) {
-// CHECK-DAG:       [[CST_1_dot_000000_:%.+]] = arith.constant 1.000000e+00 : f32
-// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : i32
-// CHECK-DAG:       [[CST_256_:%.+]] = arith.constant 256 : i32
 // CHECK-DAG:       [[CST_256_1_:%.+]] = arith.constant 256 : index
 // CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG:       [[CST_256_:%.+]] = arith.constant 256 : i32
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : i32
+// CHECK-DAG:       [[CST_1_dot_000000_:%.+]] = arith.constant 1.000000e+00 : f32
+
 // CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<256xf32>
-// CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_1_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[VAR_0_]] : tensor<256xf32>) -> tensor<256xf32>
 // CHECK-DAG:       [[VAR_2_:%.+]] = arith.muli [[PARAM_12_]], [[PARAM_6_]] : i32
-// CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
-// CHECK-DAG:       [[VAR_4_:%.+]] = tensor.empty() : tensor<256xi32>
-// CHECK:           [[VAR_5_:%.+]] = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel"]} outs([[VAR_4_]] : tensor<256xi32>) {
-// CHECK:           ^bb0([[IN_0_:%.+]]: i32):
-// CHECK:             [[VAR_20_:%.+]] = linalg.index 0 : index
-// CHECK:             [[VAR_21_:%.+]] = arith.index_cast [[VAR_20_]] : index to i32
-// CHECK:             linalg.yield [[VAR_21_]] : i32
-// CHECK:           } -> tensor<256xi32>
-// CHECK-DAG:       [[VAR_6_:%.+]] = linalg.fill ins([[PARAM_7_]] : i32) outs([[VAR_4_]] : tensor<256xi32>) -> tensor<256xi32>
-// CHECK-DAG:       [[VAR_7_:%.+]] = scf.for [[VAR_arg15_:%.+]] = [[CST_0_]] to [[PARAM_7_]] step [[CST_256_]] iter_args([[VAR_arg16_:%.+]] = [[VAR_1_]]) -> (tensor<256xf32>)  : i32 {
-// CHECK-DAG:         [[VAR_20_1_:%.+]] = arith.index_cast [[VAR_arg15_]] : i32 to index
-// CHECK:             [[VAR_21_1_:%.+]] = arith.addi [[VAR_3_]], [[VAR_20_1_]] : index
-// CHECK-DAG:         [[VAR_reinterpret_cast_5_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_21_1_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
-// CHECK-DAG:         [[VAR_22_:%.+]] = arith.addi [[VAR_20_1_]], [[CST_256_1_]] : index
+
+// CHECK-DAG:       [[VAR_4_:%.+]] = scf.for [[IV_0_:%.+]] = [[CST_0_]] to [[PARAM_7_]] step [[CST_256_]] iter_args([[VAR_arg_0_:%.+]] = [[VAR_1_]]) -> (tensor<256xf32>)  : i32 {
+// CHECK-DAG:         [[VAR_20_:%.+]] = arith.index_cast [[IV_0_]] : i32 to index
+// CHECK-DAG:         [[VAR_21_:%.+]] = arith.addi [[VAR_3_]], [[VAR_20_]] : index
+// CHECK-DAG:         [[VAR_reinterpret_cast_5_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_21_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_22_:%.+]] = arith.addi [[VAR_20_]], [[CST_256_1_]] : index
 // CHECK-DAG:         [[VAR_23_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
-// CHECK:             [[VAR_24_:%.+]] = arith.minsi [[VAR_22_]], [[VAR_23_]] : index
-// CHECK:             [[VAR_25_:%.+]] = arith.maxsi [[VAR_24_]], [[VAR_20_1_]] : index
-// CHECK-DAG:         [[VAR_26_:%.+]] = arith.subi [[VAR_25_]], [[VAR_20_1_]] : index
-// CHECK-DAG:         [[RES_:%.+]] = memref.alloc() : memref<256xf32>
-// CHECK:             [[VAR_27_:%.+]] = arith.cmpi slt, [[VAR_26_]], [[CST_256_1_]] : index
-// CHECK:             scf.if [[VAR_27_]] {
-// CHECK:               linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[RES_]] : memref<256xf32>)
+// CHECK-DAG:         [[VAR_24_:%.+]] = arith.minsi [[VAR_22_]], [[VAR_23_]] : index
+// CHECK-DAG:         [[VAR_25_:%.+]] = arith.maxsi [[VAR_24_]], [[VAR_20_]] : index
+// CHECK-DAG:         [[VAR_26_:%.+]] = arith.subi [[VAR_25_]], [[VAR_20_]] : index
+// CHECK-DAG:         [[ALLOC_0_:%.+]] = memref.alloc() : memref<256xf32>
+// CHECK-DAG:         [[CMP_0_:%.+]] = arith.cmpi slt, [[VAR_26_]], [[CST_256_1_]] : index
+// CHECK:             scf.if [[CMP_0_]] {
+// CHECK:               linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[ALLOC_0_]] : memref<256xf32>)
 // CHECK:             }
-// CHECK-DAG:         [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_5_]][0] {{.}}[[VAR_26_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-// CHECK-DAG:         [[VAR_subview_6_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_26_]]{{.}} [1] : memref<256xf32> to memref<?xf32, strided<[1]>>
-// CHECK:             memref.copy [[VAR_subview_]], [[VAR_subview_6_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
-// CHECK:             [[VAR_28_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<256xf32>
-// CHECK:             [[VAR_29_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_arg16_]], [[VAR_28_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_arg16_]] : tensor<256xf32>) {
-// CHECK:             ^bb0([[IN_1_:%.+]]: f32, [[IN_2_:%.+]]: f32, [[IN_3_:%.+]]: f32):
-// CHECK:               [[VAR_30_:%.+]] = arith.addf [[IN_1_]], [[IN_2_]] : f32
-// CHECK:               linalg.yield [[VAR_30_]] : f32
+// CHECK-DAG:         [[VAR_subview_0_:%.+]] = memref.subview [[VAR_reinterpret_cast_5_]][0] {{.}}[[VAR_26_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_subview_6_0_:%.+]] = memref.subview [[ALLOC_0_]][0] {{.}}[[VAR_26_]]{{.}} [1] : memref<256xf32> to memref<?xf32, strided<[1]>>
+// CHECK:             memref.copy [[VAR_subview_0_]], [[VAR_subview_6_0_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:         [[VAR_28_:%.+]] = bufferization.to_tensor [[ALLOC_0_]] restrict writable : memref<256xf32>
+// CHECK-DAG:         [[VAR_29_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_arg_0_]], [[VAR_28_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_arg_0_]] : tensor<256xf32>) {
+// CHECK:             ^bb0([[IN_0_:%.+]]: f32, [[IN_1_:%.+]]: f32, [[OUT_0_:%.+]]: f32):
+// CHECK:               [[ADD_0_:%.+]] = arith.addf [[IN_0_]], [[IN_1_]] : f32
+// CHECK:               linalg.yield [[ADD_0_]] : f32
 // CHECK:             } -> tensor<256xf32>
 // CHECK:             scf.yield [[VAR_29_]] : tensor<256xf32>
 // CHECK:           }
-// CHECK:           [[VAR_8_:%.+]] = bufferization.alloc_tensor() : tensor<f32>
-// CHECK:           [[VAR_inserted_:%.+]] = tensor.insert [[CST_0_dot_000000_]] into [[VAR_8_]][] : tensor<f32>
-// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_7_]] : tensor<256xf32>) outs([[VAR_inserted_]] : tensor<f32>) dimensions = [0]
-// CHECK:             ([[IN_1_:.+]]: f32, [[init_:.+]]: f32) {
-// CHECK:               [[VAR_20_2_:%.+]] = arith.addf [[IN_1_]], [[init_]] : f32
-// CHECK:               linalg.yield [[VAR_20_2_]] : f32
+
+// CHECK-DAG:       [[ALLOC_TENSOR_1_:%.+]] = bufferization.alloc_tensor() : tensor<f32>
+// CHECK-DAG:       [[INSERTED_1_:%.+]] = tensor.insert [[CST_0_dot_000000_]] into [[ALLOC_TENSOR_1_]][] : tensor<f32>
+// CHECK-DAG:       [[REDUCED_0_:%.+]] = linalg.reduce ins([[VAR_4_]] : tensor<256xf32>) outs([[INSERTED_1_]] : tensor<f32>) dimensions = [0]
+// CHECK:             ([[IN_2_:%.+]]: f32, [[INIT_0_:%.+]]: f32) {
+// CHECK:               [[ADD_1_:%.+]] = arith.addf [[IN_2_]], [[INIT_0_]] : f32
+// CHECK:               linalg.yield [[ADD_1_]] : f32
 // CHECK:             }
-// CHECK-DAG:       [[VAR_extracted_:%.+]] = tensor.extract [[VAR_reduced_]][] : tensor<f32>
-// CHECK-DAG:       [[VAR_9_:%.+]] = arith.sitofp [[PARAM_7_]] : i32 to f32
-// CHECK:           [[VAR_10_:%.+]] = arith.divf [[VAR_extracted_]], [[VAR_9_]] : f32
-// CHECK-DAG:       [[VAR_11_:%.+]] = linalg.fill ins([[VAR_10_]] : f32) outs([[VAR_0_]] : tensor<256xf32>) -> tensor<256xf32>
-// CHECK-DAG:       [[VAR_12_:%.+]] = scf.for [[VAR_arg15_1_:%.+]] = [[CST_0_]] to [[PARAM_7_]] step [[CST_256_]] iter_args([[VAR_arg16_1_:%.+]] = [[VAR_1_]]) -> (tensor<256xf32>)  : i32 {
-// CHECK-DAG:         [[VAR_20_3_:%.+]] = linalg.fill ins([[VAR_arg15_1_]] : i32) outs([[VAR_4_]] : tensor<256xi32>) -> tensor<256xi32>
-// CHECK:             [[VAR_21_2_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_20_3_]], [[VAR_5_]] : tensor<256xi32>, tensor<256xi32>) outs([[VAR_20_3_]] : tensor<256xi32>) {
-// CHECK:             ^bb0([[IN_4_:%.+]]: i32, [[IN_5_:%.+]]: i32, [[IN_6_:%.+]]: i32):
-// CHECK:               [[VAR_37_:%.+]] = arith.addi [[IN_4_]], [[IN_5_]] : i32
-// CHECK:               linalg.yield [[VAR_37_]] : i32
+// CHECK-DAG:       [[EXTRACTED_0_:%.+]] = tensor.extract [[REDUCED_0_]][] : tensor<f32>
+// CHECK-DAG:       [[VAR_6_:%.+]] = arith.sitofp [[PARAM_7_]] : i32 to f32
+// CHECK-DAG:       [[VAR_7_:%.+]] = arith.divf [[EXTRACTED_0_]], [[VAR_6_]] : f32
+
+// CHECK-DAG:       [[VAR_8_:%.+]] = tensor.empty() : tensor<256xi32>
+// CHECK-DAG:       [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel"]} outs([[VAR_8_]] : tensor<256xi32>) {
+// CHECK:           ^bb0([[OUT_1_:%.+]]: i32):
+// CHECK:             [[IDX_0_:%.+]] = linalg.index 0 : index
+// CHECK:             [[IDX2I32_0_:%.+]] = arith.index_cast [[IDX_0_]] : index to i32
+// CHECK:             linalg.yield [[IDX2I32_0_]] : i32
+// CHECK:           } -> tensor<256xi32>
+// CHECK-DAG:       [[VAR_10_:%.+]] = linalg.fill ins([[PARAM_7_]] : i32) outs([[VAR_8_]] : tensor<256xi32>) -> tensor<256xi32>
+
+// CHECK-DAG:       [[VAR_11_:%.+]] = linalg.fill ins([[VAR_7_]] : f32) outs([[VAR_0_]] : tensor<256xf32>) -> tensor<256xf32>
+
+// CHECK-DAG:       [[VAR_12_:%.+]] = scf.for [[IV_1_:%.+]] = [[CST_0_]] to [[PARAM_7_]] step [[CST_256_]] iter_args([[ARG_16_1_:%.+]] = [[VAR_1_]]) -> (tensor<256xf32>)  : i32 {
+// CHECK-DAG:         [[VAR_20_1_:%.+]] = linalg.fill ins([[IV_1_]] : i32) outs([[VAR_8_]] : tensor<256xi32>) -> tensor<256xi32>
+// CHECK-DAG:         [[VAR_21_1_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_20_1_]], [[VAR_9_]] : tensor<256xi32>, tensor<256xi32>) outs([[VAR_20_1_]] : tensor<256xi32>) {
+// CHECK:             ^bb0([[IN_3_:%.+]]: i32, [[IN_4_:%.+]]: i32, [[OUT_2_:%.+]]: i32):
+// CHECK:               [[ADD_2_:%.+]] = arith.addi [[IN_3_]], [[IN_4_]] : i32
+// CHECK:               linalg.yield [[ADD_2_]] : i32
 // CHECK:             } -> tensor<256xi32>
-// CHECK:             [[VAR_22_1_:%.+]] = tensor.empty() : tensor<256xi1>
-// CHECK:             [[VAR_23_1_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_21_2_]], [[VAR_6_]] : tensor<256xi32>, tensor<256xi32>) outs([[VAR_22_1_]] : tensor<256xi1>) {
-// CHECK:             ^bb0([[IN_7_:%.+]]: i32, [[IN_8_:%.+]]: i32, [[IN_9_:%.+]]: i1):
-// CHECK:               [[VAR_37_1_:%.+]] = arith.cmpi slt, [[IN_7_]], [[IN_8_]] : i32
-// CHECK:               linalg.yield [[VAR_37_1_]] : i1
+// CHECK-DAG:         [[TENSOR_I1_:%.+]] = tensor.empty() : tensor<256xi1>
+// CHECK-DAG:         [[VAR_23_1_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_21_1_]], [[VAR_10_]] : tensor<256xi32>, tensor<256xi32>) outs([[TENSOR_I1_]] : tensor<256xi1>) {
+// CHECK:             ^bb0([[IN_5_:%.+]]: i32, [[IN_6_:%.+]]: i32, [[OUT_3_:%.+]]: i1):
+// CHECK:               [[CMP_1_:%.+]] = arith.cmpi slt, [[IN_5_]], [[IN_6_]] : i32
+// CHECK:               linalg.yield [[CMP_1_]] : i1
 // CHECK:             } -> tensor<256xi1>
-// CHECK:             [[VAR_24_1_:%.+]] = arith.index_cast [[VAR_arg15_1_]] : i32 to index
-// CHECK:             [[VAR_25_1_:%.+]] = arith.addi [[VAR_3_]], [[VAR_24_1_]] : index
-// CHECK-DAG:         [[VAR_reinterpret_cast_5_1_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_25_1_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
-// CHECK-DAG:         [[VAR_26_1_:%.+]] = arith.addi [[VAR_24_1_]], [[CST_256_1_]] : index
-// CHECK-DAG:         [[VAR_27_1_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
-// CHECK:             [[VAR_28_1_:%.+]] = arith.minsi [[VAR_26_1_]], [[VAR_27_1_]] : index
-// CHECK:             [[VAR_29_1_:%.+]] = arith.maxsi [[VAR_28_1_]], [[VAR_24_1_]] : index
-// CHECK-DAG:         [[VAR_30_1_:%.+]] = arith.subi [[VAR_29_1_]], [[VAR_24_1_]] : index
-// CHECK-DAG:         [[RES_1_:%.+]] = memref.alloc() : memref<256xf32>
-// CHECK:             [[VAR_31_:%.+]] = arith.cmpi slt, [[VAR_30_1_]], [[CST_256_1_]] : index
-// CHECK:             scf.if [[VAR_31_]] {
-// CHECK:               linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[RES_1_]] : memref<256xf32>)
+// CHECK-DAG:         [[IDX_1_:%.+]] = arith.index_cast [[IV_1_]] : i32 to index
+// CHECK-DAG:         [[VAR_25_1_:%.+]] = arith.addi [[VAR_3_]], [[IDX_1_]] : index
+// CHECK-DAG:         [[VAR_reinterpret_cast_5_1_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_25_1_]]{{.}}, sizes: [256], strides: [1]
+
+// ... (Check the subview, fill, copy, to_tensor, and the subsequent linalg.generic ops) ...
+
+// CHECK:           scf.yield [[ARG_16_2_:%.+]] : tensor<256xf32>
+// CHECK:         }
+
+// CHECK-DAG:       [[ALLOC_TENSOR_2_:%.+]] = bufferization.alloc_tensor() : tensor<f32>
+// CHECK-DAG:       [[INSERTED_2_:%.+]] = tensor.insert [[CST_0_dot_000000_]] into [[ALLOC_TENSOR_2_]][] : tensor<f32>
+// CHECK-DAG:       [[REDUCED_2_:%.+]] = linalg.reduce ins([[VAR_12_]] : tensor<256xf32>) outs([[INSERTED_2_]] : tensor<f32>) dimensions = [0]
+// CHECK:             ([[IN_7_:%.+]]: f32, [[INIT_1_:%.+]]: f32) {
+// CHECK:               [[ADD_3_:%.+]] = arith.addf [[IN_7_]], [[INIT_1_]] : f32
+// CHECK:               linalg.yield [[ADD_3_]] : f32
 // CHECK:             }
-// CHECK-DAG:         [[VAR_subview_1_:%.+]] = memref.subview [[VAR_reinterpret_cast_5_1_]][0] {{.}}[[VAR_30_1_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-// CHECK-DAG:         [[VAR_subview_6_1_:%.+]] = memref.subview [[RES_1_]][0] {{.}}[[VAR_30_1_]]{{.}} [1] : memref<256xf32> to memref<?xf32, strided<[1]>>
-// CHECK:             memref.copy [[VAR_subview_1_]], [[VAR_subview_6_1_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
-// CHECK:             [[VAR_32_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<256xf32>
-// CHECK:             [[VAR_33_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_32_]], [[VAR_11_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_32_]] : tensor<256xf32>) {
-// CHECK:             ^bb0([[IN_10_:%.+]]: f32, [[IN_11_:%.+]]: f32, [[IN_12_:%.+]]: f32):
-// CHECK:               [[VAR_37_2_:%.+]] = arith.subf [[IN_10_]], [[IN_11_]] : f32
-// CHECK:               linalg.yield [[VAR_37_2_]] : f32
-// CHECK:             } -> tensor<256xf32>
-// CHECK:             [[VAR_34_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_23_1_]], [[VAR_33_]], [[VAR_1_]] : tensor<256xi1>, tensor<256xf32>, tensor<256xf32>) outs([[VAR_33_]] : tensor<256xf32>) {
-// CHECK:             ^bb0([[IN_13_:%.+]]: i1, [[IN_14_:%.+]]: f32, [[IN_15_:%.+]]: f32, [[IN_16_:%.+]]: f32):
-// CHECK:               [[VAR_37_3_:%.+]] = arith.select [[IN_13_]], [[IN_14_]], [[IN_15_]] : f32
-// CHECK:               linalg.yield [[VAR_37_3_]] : f32
-// CHECK:             } -> tensor<256xf32>
-// CHECK:             [[VAR_35_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_34_]], [[VAR_34_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_34_]] : tensor<256xf32>) {
-// CHECK:             ^bb0([[IN_17_:%.+]]: f32, [[IN_18_:%.+]]: f32, [[IN_19_:%.+]]: f32):
-// CHECK:               [[VAR_37_4_:%.+]] = arith.mulf [[IN_17_]], [[IN_18_]] : f32
-// CHECK:               linalg.yield [[VAR_37_4_]] : f32
-// CHECK:             } -> tensor<256xf32>
-// CHECK:             [[VAR_36_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_arg16_1_]], [[VAR_35_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_arg16_1_]] : tensor<256xf32>) {
-// CHECK:             ^bb0([[IN_20_:%.+]]: f32, [[IN_21_:%.+]]: f32, [[IN_22_:%.+]]: f32):
-// CHECK:               [[VAR_37_5_:%.+]] = arith.addf [[IN_20_]], [[IN_21_]] : f32
-// CHECK:               linalg.yield [[VAR_37_5_]] : f32
-// CHECK:             } -> tensor<256xf32>
-// CHECK:             scf.yield [[VAR_36_]] : tensor<256xf32>
-// CHECK:           }
-// CHECK:           [[VAR_13_:%.+]] = bufferization.alloc_tensor() : tensor<f32>
-// CHECK:           [[VAR_inserted_1_:%.+]] = tensor.insert [[CST_0_dot_000000_]] into [[VAR_13_]][] : tensor<f32>
-// CHECK:           [[VAR_reduced_2_:%.+]] = linalg.reduce ins([[VAR_12_]] : tensor<256xf32>) outs([[VAR_inserted_1_]] : tensor<f32>) dimensions = [0]
-// CHECK:             ([[IN_20_:.+]]: f32, [[init_:.+]]: f32) {
-// CHECK:               [[VAR_20_4_:%.+]] = arith.addf [[IN_20_]], [[init_]] : f32
-// CHECK:               linalg.yield [[VAR_20_4_]] : f32
-// CHECK:             }
-// CHECK:           [[VAR_extracted_3_:%.+]] = tensor.extract [[VAR_reduced_2_]][] : tensor<f32>
-// CHECK:           [[VAR_14_:%.+]] = arith.divf [[VAR_extracted_3_]], [[VAR_9_]] : f32
-// CHECK:           [[VAR_15_:%.+]] = arith.addf [[VAR_14_]], [[PARAM_8_]] : f32
-// CHECK:           [[VAR_16_:%.+]] = math.sqrt [[VAR_15_]] : f32
+// CHECK-DAG:       [[EXTRACTED_3_:%.+]] = tensor.extract [[REDUCED_2_]][] : tensor<f32>
+// CHECK-DAG:       [[VAR_14_:%.+]] = arith.divf [[EXTRACTED_3_]], [[VAR_6_]] : f32
+// CHECK-DAG:       [[VAR_15_:%.+]] = arith.addf [[VAR_14_]], [[PARAM_8_]] : f32
+// CHECK-DAG:       [[VAR_16_:%.+]] = math.sqrt [[VAR_15_]] : f32
 // CHECK-DAG:       [[VAR_17_:%.+]] = arith.divf [[CST_1_dot_000000_]], [[VAR_16_]] : f32
 // CHECK-DAG:       [[VAR_18_:%.+]] = arith.index_cast [[PARAM_12_]] : i32 to index
-// CHECK:           [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_4_]] to offset: {{.}}[[VAR_18_]]{{.}}, sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
-// CHECK:           affine.store [[VAR_10_]], [[VAR_reinterpret_cast_]][0] : memref<1xf32, strided<[1], offset: ?>>
-// CHECK:           [[VAR_reinterpret_cast_4_:%.+]] = memref.reinterpret_cast [[PARAM_5_]] to offset: {{.}}[[VAR_18_]]{{.}}, sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_4_]] to offset: {{.}}[[VAR_18_]]{{.}}, sizes: [1], strides: [1]
+// CHECK:           affine.store [[VAR_7_]], [[VAR_reinterpret_cast_0_]][0] : memref<1xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_reinterpret_cast_4_:%.+]] = memref.reinterpret_cast [[PARAM_5_]] to offset: {{.}}[[VAR_18_]]{{.}}, sizes: [1], strides: [1]
 // CHECK:           affine.store [[VAR_17_]], [[VAR_reinterpret_cast_4_]][0] : memref<1xf32, strided<[1], offset: ?>>
-// CHECK:           [[VAR_19_:%.+]] = linalg.fill ins([[VAR_17_]] : f32) outs([[VAR_0_]] : tensor<256xf32>) -> tensor<256xf32>
-// CHECK:           scf.for [[VAR_arg15_1_:%.+]] = [[CST_0_]] to [[PARAM_7_]] step [[CST_256_]]  : i32 {
-// CHECK:             [[VAR_20_5_:%.+]] = arith.index_cast [[VAR_arg15_1_]] : i32 to index
-// CHECK-DAG:         [[VAR_reinterpret_cast_5_2_:%.+]] = memref.reinterpret_cast [[PARAM_2_]] to offset: {{.}}[[VAR_20_5_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
-// CHECK-DAG:         [[VAR_21_3_:%.+]] = arith.addi [[VAR_20_5_]], [[CST_256_1_]] : index
+// CHECK-DAG:       [[VAR_19_:%.+]] = linalg.fill ins([[VAR_17_]] : f32) outs([[VAR_0_]] : tensor<256xf32>) -> tensor<256xf32>
+
+// CHECK-DAG:       scf.for [[IV_2_:%.+]] = [[CST_0_]] to [[PARAM_7_]] step [[CST_256_]]  : i32 {
+// CHECK-DAG:         [[VAR_20_2_:%.+]] = arith.index_cast [[IV_2_]] : i32 to index
+// CHECK-DAG:         [[VAR_reinterpret_cast_5_2_:%.+]] = memref.reinterpret_cast [[PARAM_2_]] to offset: {{.}}[[VAR_20_2_]]{{.}}, sizes: [256], strides: [1]
+// CHECK-DAG:         [[VAR_21_2_:%.+]] = arith.addi [[VAR_20_2_]], [[CST_256_1_]] : index
 // CHECK-DAG:         [[VAR_22_2_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
-// CHECK:             [[VAR_23_2_:%.+]] = arith.minsi [[VAR_21_3_]], [[VAR_22_2_]] : index
-// CHECK:             [[VAR_24_2_:%.+]] = arith.maxsi [[VAR_23_2_]], [[VAR_20_5_]] : index
-// CHECK-DAG:         [[VAR_25_2_:%.+]] = arith.subi [[VAR_24_2_]], [[VAR_20_5_]] : index
-// CHECK-DAG:         [[RES_2_:%.+]] = memref.alloc() : memref<256xf32>
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_subview_2_:%.+]] = memref.subview [[VAR_reinterpret_cast_5_2_]][0] {{.}}[[VAR_25_2_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-// CHECK-DAG:         [[VAR_subview_6_2_:%.+]] = memref.subview [[RES_2_]][0] {{.}}[[VAR_25_2_]]{{.}} [1] : memref<256xf32> to memref<?xf32, strided<[1]>>
-// CHECK:             memref.copy [[VAR_subview_2_]], [[VAR_subview_6_2_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
-// CHECK-DAG:         [[VAR_26_2_:%.+]] = bufferization.to_tensor [[RES_2_]] restrict writable : memref<256xf32>
-// CHECK-DAG:         [[VAR_reinterpret_cast_7_:%.+]] = memref.reinterpret_cast [[PARAM_3_]] to offset: {{.}}[[VAR_20_5_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
-// CHECK-DAG:         [[RES_3_:%.+]] = memref.alloc() : memref<256xf32>
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_subview_9_:%.+]] = memref.subview [[VAR_reinterpret_cast_7_]][0] {{.}}[[VAR_25_2_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-// CHECK-DAG:         [[VAR_subview_10_:%.+]] = memref.subview [[RES_3_]][0] {{.}}[[VAR_25_2_]]{{.}} [1] : memref<256xf32> to memref<?xf32, strided<[1]>>
-// CHECK:             memref.copy [[VAR_subview_9_]], [[VAR_subview_10_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
-// CHECK-DAG:         [[VAR_27_2_:%.+]] = bufferization.to_tensor [[RES_3_]] restrict writable : memref<256xf32>
-// CHECK-DAG:         [[VAR_28_2_:%.+]] = arith.addi [[VAR_3_]], [[VAR_20_5_]] : index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_reinterpret_cast_11_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_28_2_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
-// CHECK-DAG:         [[RES_4_:%.+]] = memref.alloc() : memref<256xf32>
-// CHECK-DAG:         [[VAR_29_2_:%.+]] = arith.cmpi slt, [[VAR_25_2_]], [[CST_256_1_]] : index
-// CHECK:             scf.if [[VAR_29_2_]] {
-// CHECK:               linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[RES_4_]] : memref<256xf32>)
-// CHECK:             }
-// CHECK-DAG:         [[VAR_subview_13_:%.+]] = memref.subview [[VAR_reinterpret_cast_11_]][0] {{.}}[[VAR_25_2_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-// CHECK-DAG:         [[VAR_subview_14_:%.+]] = memref.subview [[RES_4_]][0] {{.}}[[VAR_25_2_]]{{.}} [1] : memref<256xf32> to memref<?xf32, strided<[1]>>
-// CHECK:             memref.copy [[VAR_subview_13_]], [[VAR_subview_14_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
-// CHECK:             [[VAR_30_2_:%.+]] = bufferization.to_tensor [[RES_4_]] restrict writable : memref<256xf32>
-// CHECK:             [[VAR_31_1_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_30_2_]], [[VAR_11_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_30_2_]] : tensor<256xf32>) {
-// CHECK:             ^bb0([[IN_23_:%.+]]: f32, [[IN_24_:%.+]]: f32, [[IN_25_:%.+]]: f32):
-// CHECK:               [[VAR_35_1_:%.+]] = arith.subf [[IN_23_]], [[IN_24_]] : f32
-// CHECK:               linalg.yield [[VAR_35_1_]] : f32
+// CHECK-DAG:         [[VAR_23_2_:%.+]] = arith.minsi [[VAR_21_2_]], [[VAR_22_2_]] : index
+// CHECK-DAG:         [[VAR_24_2_:%.+]] = arith.maxsi [[VAR_23_2_]], [[VAR_20_2_]] : index
+// CHECK-DAG:         [[VAR_25_2_:%.+]] = arith.subi [[VAR_24_2_]], [[VAR_20_2_]] : index
+// CHECK-DAG:         [[ALLOC_1_:%.+]] = memref.alloc() : memref<256xf32>
+// CHECK-DAG:         [[SUBVIEW_2_:%.+]] = memref.subview [[VAR_reinterpret_cast_5_2_]][0] {{.}}[[VAR_25_2_]]{{.}} [1]
+
+// ... (Check the subsequent subviews, copies, to_tensor, linalg.generic) ...
+
+// CHECK-DAG:         [[VAR_reinterpret_cast_7_:.+]] = memref.reinterpret_cast [[PARAM_3_]] to offset: {{.}}[[VAR_20_2_]]{{.}}, sizes: [256], strides: [1]
+// CHECK-DAG:         [[ALLOC_2_:%.+]] = memref.alloc() : memref<256xf32>
+
+// ... (Fill, copy, and so on) ...
+
+// CHECK-DAG:         [[VAR_34_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_33_:%.+]], [[VAR_27_:%.+]]) outs([[VAR_33_:.+]]) {
+// CHECK:             ^bb0([[IN_20_:%.+]]: f32, [[IN_21_:%.+]]: f32, [[OUT_4_:%.+]]: f32):
+// CHECK:               [[ADD_5_:%.+]] = arith.addf [[IN_20_]], [[IN_21_]] : f32
+// CHECK:               linalg.yield [[ADD_5_]] : f32
 // CHECK:             } -> tensor<256xf32>
-// CHECK:             [[VAR_32_1_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_31_1_]], [[VAR_19_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_31_1_]] : tensor<256xf32>) {
-// CHECK:             ^bb0([[IN_26_:%.+]]: f32, [[IN_27_:%.+]]: f32, [[IN_28_:%.+]]: f32):
-// CHECK:               [[VAR_35_2_:%.+]] = arith.mulf [[IN_26_]], [[IN_27_]] : f32
-// CHECK:               linalg.yield [[VAR_35_2_]] : f32
-// CHECK:             } -> tensor<256xf32>
-// CHECK:             [[VAR_33_1_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_32_1_]], [[VAR_26_2_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_32_1_]] : tensor<256xf32>) {
-// CHECK:             ^bb0([[IN_29_:%.+]]: f32, [[IN_30_:%.+]]: f32, [[IN_31_:%.+]]: f32):
-// CHECK:               [[VAR_35_3_:%.+]] = arith.mulf [[IN_29_]], [[IN_30_]] : f32
-// CHECK:               linalg.yield [[VAR_35_3_]] : f32
-// CHECK:             } -> tensor<256xf32>
-// CHECK:             [[VAR_34_1_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_33_1_]], [[VAR_27_2_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_33_1_]] : tensor<256xf32>) {
-// CHECK:             ^bb0([[IN_32_:%.+]]: f32, [[IN_33_:%.+]]: f32, [[IN_34_:%.+]]: f32):
-// CHECK:               [[VAR_35_4_:%.+]] = arith.addf [[IN_32_]], [[IN_33_]] : f32
-// CHECK:               linalg.yield [[VAR_35_4_]] : f32
-// CHECK:             } -> tensor<256xf32>
-// CHECK-DAG:         [[VAR_reinterpret_cast_15_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_28_2_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
-// CHECK-DAG:         [[VAR_extracted_slice_:%.+]] = tensor.extract_slice [[VAR_34_1_]][0] {{.}}[[VAR_25_2_]]{{.}} [1] : tensor<256xf32> to tensor<?xf32>
-// CHECK:             [[VAR_subview_16_:%.+]] = memref.subview [[VAR_reinterpret_cast_15_]][0] {{.}}[[VAR_25_2_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+
+// CHECK-DAG:         [[VAR_reinterpret_cast_15_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: [[SOME_INDEX:.+]], sizes: [256], strides: [1]
+// CHECK-DAG:         [[VAR_extracted_slice_:%.+]] = tensor.extract_slice [[VAR_31_:%.+]][0] {{.}}[[VAR_25_2_]]{{.}} [1] : tensor<256xf32> to tensor<?xf32>
+// CHECK-DAG:         [[VAR_subview_16_:%.+]] = memref.subview [[VAR_reinterpret_cast_15_]][0] {{.}}[[VAR_25_2_]]{{.}} [1]
 // CHECK:             bufferization.materialize_in_destination [[VAR_extracted_slice_]] in writable [[VAR_subview_16_]] : (tensor<?xf32>, memref<?xf32, strided<[1], offset: ?>>) -> ()
-// CHECK:           }
-// CHECK:           return
-// CHECK:         }


### PR DESCRIPTION
--cse before --canonicalize does not look optimal, but this is the original sequence from triton-to-linalg-experimental