### PR TITLE
Do not assert in pointer analysis when visiting unknown ops

### DIFF
--- a/lib/AnalysisStructured/PtrAnalysis.cpp
+++ b/lib/AnalysisStructured/PtrAnalysis.cpp
@@ -711,7 +711,8 @@ LogicalResult PtrAnalysis::visitOperand(Value operand, PtrState &state,
       } else if (auto makeTensorOp = dyn_cast<triton::MakeTensorPtrOp>(op)) {
         llvm_unreachable("Unexpected operand defining operation tts.make_tptr");
       } else {
-        llvm_unreachable("Unexpected operand defining operation");
+        op->emitRemark("Unexpected defining op for triton pointer operand");
+        return failure();
       }
     } else {
       state.source = operand;


### PR DESCRIPTION
Instead of asserting which will crash the pass, we want to return failure which allow other fallback passes to handle the unsupported pointer sequences.