### PR TITLE
Remove unused TritonAnalysis and TritonGPU dependencies

### DIFF
--- a/lib/Analysis/CMakeLists.txt
+++ b/lib/Analysis/CMakeLists.txt
@@ -5,10 +5,8 @@ add_triton_library(TritonSharedAnalysis
   UseAnalysis.cpp
 
   DEPENDS
-  TritonAnalysis
   TritonTableGen
   TritonStructuredTableGen
-  TritonGPUAttrDefsIncGen
 
   LINK_LIBS PUBLIC
   MLIRAnalysis

--- a/lib/AnalysisStructured/CMakeLists.txt
+++ b/lib/AnalysisStructured/CMakeLists.txt
@@ -2,10 +2,8 @@ add_triton_library(TritonSharedAnalysisStructured
   PtrAnalysis.cpp
 
   DEPENDS
-  TritonAnalysis
   TritonTableGen
   TritonStructuredTableGen
-  TritonGPUAttrDefsIncGen
 
   LINK_LIBS PUBLIC
   TritonStructuredIR

--- a/lib/Conversion/TritonToLinalg/CMakeLists.txt
+++ b/lib/Conversion/TritonToLinalg/CMakeLists.txt
@@ -21,7 +21,6 @@ add_triton_library(TritonToLinalg
   MLIRTensorDialect
   MLIRTransforms
   MLIRSupport
-  TritonAnalysis
   TritonIR
   TritonTransforms
   TritonSharedAnalysis

--- a/lib/Conversion/TritonToLinalgExperimental/CMakeLists.txt
+++ b/lib/Conversion/TritonToLinalgExperimental/CMakeLists.txt
@@ -20,7 +20,6 @@ add_triton_library(TritonToLinalgExperimental
   MLIRTensorDialect
   MLIRTransforms
   MLIRSupport
-  TritonAnalysis
   TritonIR
   TritonTransforms
   TritonSharedAnalysis

--- a/lib/Conversion/UnstructuredToMemref/CMakeLists.txt
+++ b/lib/Conversion/UnstructuredToMemref/CMakeLists.txt
@@ -21,7 +21,6 @@ add_triton_library(UnstructuredToMemref
   MLIRTensorDialect
   MLIRTransforms
   MLIRSupport
-  TritonAnalysis
   TritonIR
   TritonTransforms
   TritonSharedAnalysis

--- a/tools/RegisterTritonSharedDialects.h
+++ b/tools/RegisterTritonSharedDialects.h
@@ -7,12 +7,8 @@
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "triton-shared/Conversion/StructuredToMemref/Passes.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
-#include "triton/Dialect/TritonGPU/IR/Dialect.h"
 
 #include "triton/Dialect/Triton/Transforms/Passes.h"
-#include "triton/Dialect/TritonGPU/Transforms/Passes.h"
-
-#include "triton/Conversion/TritonToTritonGPU/Passes.h"
 
 #include "triton-shared/Conversion/StructuredToMemref/Passes.h"
 #include "triton-shared/Conversion/TritonArithToLinalg/Passes.h"
@@ -20,8 +16,8 @@
 #include "triton-shared/Conversion/TritonToLinalg/Passes.h"
 #include "triton-shared/Conversion/TritonToLinalgExperimental/Passes.h"
 #include "triton-shared/Conversion/TritonToStructured/Passes.h"
-#include "triton-shared/Conversion/UnstructuredToMemref/Passes.h"
 #include "triton-shared/Conversion/TritonToUnstructured/Passes.h"
+#include "triton-shared/Conversion/UnstructuredToMemref/Passes.h"
 #include "triton-shared/Dialect/TritonStructured/IR/TritonStructuredDialect.h"
 #include "triton-shared/Dialect/TritonTilingExt/IR/TritonTilingExtDialect.h"
 
@@ -39,7 +35,6 @@ void registerTestMembarPass();
 inline void registerTritonSharedDialects(mlir::DialectRegistry &registry) {
   mlir::registerAllPasses();
   mlir::registerTritonPasses();
-  mlir::triton::gpu::registerTritonGPUPasses();
   mlir::registerLinalgPasses();
   mlir::test::registerTestAliasPass();
   mlir::test::registerTestAlignmentPass();
@@ -52,16 +47,14 @@ inline void registerTritonSharedDialects(mlir::DialectRegistry &registry) {
   mlir::triton::registerUnstructuredToMemref();
   mlir::triton::registerTritonToUnstructuredPasses();
   mlir::triton::registerTritonArithToLinalgPasses();
-  mlir::triton::registerConvertTritonToTritonGPUPass();
   mlir::triton::registerStructuredToMemrefPasses();
 
   // TODO: register Triton & TritonGPU passes
   registry.insert<
       mlir::ttx::TritonTilingExtDialect, mlir::tts::TritonStructuredDialect,
       mlir::triton::TritonDialect, mlir::cf::ControlFlowDialect,
-      mlir::triton::gpu::TritonGPUDialect, mlir::math::MathDialect,
-      mlir::arith::ArithDialect, mlir::scf::SCFDialect, mlir::gpu::GPUDialect,
-      mlir::linalg::LinalgDialect, mlir::func::FuncDialect,
-      mlir::tensor::TensorDialect, mlir::memref::MemRefDialect,
-      mlir::bufferization::BufferizationDialect>();
+      mlir::math::MathDialect, mlir::arith::ArithDialect, mlir::scf::SCFDialect,
+      mlir::gpu::GPUDialect, mlir::linalg::LinalgDialect,
+      mlir::func::FuncDialect, mlir::tensor::TensorDialect,
+      mlir::memref::MemRefDialect, mlir::bufferization::BufferizationDialect>();
 }

--- a/tools/triton-shared-opt/CMakeLists.txt
+++ b/tools/triton-shared-opt/CMakeLists.txt
@@ -6,10 +6,7 @@ add_llvm_executable(triton-shared-opt triton-shared-opt.cpp PARTIAL_SOURCES_INTE
 # TODO: what's this?
 llvm_update_compile_flags(triton-shared-opt)
 target_link_libraries(triton-shared-opt PRIVATE
-  TritonAnalysis
   TritonTransforms
-  TritonGPUTransforms
-  TritonTestDialectTritonGPU
   TritonSharedAnalysis
   ${dialect_libs}
   ${conversion_libs}


### PR DESCRIPTION
Modify CMake to remove unused `TritonAnalysis` and `TritonGPU` related depedencies.