### PR TITLE
Add option to lower triton tensor ptr ops to linalg

### DIFF
--- a/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
+++ b/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
@@ -1977,6 +1977,85 @@ class AddPtrConverter : public OpConversionPattern<triton::AddPtrOp> {
   }
 };
 
+// Convert triton op X operating on tensors of pointers to a linalg.generic
+// wrapping op X to operate on single pointer.
+template <typename OpType>
+class TensorOpConverter : public OpConversionPattern<OpType> {
+  using OpConversionPattern<OpType>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(OpType op, typename OpType::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto resType = op.getResult().getType();
+    if (!isa<ShapedType>(resType)) {
+      return failure();
+    }
+    auto resultTensorType = cast<RankedTensorType>(resType);
+    auto rank = resultTensorType.getRank();
+    SmallVector<AffineMap> indexingMaps(
+        /*numResult + numOperands*/ op->getNumResults() + op->getNumOperands(),
+        rewriter.getMultiDimIdentityMap(rank));
+    SmallVector<utils::IteratorType> iteratorTypes(
+        rank, utils::IteratorType::parallel);
+    SmallVector<Value> outputs = {rewriter.create<tensor::EmptyOp>(
+        op->getLoc(), resultTensorType.getShape(),
+        resultTensorType.getElementType())};
+    rewriter.replaceOpWithNewOp<linalg::GenericOp>(
+        op, op->getResultTypes(), op->getOperands(), outputs, indexingMaps,
+        iteratorTypes,
+        [&](OpBuilder &builder, Location loc, ValueRange regionArgs) {
+          auto resultTypes = llvm::to_vector(
+              llvm::map_range(op->getResultTypes(), [](Type type) {
+                return cast<TensorType>(type).getElementType();
+              }));
+          auto *scalarOp =
+              builder.create(loc, op->getName().getIdentifier(),
+                             regionArgs.take_front(op->getNumOperands()),
+                             resultTypes, op->getAttrs());
+          builder.create<linalg::YieldOp>(loc, scalarOp->getResults());
+        });
+    return success();
+  }
+};
+
+// Convert triton store op operating on tensors of pointers to a linalg.generic
+// wrapping op a triton store op on single pointer.
+// Note that this linalg.generic op has an empty `out` param.
+class StorePtrToLinalgConverter : public OpConversionPattern<triton::StoreOp> {
+  using OpConversionPattern<triton::StoreOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(triton::StoreOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto storeTensorType = dyn_cast<RankedTensorType>(op.getValue().getType());
+    if (!storeTensorType) {
+      return failure();
+    }
+    auto rank = storeTensorType.getRank();
+    SmallVector<AffineMap> indexingMaps(
+        /*numResult + numOperands*/ op->getNumResults() + op.getNumOperands(),
+        rewriter.getMultiDimIdentityMap(rank));
+    SmallVector<utils::IteratorType> iteratorTypes(
+        rank, utils::IteratorType::parallel);
+    SmallVector<Value> outputs;
+    rewriter.replaceOpWithNewOp<linalg::GenericOp>(
+        op, op->getResultTypes(), op->getOperands(), outputs, indexingMaps,
+        iteratorTypes,
+        [&](OpBuilder &builder, Location loc, ValueRange regionArgs) {
+          auto resultTypes = llvm::to_vector<6>(
+              llvm::map_range(op->getResultTypes(), [](Type type) {
+                return cast<TensorType>(type).getElementType();
+              }));
+          auto *scalarOp =
+              builder.create(loc, op->getName().getIdentifier(),
+                             regionArgs.take_front(op->getNumOperands()),
+                             resultTypes, op->getAttrs());
+          builder.create<linalg::YieldOp>(loc, scalarOp->getResults());
+        });
+    return success();
+  }
+};
+
 class ReshapeConverter : public OpConversionPattern<triton::ReshapeOp> {
   using OpConversionPattern<triton::ReshapeOp>::OpConversionPattern;
 

--- a/include/triton-shared/Conversion/TritonArithToLinalg/Passes.td
+++ b/include/triton-shared/Conversion/TritonArithToLinalg/Passes.td
@@ -14,6 +14,8 @@ def TritonArithToLinalg : Pass<"triton-arith-to-linalg", "mlir::ModuleOp"> {
              "Convert tt.addptr on tensors to linalg">,
       Option<"assertToCf", "assert-to-cf", "bool", /*default*/"true",
              "Convert tt.assert to cf.assert">,
+      Option<"tensorPtrToLinalg", "tensor-ptr-to-linalg", "bool", /*default*/"false",
+             "Convert triton ops on tensor of pointers to linalg.generic">,
   ];
 }
 

