### PR TITLE
Fix passing pid args to call op

### DIFF
--- a/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
+++ b/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
@@ -888,8 +888,9 @@ struct CallConverter : public OpConversionPattern<triton::CallOp> {
 
           if (argsNeed > args.size()) {
             int missing = argsNeed - args.size();
+            int missingArgsStart = argsParent - missing;
             for (int i = 0; i < missing; i++) {
-              args.push_back(parentInputs[args.size()]);
+              args.push_back(parentInputs[missingArgsStart + i]);
             }
           }
         }

--- a/test/Conversion/TritonPtrToMemref/call.mlir
+++ b/test/Conversion/TritonPtrToMemref/call.mlir
@@ -5,9 +5,11 @@ module {
     %0 = arith.constant 42.0 : f32
     tt.return %0 : f32
   }
-  tt.func @test(%arg0: !tt.ptr<f32>) -> f32{
+  tt.func @test(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>) -> f32{
     %0 = tt.call @_sum_combine__fp32(%arg0) : (!tt.ptr<f32>) -> f32
-    tt.return %0 : f32
+    %1 = tt.call @_sum_combine__fp32(%arg1) : (!tt.ptr<f32>) -> f32
+    %2 = arith.addf %0, %1 : f32
+    tt.return %2 : f32
   }
 }
 
@@ -16,8 +18,10 @@ module {
 // CHECK:     %cst = arith.constant 4.200000e+01 : f32
 // CHECK:     return %cst : f32
 // CHECK:   }
-// CHECK:   func.func @test(%arg0: memref<*xf32>, %arg1: i32, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32, %arg6: i32) -> f32 {
-// CHECK:     %0 = call @_sum_combine__fp32(%arg0, %arg1, %arg2, %arg3, %arg4, %arg5, %arg6) : (memref<*xf32>, i32, i32, i32, i32, i32, i32) -> f32
-// CHECK:     return %0 : f32
+// CHECK:   func.func @test(%arg0: memref<*xf32>, %arg1: memref<*xf32>, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32, %arg6: i32, %arg7: i32) -> f32 {
+// CHECK:     %0 = call @_sum_combine__fp32(%arg0, %arg2, %arg3, %arg4, %arg5, %arg6, %arg7) : (memref<*xf32>, i32, i32, i32, i32, i32, i32) -> f32
+// CHECK:     %1 = call @_sum_combine__fp32(%arg1, %arg2, %arg3, %arg4, %arg5, %arg6, %arg7) : (memref<*xf32>, i32, i32, i32, i32, i32, i32) -> f32
+// CHECK:     %2 = arith.addf %0, %1 : f32
+// CHECK:     return %2 : f32
 // CHECK:   }
 // CHECK: }


### PR DESCRIPTION
**Description:**
The start index of `num_programs`/`program_id` arguments (missing args) is incorrect. When the args of `parentFunc` and `calleeFunc` are different, it fails (e.g. the modified test case for `tt.call` op).

**Fix:**
Modify the calculation of the start index.