### PR TITLE
Handle `ptr_to_int` in triton-to-unstructured

### DIFF
--- a/lib/Conversion/TritonToUnstructured/CMakeLists.txt
+++ b/lib/Conversion/TritonToUnstructured/CMakeLists.txt
@@ -19,4 +19,5 @@ add_triton_library(TritonToUnstructured
   TritonTransforms
   TritonSharedAnalysisStructured
   TritonStructuredIR
+  TritonSharedUtils
 )

--- a/lib/Conversion/TritonToUnstructured/TritonToUnstructuredPass.cpp
+++ b/lib/Conversion/TritonToUnstructured/TritonToUnstructuredPass.cpp
@@ -264,6 +264,8 @@ public:
     });
 
     getOperation().walk([&](triton::IntToPtrOp op) {
+      // We only want to handle single source pointer,
+      // skip if this op produces tensor of pointers
       if (isa<RankedTensorType>(op.getType())) {
         return;
       }
@@ -599,8 +601,6 @@ public:
           "with tensor of offsets");
       return;
     }
-
-    return;
 
     PassManager pm(&getContext(), getOperation().getOperationName());
     pm.addPass(createCanonicalizerPass());


### PR DESCRIPTION
This PR adds support for `ptr_to_int` in triton-to-unstructured and also fixes a bug with `int_to_ptr` 
- When we convert a pointer to an integer, materialize a new pointer using the offset that we have built up so far. This helps simplify the pointer chain leading to `ptr_to_int`.
- Only walk pointer chains originating from `int_to_ptr` if the op produces single pointers.