### PR TITLE
Generate obj instead asm when lower llir to bin

### DIFF
--- a/backend/compiler.py
+++ b/backend/compiler.py
@@ -152,7 +152,7 @@ class CPUOptions:
 
 
 class CPUBackend(BaseBackend):
-    binary_ext = 'cpuasm'
+    binary_ext = 'obj'
 
     @staticmethod
     def supports_target(target: GPUTarget):
@@ -207,7 +207,7 @@ class CPUBackend(BaseBackend):
         stages["ttir"] = lambda src, metadata: self.make_ttir(src, metadata, options)
         stages["ttsharedir"] = lambda src, metadata: _optimize_ttsharedir(_ttir_to_ttsharedir(src))
         stages["llir"] = lambda src, metadata: _optimize_llir(_ttsharedir_to_llir(src))
-        stages["cpuasm"] = lambda src, metadata: _llir_to_bin(src, metadata)
+        stages["obj"] = lambda src, metadata: _llir_to_bin(src, metadata)
 
 
     @functools.lru_cache()

--- a/backend/compiler.py
+++ b/backend/compiler.py
@@ -119,9 +119,8 @@ def _llir_to_bin(llir: str, metadata):
         dst_path = os.path.join(tmpdir, "kernel.o")
         Path(src_path).write_text(llir)
         llc_path = _get_llvm_bin_path("llc")
-        subprocess.check_call([llc_path, src_path, "-o", dst_path])
-        # Actually it's text-format assembly.  Use read_text().
-        return Path(dst_path).read_text()
+        subprocess.check_call([llc_path, src_path, "-filetype=obj", "-o", dst_path])
+        return Path(dst_path).read_bytes()
 
 
 

--- a/backend/driver.py
+++ b/backend/driver.py
@@ -238,14 +238,14 @@ def compile_module(launcher_src, kernel_placeholder_name):
         kernel_metadata, launch_metadata,
         launch_enter_hook, launch_exit_hook, *args):
         # Unlike CUDA/HIP, we cannot easily pass function pointer across different pybind libraries.
-        # Let's compile a kernel every time.
-        # The cu_function parameter actually contains our assembly source code.
+        # Let's compile one kernel every time.
+        # The cu_function parameter actually contains our kernel obj.
         # See CPUUtils.load_binary method.
-        asm_src = cu_function
+        kernel_obj = cu_function
         kernel_name = kernel_metadata[6] # see pack_metadata in compiler.py
         src = launcher_src.replace(kernel_placeholder_name, kernel_name)
 
-        key = hashlib.md5(src.encode("utf-8") + asm_src).hexdigest()
+        key = hashlib.md5(src.encode("utf-8") + kernel_obj).hexdigest()
         cache = get_cache_manager(key)
         name = "__triton_shared_ref_cpu_kernel_launcher"
         filename = f"{name}.so"
@@ -253,14 +253,14 @@ def compile_module(launcher_src, kernel_placeholder_name):
 
         if cache_path is None:
           with tempfile.TemporaryDirectory() as tmpdir:
-              asm_src_path = os.path.join(tmpdir, "kernel.o")
+              obj_path = os.path.join(tmpdir, "kernel.o")
               launcher_src_path = os.path.join(tmpdir, "main.cxx")
               so_path = os.path.join(tmpdir, "kernel.so")
-              Path(asm_src_path).write_bytes(asm_src)
+              Path(obj_path).write_bytes(kernel_obj)
               Path(launcher_src_path).write_text(src)
               # Compile it together.
               subprocess.check_call([
-                "g++", "-std=c++17", launcher_src_path, asm_src_path,
+                "g++", "-std=c++17", launcher_src_path, obj_path,
                 f"-I{py_include_dir}", f"-I{include_dir}", f"-L{py_lib_dir}",
                 "-shared", f"-l{py_lib}", "-fPIC", "-o", so_path
               ])
@@ -326,13 +326,13 @@ class CPUUtils(object):
 
     # Important note:
     # Since we cannot easy pass function pointers around, we pass along the
-    # assembly source code so that compile_module above can recompile the
+    # obj of the kernel so that compile_module above can recompile the
     # module every time.
     @staticmethod
-    def load_binary(name, kernel_asm, shared, device):
+    def load_binary(name, kernel_obj, shared, device):
         return (
           None,       # module
-          kernel_asm, # function
+          kernel_obj, # function
           None,       # n_regs
           None        # n_spills
         )

--- a/backend/driver.py
+++ b/backend/driver.py
@@ -344,7 +344,7 @@ class CPUDriver(DriverBase):
         super().__init__()
         self.utils = CPUUtils()
         self.launcher_cls = CPULauncher
-        self.binary_ext = "cpuasm"
+        self.binary_ext = "obj"
 
     # CPU driver won't be automatically chosen unless explicitly set through
     # triton.runtime.driver.set_active(CPUDriver())

--- a/backend/driver.py
+++ b/backend/driver.py
@@ -253,7 +253,7 @@ def compile_module(launcher_src, kernel_placeholder_name):
 
         if cache_path is None:
           with tempfile.TemporaryDirectory() as tmpdir:
-              asm_src_path = os.path.join(tmpdir, "kernel.s")
+              asm_src_path = os.path.join(tmpdir, "kernel.o")
               launcher_src_path = os.path.join(tmpdir, "main.cxx")
               so_path = os.path.join(tmpdir, "kernel.so")
               Path(asm_src_path).write_bytes(asm_src)

--- a/python/examples/test_reduce.py
+++ b/python/examples/test_reduce.py
@@ -58,4 +58,4 @@ def test(device):
     print(ret.asm["ttir"])
     print(ret.asm["ttsharedir"])
     print(ret.asm["llir"])
-    print(ret.asm["cpuasm"])
+    print(ret.asm["obj"])


### PR DESCRIPTION
Currently, [_llir_to_bin generates ASM instead of OBJ](https://github.com/microsoft/triton-shared/blob/main/backend/compiler.py#L123C1-L123C64)

This approach works fine for Linux. However, for Windows using MSVC, compiling an ASM file and a CPP file together is not supported. You have to compile ASM separately and then link the resulting OBJ when compiling the CPP file.

This change will let _llir_to_bin generate OBJ directly. This would be similar to make_hsaco for AMD and make_cubin for CUDA, where the result is binary instead of text as well.