### PR TITLE
Add missing TPtrIR dependency to TritonToLinalg

### DIFF
--- a/lib/Conversion/TritonToLinalgExperimental/CMakeLists.txt
+++ b/lib/Conversion/TritonToLinalgExperimental/CMakeLists.txt
@@ -22,6 +22,7 @@ add_triton_library(TritonToLinalgExperimental
   MLIRTensorDialect
   MLIRTransforms
   MLIRSupport
+  TPtrIR
   TritonIR
   TritonTransforms
   TritonSharedAnalysis


### PR DESCRIPTION
This pass uses TPtr, and so it should have the dependency. Not having it can sometimes cause build failures.