--- a/include/triton-shared/Conversion/TritonArithToLinalg/TritonArithToLinalg.h
+++ b/include/triton-shared/Conversion/TritonArithToLinalg/TritonArithToLinalg.h
@@ -20,7 +20,11 @@ void populateTritonArithToLinalgConversionPatterns(bool pidsToFuncArgs,
                                                    bool assertToCf,
                                                    RewritePatternSet &patterns);
 
-std::unique_ptr<OperationPass<ModuleOp>> createTritonArithToLinalgPass();
+// Expand the triton pointer ops operating on pointers to linalg
+void populateTritonTensorPtrConversionPatterns(RewritePatternSet &patterns);
+
+std::unique_ptr<OperationPass<ModuleOp>>
+createTritonArithToLinalgPass(bool tensorPtrToLinalg = false);
 
 } // namespace triton
 } // namespace mlir

--- a/lib/Conversion/TritonArithToLinalg/TritonArithToLinalg.cpp
+++ b/lib/Conversion/TritonArithToLinalg/TritonArithToLinalg.cpp
@@ -40,6 +40,14 @@ void mlir::triton::populateTritonArithToLinalgCanonicalizationPatterns(
       patterns.getContext());
 }
 
+void mlir::triton::populateTritonTensorPtrConversionPatterns(
+    RewritePatternSet &patterns) {
+  patterns.add<StorePtrToLinalgConverter, TensorOpConverter<triton::LoadOp>,
+               TensorOpConverter<triton::IntToPtrOp>,
+               TensorOpConverter<triton::PtrToIntOp>,
+               TensorOpConverter<triton::BitcastOp>>(patterns.getContext());
+}
+
 void mlir::triton::populateTritonArithToLinalgConversionPatterns(
     bool pidsToFuncArgs, bool addptrToLinalg, bool assertToCf,
     RewritePatternSet &patterns) {

--- a/lib/Conversion/TritonArithToLinalg/TritonArithToLinalgPass.cpp
+++ b/lib/Conversion/TritonArithToLinalg/TritonArithToLinalgPass.cpp
@@ -158,10 +158,9 @@ public:
     }
 
     if (addptrToLinalg) {
-      target.addDynamicallyLegalOp<triton::AddPtrOp>(
-          [](auto op) {
-            return !isa<ShapedType>(op->getOperands()[0].getType());
-          });
+      target.addDynamicallyLegalOp<triton::AddPtrOp>([](auto op) {
+        return !isa<ShapedType>(op->getOperands()[0].getType());
+      });
     }
 
     // TODO: Might want to consolidate this flag with addptrToLinalg later.

