### PR TITLE
Fix missing cmake build dependency in `MaskAnalysis`

### DIFF
--- a/lib/Analysis/CMakeLists.txt
+++ b/lib/Analysis/CMakeLists.txt
@@ -7,6 +7,7 @@ add_triton_library(TritonSharedAnalysis
   DEPENDS
   TritonAnalysis
   TritonTableGen
+  TritonStructuredTableGen
   TritonGPUAttrDefsIncGen
 
   LINK_LIBS PUBLIC


### PR DESCRIPTION
The MaskAnalysis file depends on the triton structured dialect, but it isn't specified in the cmake file. This caused build failure in the rare cases.