### PR TITLE
Support for tt.bitcast and tt.int_to_ptr in pointer analysis and lowering

### DIFF
--- a/include/triton-shared/AnalysisStructured/PtrAnalysis.h
+++ b/include/triton-shared/AnalysisStructured/PtrAnalysis.h
@@ -225,6 +225,18 @@ public:
                                           PtrState &state, const Location loc,
                                           OpBuilder &builder);
 
+  // Operand is the result of tt.int_to_ptr.
+  // Expected result:
+  //  Directly grab op result
+  LogicalResult visitOperandIntToPtr(triton::IntToPtrOp intToPtrOp, PtrState &state,
+                                     const Location loc, OpBuilder &builder);
+
+  // Operand is the result of tt.bitcast.
+  // Expected result:
+  //  Directly grab op result
+  LogicalResult visitOperandBitcast(triton::BitcastOp bitcastOp, PtrState &state,
+                                    const Location loc, OpBuilder &builder);
+
   // Get the computed PtrState for the forOp's init-arg at the provided index.
   FailureOr<PtrState> getLoopInitArgPtrState(scf::ForOp forOp, size_t index);
 

--- a/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
+++ b/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
@@ -852,6 +852,11 @@ struct BitcastConverter : public OpConversionPattern<triton::BitcastOp> {
   LogicalResult
   matchAndRewrite(triton::BitcastOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
+    // arith::bitcast does not support casting pointers
+    if (isa<triton::PointerType>(op.getSrc().getType())) {
+      return failure();
+    }
+
     auto arithBitcast = rewriter.create<arith::BitcastOp>(
         op.getLoc(), op.getType(), op.getOperand());
 

--- a/lib/Conversion/TritonArithToLinalg/TritonArithToLinalgPass.cpp
+++ b/lib/Conversion/TritonArithToLinalg/TritonArithToLinalgPass.cpp
@@ -122,6 +122,10 @@ public:
 
     target.addLegalOp<triton::FuncOp, triton::ReturnOp>();
 
+    target.addDynamicallyLegalOp<triton::BitcastOp>([](triton::BitcastOp op) {
+      return isa<triton::PointerType>(op.getSrc().getType());
+    });
+
     target.addDynamicallyLegalDialect<arith::ArithDialect, math::MathDialect>(
         [](Operation *op) {
           // Lower dense constant to linalg.fill

--- a/test/Conversion/TritonToStructured/addptr_bitcast.mlir
+++ b/test/Conversion/TritonToStructured/addptr_bitcast.mlir
@@ -1,0 +1,22 @@
+// RUN: triton-shared-opt --triton-to-structured %s | FileCheck %s
+
+module {
+  tt.func @test(%arg0: !tt.ptr<i64>, %arg1: !tt.ptr<f32>) {
+    %0 = tt.load %arg0 : !tt.ptr<i64>
+    %1 = tt.int_to_ptr %0 : i64 -> !tt.ptr<f16>
+    %2 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %3 = tt.splat %1 : !tt.ptr<f16> -> tensor<32x!tt.ptr<f16>>
+    %4 = tt.addptr %3, %2 : tensor<32x!tt.ptr<f16>>, tensor<32xi32>
+    %5 = tt.load %4 : tensor<32x!tt.ptr<f16>>
+    %6 = tt.bitcast %arg1 : !tt.ptr<f32> -> !tt.ptr<f16>
+    %7 = tt.splat %6 : !tt.ptr<f16> -> tensor<32x!tt.ptr<f16>>
+    %8 = tt.addptr %7, %2 : tensor<32x!tt.ptr<f16>>, tensor<32xi32>
+    tt.store %8, %5 : tensor<32x!tt.ptr<f16>>
+    tt.return
+  }
+}
+
+// CHECK: [[IN_SRC:%.+]] = tt.int_to_ptr
+// CHECK: [[IN_PTR:%.+]] = tts.make_tptr [[IN_SRC]]
+// CHECK: [[OUT_SRC:%.+]] = tt.bitcast
+// CHECK: [[OUT_PTR:%.+]] = tts.make_tptr [[OUT_SRC]]


### PR DESCRIPTION
Add support for tt.bitcast and tt.int_to_ptr in pointer analysis and lowering

## Summary
This diff adds support for tt.bitcast and tt.int_to_ptr in pointer analysis and lowering. Kernels that does indirect memory accesses (horizontal fusion, jagged tensor, etc.) could potentially use this feature.

## Testing

Added Lit test