### PR TITLE
Update Triton to 8f5984c192c095bb258bc212c7f07794a5b72d6f

### DIFF
--- a/.github/workflows/test-plugin.yml
+++ b/.github/workflows/test-plugin.yml
@@ -67,7 +67,7 @@ jobs:
       working-directory: triton_shared/triton/python
       run: |
         python3 -m pip install --upgrade pip
-        python3 -m pip install cmake==3.24 ninja pytest-xdist pybind11
+        python3 -m pip install cmake==3.24 ninja pytest-xdist pybind11 setuptools
         sudo apt-get update -y
         sudo apt-get install -y ccache clang lld
         export TRITON_PLUGIN_DIRS="${GITHUB_WORKSPACE}/triton_shared"
@@ -102,7 +102,7 @@ jobs:
 
 
   build_and_test_triton_shared_arm:
-    runs-on: ["self-hosted", "1ES.Pool=triton-shared-github-arm"]
+    runs-on: ubuntu-24.04-arm
 
     steps:
     - name: Check Architecture
@@ -111,7 +111,6 @@ jobs:
     - name: Force Failure
       if: ${{ inputs.force-failure }}
       run: exit 1
-
 
     - name: Checkout Triton-Shared
       uses: actions/checkout@v4
@@ -142,7 +141,7 @@ jobs:
       working-directory: triton_shared/triton/python
       run: |
         python3 -m pip install --upgrade pip
-        python3 -m pip install cmake==3.24 ninja pytest-xdist pybind11
+        python3 -m pip install cmake==3.24 ninja pytest-xdist pybind11 setuptools
         sudo apt-get update -y
         sudo apt-get install -y ccache clang lld
         export TRITON_PLUGIN_DIRS="${GITHUB_WORKSPACE}/triton_shared"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.pyc
 .cache
 compile_commands.json
+build/*
+.vscode/*

--- a/backend/compiler.py
+++ b/backend/compiler.py
@@ -41,9 +41,9 @@ def _ttir_to_ttsharedir(mod):
         src_path = os.path.join(tmpdir, "tt.mlir")
         dst_path = os.path.join(tmpdir, "ttshared.mlir")
         Path(src_path).write_text(ttir_code)
+        _dump_ir_if_needed([src_path])
         triton_shared_opt_path = _get_triton_shared_opt_path()
         subprocess.check_call([triton_shared_opt_path, src_path, "--triton-to-linalg-experimental", "--mlir-print-debuginfo", "-o", dst_path])
-        _dump_ir_if_needed([src_path])
         return Path(dst_path).read_text()
 
 

--- a/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
+++ b/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
@@ -1518,7 +1518,9 @@ class ArgMinMaxBaseConverter : public OpConversionPattern<triton::ReduceOp> {
 public:
   ArgMinMaxBaseConverter(MLIRContext *context) : OpConversionPattern(context) {}
 
-  LogicalResult match(ReduceOp op) const override final {
+  LogicalResult
+  matchAndRewrite(ReduceOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override final {
     if (op.getBody()->getNumArguments() != 4) {
       return failure();
     }
@@ -1575,12 +1577,7 @@ public:
     } else {
       return failure();
     }
-
-    return success();
-  }
-
-  void rewrite(ReduceOp op, OpAdaptor adaptor,
-               ConversionPatternRewriter &rewriter) const override final {
+    
     auto loc = op.getLoc();
 
     auto elemTypes = op.getElementTypes();
@@ -1644,6 +1641,7 @@ public:
     } else {
       rewriter.replaceOp(op, linalgOp);
     }
+    return success();
   }
 };
 


### PR DESCRIPTION
This PR includes cosmetic changes due to LLVM API change, adjust dump ir code loc in `_ttir_to_ttsharedir`, add ignore items in `.gitignore`