### PR TITLE
Add support for `tt.bitcast` on tensor of pointers

### DIFF
--- a/include/triton-shared/AnalysisStructured/PtrAnalysis.h
+++ b/include/triton-shared/AnalysisStructured/PtrAnalysis.h
@@ -256,6 +256,10 @@ public:
   // PtrState for knownPtrs.
   LogicalResult rewriteAddptrOp(triton::AddPtrOp op);
 
+  // Move the BitcastOp on tensor of pointers to the source scalar pointer
+  // tracked by PtrAnalysis.
+  LogicalResult rewriteBitcastOp(triton::BitcastOp op);
+
   LogicalResult rewriteMakeTensorPtrOp(triton::MakeTensorPtrOp op);
 
   LogicalResult rewriteAdvanceOp(triton::AdvanceOp op);

--- a/lib/Conversion/TritonToUnstructured/TritonToUnstructuredPass.cpp
+++ b/lib/Conversion/TritonToUnstructured/TritonToUnstructuredPass.cpp
@@ -412,6 +412,7 @@ public:
 
                   return success();
                 })
+                .Case<triton::BitcastOp>([](auto) { return success(); })
                 .Case<scf::YieldOp>([](auto) { return success(); })
                 .Case<triton::CatOp>([](triton::CatOp op) {
                   op->emitError("Do not support gather / scatter with multiple "

--- a/test/Conversion/TritonPtrToMemref/bitcast.mlir
+++ b/test/Conversion/TritonPtrToMemref/bitcast.mlir
@@ -1,0 +1,33 @@
+// RUN: triton-shared-opt --triton-ptr-to-memref %s | FileCheck %s
+
+module {
+  func.func @kernel(%arg0: !tt.ptr<i1>, %arg1: i32, %arg2: i8) {
+    %c512 = arith.constant 512 : index
+    %c512_i32 = arith.constant 512 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c512_i32 : i32
+    %2 = arith.index_cast %1 : i32 to index
+    %3 = tt.bitcast %arg0 : !tt.ptr<i1> -> !tt.ptr<i8>
+    %4 = builtin.unrealized_conversion_cast %3 : !tt.ptr<i8> to memref<*xi8>
+    %reinterpret_cast = memref.reinterpret_cast %4 to offset: [%2], sizes: [512], strides: [1] : memref<*xi8> to memref<512xi8, strided<[1], offset: ?>>
+    %5 = tensor.empty() : tensor<512xi8>
+    %6 = linalg.fill ins(%arg2 : i8) outs(%5 : tensor<512xi8>) -> tensor<512xi8>
+    %7 = arith.addi %2, %c512 : index
+    %8 = arith.index_cast %arg1 : i32 to index
+    %9 = arith.minsi %7, %8 : index
+    %10 = arith.maxsi %9, %2 : index
+    %11 = arith.subi %10, %2 : index
+    %extracted_slice = tensor.extract_slice %6[0] [%11] [1] : tensor<512xi8> to tensor<?xi8>
+    %subview = memref.subview %reinterpret_cast[0] [%11] [1] : memref<512xi8, strided<[1], offset: ?>> to memref<?xi8, strided<[1], offset: ?>>
+    bufferization.materialize_in_destination %extracted_slice in writable %subview : (tensor<?xi8>, memref<?xi8, strided<[1], offset: ?>>) -> ()
+    return
+  }
+}
+
+// CHECK-LABEL:   func.func @kernel(
+// CHECK-SAME:      [[PARAM_0_:%.+]]: memref<*xi1>,
+// CHECK-SAME:      [[PARAM_1_:%.+]]: i32,
+// CHECK-SAME:      [[PARAM_2_:%.+]]: i8
+// CHECK-SAME:    ) {
+// CHECK-DAG:       %[[VAR_0_:.*]] = builtin.unrealized_conversion_cast [[PARAM_0_]] : memref<*xi1> to memref<*xi8>
+// CHECK-NOT:       tt.bitcast

--- a/test/Conversion/TritonToStructured/bitcast_ptrs_tensor.mlir
+++ b/test/Conversion/TritonToStructured/bitcast_ptrs_tensor.mlir
@@ -1,0 +1,51 @@
+// RUN: triton-shared-opt --triton-to-structured --canonicalize --cse %s | FileCheck %s
+
+module {
+  tt.func @kernel(
+    %out_ptr: !tt.ptr<i1>,
+    %num_elements: i32,
+    %value: i8
+  ) -> () {
+    // compute offsets.
+    %c512 = arith.constant 512 : i32
+    %pid = tt.get_program_id x : i32
+    %0 = arith.muli %pid, %c512 : i32
+    %1 = tt.splat %0 : i32 -> tensor<512xi32>
+    %2 = tt.make_range {start = 0 : i32, end = 512 : i32} : tensor<512xi32>
+    %3 = arith.addi %1, %2 : tensor<512xi32>
+    // compute mask.
+    %4 = tt.splat %num_elements : i32 -> tensor<512xi32>
+    %5 = arith.cmpi slt, %3, %4 : tensor<512xi32>
+    // ptr arithmetics.
+    %6 = tt.splat %out_ptr : !tt.ptr<i1> -> tensor<512x!tt.ptr<i1>>
+    %7 = tt.addptr %6, %3 : tensor<512x!tt.ptr<i1>>, tensor<512xi32>
+    // reinterpret cast ptr data type.
+    %8 = tt.bitcast %7 : tensor<512x!tt.ptr<i1>> -> tensor<512x!tt.ptr<i8>>
+    // store.
+    %9 = tt.splat %value : i8 -> tensor<512xi8>
+    tt.store %8, %9, %5: tensor<512x!tt.ptr<i8>>
+    tt.return
+  }
+}
+
+// CHECK-LABEL:   tt.func @kernel(
+// CHECK-SAME:      [[PARAM_0_:%.+]]: !tt.ptr<i1>,
+// CHECK-SAME:      [[PARAM_1_:%.+]]: i32,
+// CHECK-SAME:      [[PARAM_2_:%.+]]: i8
+// CHECK-SAME:    ) {
+// CHECK-DAG:     [[CST_512_index_:%.+]] = arith.constant 512 : index
+// CHECK-DAG:     [[CST_512_i32_:%.+]] = arith.constant 512 : i32
+// CHECK-DAG:     [[VAR_0_:%.+]] = tt.get_program_id x : i32
+// CHECK:         [[VAR_1_:%.+]] = arith.muli [[VAR_0_]], [[CST_512_i32_]] : i32
+// CHECK:         [[VAR_2_:%.+]] = arith.index_cast [[VAR_1_]] : i32 to index
+// CHECK-DAG:     [[VAR_3_:%.+]] = tt.bitcast [[PARAM_0_]] : !tt.ptr<i1> -> !tt.ptr<i8>
+// CHECK:         [[VAR_4_:%.+]] = tts.make_tptr [[VAR_3_]] to sizes: [512], strides: [1], offsets: {{.}}[[VAR_2_]]{{.}}, shape: [0], order: [] : <i8> to tensor<512x!tt.ptr<i8>>
+// CHECK:         [[VAR_5_:%.+]] = tt.splat [[PARAM_2_]] : i8 -> tensor<512xi8>
+// CHECK:         [[VAR_6_:%.+]] = arith.addi [[VAR_2_]], [[CST_512_index_]] : index
+// CHECK:         [[VAR_7_:%.+]] = arith.index_cast [[PARAM_1_]] : i32 to index
+// CHECK:         [[VAR_8_:%.+]] = arith.minsi [[VAR_6_]], [[VAR_7_]] : index
+// CHECK:         [[VAR_9_:%.+]] = arith.maxsi [[VAR_8_]], [[VAR_2_]] : index
+// CHECK:         [[VAR_10_:%.+]] = arith.subi [[VAR_9_]], [[VAR_2_]] : index
+// CHECK:         "tts.store"([[VAR_4_]], [[VAR_5_]], [[VAR_10_]]) <{static_mask_dims = array<i64: -9223372036854775808>}> : (tensor<512x!tt.ptr<i8>>, tensor<512xi8>, index) -> ()
+// CHECK:         return
+// CHECK:       }


### PR DESCRIPTION
1. In `TritonToStructured`, move `tt.bitcast` on tensor of pointers to the source scalar pointer tracked by `PtrAnalysis`, for instance:

```mlir
%6 = tt.splat %arg0: !tt.ptr<i1> -> tensor<512x!tt.ptr<i1>>
%7 = tt.addptr %6, %offsets : tensor<512x!tt.ptr<i1>>, tensor<512xi32>
%8 = tt.bitcast %7 : tensor<512x!tt.ptr<i1>> -> tensor<512x!tt.ptr<i8>>
```
to
```mlir
 %3 = tt.bitcast %arg0 : !tt.ptr<i1> -> !tt.ptr<i8>
 %4 = tts.make_tptr %3 to sizes: [512], strides: [1], offsets: [%offsets], shape: [0], order: [] : <i8> to tensor<512x!tt.ptr<i8>>
```

2. In `TritonToUnstructured`, Allow `tt.bitcast` op in ptr sequence.
3. In `TritonPtrToMemref`, convert `tt.bitcast` op on ptr to `builtin.unrealized_conversion_cast` op on unranked memref, since currently memref dialect does not have a suitable op for "pointer reinterpret cast" semantics.

The whole thing is kind of hacky, maybe we can wait for upstream [ptr dialect](https://discourse.llvm.org/t/rfc-ptr-dialect-modularizing-ptr-ops-in-the-llvm-dialect/75142/58) is fully landed, and rework on the whole pointer bitcast lowering. 