--- a/lib/Conversion/TritonArithToLinalg/TritonArithToLinalgPass.cpp
+++ b/lib/Conversion/TritonArithToLinalg/TritonArithToLinalgPass.cpp
@@ -158,8 +158,8 @@ public:
     }
 
     if (addptrToLinalg) {
-      target.addDynamicallyLegalOp<triton::AddPtrOp>([](auto op) {
-        return !isa<ShapedType>(op->getOperands()[0].getType());
+      target.addDynamicallyLegalOp<triton::AddPtrOp>([](triton::AddPtrOp op) {
+        return !isa<ShapedType>(op.getResult().getType());
       });
     }
 

--- a/test/Conversion/TritonArithToLinalg/triton_tensor_ptr_ops.mlir
+++ b/test/Conversion/TritonArithToLinalg/triton_tensor_ptr_ops.mlir
@@ -1,0 +1,51 @@
+// Test all triton ops on tensor of pointers are converted to linalg.generic
+// Original triton program:
+//    @triton.jit
+//    def tensor_ptr(in_ptr0, out_ptr0):
+//        ints = tl.load(in_ptr0 + tl.arange(0, 16)).to(tl.int64)
+//        ptrs = ints.to(tl.pointer_type(tl.int32))
+//        vals = tl.load(ptrs)
+//        out_ptrs = out_ptr0 + tl.arange(0, 16)
+//        ints_2 = out_ptrs.to(tl.int64) + vals
+//        out_ptrs = out_ptr0 + tl.arange(0, 16)
+//        out_ptrs_i64 = out_ptrs.to(tl.pointer_type(tl.int64))
+//        out_ptrs_i64 += 2
+//        out_ptrs_i32 = out_ptrs_i64.to(tl.pointer_type(tl.int32))
+//        tl.store(out_ptrs_i32, ints_2.to(tl.int32))
+
+// RUN: triton-shared-opt --triton-arith-to-linalg="tensor-ptr-to-linalg=true" %s | FileCheck %s
+
+module {
+  tt.func public @tensor_ptr(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>) attributes {noinline = false} {
+    %cst = arith.constant dense<2> : tensor<16xi32>
+    %0 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %1 = tt.splat %arg0 : !tt.ptr<i32> -> tensor<16x!tt.ptr<i32>>
+    %2 = tt.addptr %1, %0 : tensor<16x!tt.ptr<i32>>, tensor<16xi32>
+    %3 = tt.load %2 : tensor<16x!tt.ptr<i32>>
+    %4 = arith.extsi %3 : tensor<16xi32> to tensor<16xi64>
+    %5 = tt.int_to_ptr %4 : tensor<16xi64> -> tensor<16x!tt.ptr<i32>>
+    %6 = tt.load %5 : tensor<16x!tt.ptr<i32>>
+    %7 = tt.splat %arg1 : !tt.ptr<i32> -> tensor<16x!tt.ptr<i32>>
+    %8 = tt.addptr %7, %0 : tensor<16x!tt.ptr<i32>>, tensor<16xi32>
+    %9 = tt.ptr_to_int %8 : tensor<16x!tt.ptr<i32>> -> tensor<16xi64>
+    %10 = arith.extsi %6 : tensor<16xi32> to tensor<16xi64>
+    %11 = arith.addi %9, %10 : tensor<16xi64>
+    %12 = tt.bitcast %8 : tensor<16x!tt.ptr<i32>> -> tensor<16x!tt.ptr<i64>>
+    %13 = tt.addptr %12, %cst : tensor<16x!tt.ptr<i64>>, tensor<16xi32>
+    %14 = tt.bitcast %13 : tensor<16x!tt.ptr<i64>> -> tensor<16x!tt.ptr<i32>>
+    %15 = arith.trunci %11 : tensor<16xi64> to tensor<16xi32>
+    tt.store %14, %15 : tensor<16x!tt.ptr<i32>>
+    tt.return
+  }
+}
+
+// CHECK: tt.addptr %in, %in_0 : !tt.ptr<i32>, i32
+// CHECK: tt.load %in : !tt.ptr<i32>
+// CHECK: tt.int_to_ptr %in : i64 -> !tt.ptr<i32>
+// CHECK: tt.load %in : !tt.ptr<i32>
+// CHECK: tt.addptr %in, %in_0 : !tt.ptr<i32>, i32
+// CHECK: tt.ptr_to_int %in : !tt.ptr<i32> -> i64
+// CHECK: tt.bitcast %in : !tt.ptr<i32> -> !tt.ptr<i64>
+// CHECK: tt.addptr %in, %in_0 : !tt.ptr<i64>, i32
+// CHECK: tt.bitcast %in : !tt.ptr<i64> -> !tt.ptr<i32>
+// CHECK: tt.store %in, %in_0 : !tt.ptr<i32>

--- a/test/Conversion/TritonArithToLinalg/triton_tensor_ptr_ops.mlir
+++ b/test/Conversion/TritonArithToLinalg/triton_tensor_ptr_ops.mlir
@@ -39,13 +39,53 @@ module {
   }
 }
 
-// CHECK: tt.addptr %in, %in_0 : !tt.ptr<i32>, i32
-// CHECK: tt.load %in : !tt.ptr<i32>
-// CHECK: tt.int_to_ptr %in : i64 -> !tt.ptr<i32>
-// CHECK: tt.load %in : !tt.ptr<i32>
-// CHECK: tt.addptr %in, %in_0 : !tt.ptr<i32>, i32
-// CHECK: tt.ptr_to_int %in : !tt.ptr<i32> -> i64
-// CHECK: tt.bitcast %in : !tt.ptr<i32> -> !tt.ptr<i64>
-// CHECK: tt.addptr %in, %in_0 : !tt.ptr<i64>, i32
-// CHECK: tt.bitcast %in : !tt.ptr<i64> -> !tt.ptr<i32>
-// CHECK: tt.store %in, %in_0 : !tt.ptr<i32>
+// CHECK:  linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]}
+// CHECK:           ^bb0([[in0:%.+]]: !tt.ptr<i32>, [[in1:%.+]]: i32, [[IN_3_:%.+]]: !tt.ptr<i32>):
+// CHECK:             [[res:%.+]] = tt.addptr [[in0]], [[in1]] : !tt.ptr<i32>, i32
+// CHECK:             linalg.yield [[res]] : !tt.ptr<i32>
+// CHECK:           } -> tensor<16x!tt.ptr<i32>>
+// CHECK:  linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]}
+// CHECK:           ^bb0([[in0:%.+]]: !tt.ptr<i32>, [[in1:%.+]]: i32):
+// CHECK:             [[res:%.+]] = tt.load [[in0]] : !tt.ptr<i32>
+// CHECK:             linalg.yield [[res]] : i32
+// CHECK:           } -> tensor<16xi32>
+// CHECK:  linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]}
+// CHECK:           ^bb0([[in0:%.+]]: i64, [[in1:%.+]]: !tt.ptr<i32>):
+// CHECK:             [[res:%.+]] = tt.int_to_ptr [[in0]] : i64 -> !tt.ptr<i32>
+// CHECK:             linalg.yield [[res]] : !tt.ptr<i32>
+// CHECK:           } -> tensor<16x!tt.ptr<i32>>
+// CHECK:  linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]}
+// CHECK:           ^bb0([[in0:%.+]]: !tt.ptr<i32>, [[in1:%.+]]: i32):
+// CHECK:             [[res:%.+]] = tt.load [[in0]] : !tt.ptr<i32>
+// CHECK:             linalg.yield [[res]] : i32
+// CHECK:           } -> tensor<16xi32>
+// CHECK:  linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]}
+// CHECK:           ^bb0([[in0:%.+]]: !tt.ptr<i32>, [[in1:%.+]]: i32, [[IN_14_:%.+]]: !tt.ptr<i32>):
+// CHECK:             [[res:%.+]] = tt.addptr [[in0]], [[in1]] : !tt.ptr<i32>, i32
+// CHECK:             linalg.yield [[res]] : !tt.ptr<i32>
+// CHECK:           } -> tensor<16x!tt.ptr<i32>>
+// CHECK:  linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]}
+// CHECK:           ^bb0([[in0:%.+]]: !tt.ptr<i32>, [[in1:%.+]]: i64):
+// CHECK:             [[res:%.+]] = tt.ptr_to_int [[in0]] : !tt.ptr<i32> -> i64
+// CHECK:             linalg.yield [[res]] : i64
+// CHECK:           } -> tensor<16xi64>
+// CHECK:  linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]}
+// CHECK:           ^bb0([[in0:%.+]]: !tt.ptr<i32>, [[in1:%.+]]: !tt.ptr<i64>):
+// CHECK:             [[res:%.+]] = tt.bitcast [[in0]] : !tt.ptr<i32> -> !tt.ptr<i64>
+// CHECK:             linalg.yield [[res]] : !tt.ptr<i64>
+// CHECK:           } -> tensor<16x!tt.ptr<i64>>
+// CHECK:  linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]}
+// CHECK:           ^bb0([[in0:%.+]]: !tt.ptr<i64>, [[in1:%.+]]: i32, [[IN_26_:%.+]]: !tt.ptr<i64>):
+// CHECK:             [[res:%.+]] = tt.addptr [[in0]], [[in1]] : !tt.ptr<i64>, i32
+// CHECK:             linalg.yield [[res]] : !tt.ptr<i64>
+// CHECK:           } -> tensor<16x!tt.ptr<i64>>
+// CHECK:  linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]}
+// CHECK:           ^bb0([[in0:%.+]]: !tt.ptr<i64>, [[in1:%.+]]: !tt.ptr<i32>):
+// CHECK:             [[res:%.+]] = tt.bitcast [[in0]] : !tt.ptr<i64> -> !tt.ptr<i32>
+// CHECK:             linalg.yield [[res]] : !tt.ptr<i32>
+// CHECK:           } -> tensor<16x!tt.ptr<i32>>
+// CHECK:           linalg.generic
+// CHECK:           ^bb0([[in0:%.+]]: !tt.ptr<i32>, [[in1:%.+]]: i32):
+// CHECK:             tt.store [[in0]], [[in1]] : !tt.ptr<i32>
+// CHECK:             linalg.yield
+// CHECK:           }


### PR DESCRIPTION
Add an option in `triton-arith-to-linalg` to convert triton ops on tensor of pointers (tt.load, tt.store, tt.bitcast, tt.int_to_ptr, tt.ptr_to_int) to linalg. This option is disabled by default and can be enabled by setting the `convert-tensor-ptr-ops` flag to true in the `triton-arith-to-linalg` pass.

This will help with lowering these triton ops to the equivalent ops in the PtrDialect later.