### PR TITLE
Update triton to 9451f8f2bf12014ddadb8a001b1f5ca7db60322a

### DIFF
--- a/include/triton-shared/Dialect/TPtr/IR/CMakeLists.txt
+++ b/include/triton-shared/Dialect/TPtr/IR/CMakeLists.txt
@@ -1,4 +1,6 @@
 set(LLVM_TARGET_DEFINITIONS TPtrDialect.td)
+mlir_tablegen(TPtrAttributes.h.inc  -gen-attrdef-decls -attrdefs-dialect=tptr)
+mlir_tablegen(TPtrAttributes.cpp.inc  -gen-attrdef-defs -attrdefs-dialect=tptr)
 mlir_tablegen(TPtrDialect.h.inc -gen-dialect-decls -dialect=tptr)
 mlir_tablegen(TPtrDialect.cpp.inc -gen-dialect-defs -dialect=tptr)
 mlir_tablegen(TPtrOps.h.inc -gen-op-decls)

--- a/include/triton-shared/Dialect/TPtr/IR/TPtrDialect.h
+++ b/include/triton-shared/Dialect/TPtr/IR/TPtrDialect.h
@@ -1,18 +1,18 @@
 #ifndef MLIR_DIALECT_TPTR_IR_TPTR_DIALECT_H_
 #define MLIR_DIALECT_TPTR_IR_TPTR_DIALECT_H_
 
-#include "mlir/Interfaces/SideEffectInterfaces.h" // Required for IR/TPtrOps.h.inc
 #include "mlir/Bytecode/BytecodeOpInterface.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h" // Required for IR/TPtrOps.h.inc
 
 #include "mlir/Dialect/Ptr/IR/PtrDialect.h" // Required for IR/TPtrOps.h.inc
-#include "mlir/Dialect/Ptr/IR/PtrTypes.h" // Required for IR/TPtrOps.h.inc
+#include "mlir/Dialect/Ptr/IR/PtrTypes.h"   // Required for IR/TPtrOps.h.inc
 
 //===----------------------------------------------------------------------===//
 // Temporary Pointer Dialect Operations
 //===----------------------------------------------------------------------===//
 #include "triton-shared/Dialect/TPtr/IR/TPtrDialect.h.inc"
 
-// Include the auto-generated header file containing the declarations of the
+// Include the auto-generated header files containing the declarations of the
 // Temporary Pointer Dialect operations.
 #define GET_OP_CLASSES
 #include "triton-shared/Dialect/TPtr/IR/TPtrOps.h.inc"
@@ -20,4 +20,6 @@
 #define GET_TYPEDEF_CLASSES
 #include "triton-shared/Dialect/TPtr/IR/TPtrTypes.h.inc"
 
+#define GET_ATTRDEF_CLASSES
+#include "triton-shared/Dialect/TPtr/IR/TPtrAttributes.h.inc"
 #endif

--- a/include/triton-shared/Dialect/TPtr/IR/TPtrDialect.td
+++ b/include/triton-shared/Dialect/TPtr/IR/TPtrDialect.td
@@ -3,8 +3,10 @@
 
 include "mlir/IR/OpBase.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
+include "mlir/Dialect/Ptr/IR/MemorySpaceInterfaces.td"
 include "mlir/Dialect/Ptr/IR/PtrDialect.td"
 include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/BuiltinAttributeInterfaces.td"
 include "mlir/IR/BuiltinTypeInterfaces.td"
 
 def TPtr_Dialect : Dialect {
@@ -26,6 +28,7 @@ def TPtr_Dialect : Dialect {
     "mlir::ptr::PtrDialect"
   ];
 
+  let useDefaultAttributePrinterParser = 1;
   let usePropertiesForAttributes = 1;
 }
 
@@ -33,6 +36,20 @@ class TPtrTypeDef<string name, string _mnemonic, list<Trait> traits = []>
     : TypeDef<TPtr_Dialect, name, traits> {
     // Used by printer/parser
     let mnemonic = _mnemonic;
+}
+
+class TPtr_Attr<string name, string _mnemonic,
+                     list<Trait> traits = []>
+    : AttrDef<TPtr_Dialect, name, traits> {
+  let mnemonic = _mnemonic;
+}
+
+// Memory space attr is required for building Ptr ops
+// This acts as default memory space since there is
+// no such default implemented upstream
+def DefaultMemorySpaceAttr
+    : TPtr_Attr<"DefaultMemorySpace", "default_memory_space",
+                     [DeclareAttrInterfaceMethods<MemorySpaceAttrInterface>]> {
 }
 
 //

--- a/lib/Conversion/TritonToLinalgExperimental/ReconcilePtrCastsPass.cpp
+++ b/lib/Conversion/TritonToLinalgExperimental/ReconcilePtrCastsPass.cpp
@@ -4,17 +4,16 @@
 // Licensed under the MIT license.
 //
 //===----------------------------------------------------------------------===//
-// Throughout the conversion process, we convert !tt.ptr -> {!ptr.ptr or memref<*>}.
-// This process leaves around unrealized_conversion_cast ops between these types.
-// We want to remove these unrealized casts and use the proper conversion ops
-// in the PtrDialect: to_memref or from_memref.
-// To do this, we use a pattern that simplifies the chain of conversions by
-// removing intermediate conversion cast ops. At the end, we are left with just
-// pointer to memref or vice versa. We then convert the unrealized cast to
-// to_memref or from_memref accordingly.
+// Throughout the conversion process, we convert !tt.ptr -> {!ptr.ptr or
+// memref<*>}. This process leaves around unrealized_conversion_cast ops between
+// these types. We want to remove these unrealized casts and use the proper
+// conversion ops in the PtrDialect: to_memref or from_memref. To do this, we
+// use a pattern that simplifies the chain of conversions by removing
+// intermediate conversion cast ops. At the end, we are left with just pointer
+// to memref or vice versa. We then convert the unrealized cast to to_memref or
+// from_memref accordingly.
 //===----------------------------------------------------------------------===//
 
-#include "triton-shared/Conversion/TritonToLinalgExperimental/ReconcilePtrCasts.h"
 #include "mlir/Conversion/ReconcileUnrealizedCasts/ReconcileUnrealizedCasts.h"
 #include "mlir/Dialect/Ptr/IR/PtrTypes.h"
 #include "mlir/IR/Builders.h"
@@ -23,6 +22,7 @@
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/ValueRange.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "triton-shared/Conversion/TritonToLinalgExperimental/ReconcilePtrCasts.h"
 
 #include "triton-shared/Dialect/TPtr/IR/TPtrDialect.h"
 
@@ -94,7 +94,11 @@ struct FromMemrefConverter
           op.getLoc(), MemRefType::get({}, unrankedInput.getElementType()),
           input);
       auto memrefToPtr = rewriter.create<tptr::FromMemrefOp>(
-          op->getLoc(), ptr::PtrType::get(rewriter.getContext()), rankedMemref);
+          op->getLoc(),
+          ptr::PtrType::get(
+              rewriter.getContext(),
+              tptr::DefaultMemorySpaceAttr::get(rewriter.getContext())),
+          rankedMemref);
 
       rewriter.replaceAllUsesWith(output, memrefToPtr);
       rewriter.eraseOp(op);
@@ -161,7 +165,6 @@ public:
 };
 } // namespace
 
-std::unique_ptr<OperationPass<ModuleOp>>
-triton::createReconcilePtrCastsPass() {
+std::unique_ptr<OperationPass<ModuleOp>> triton::createReconcilePtrCastsPass() {
   return std::make_unique<ReconcilePtrCastsPass>();
 }

--- a/lib/Dialect/TPtr/IR/TPtrDialect.cpp
+++ b/lib/Dialect/TPtr/IR/TPtrDialect.cpp
@@ -4,6 +4,8 @@
 
 #include "mlir/Dialect/Ptr/IR/PtrDialect.h"
 #include "mlir/Dialect/Ptr/IR/PtrTypes.h"
+#include "mlir/IR/DialectImplementation.h"
+#include "llvm/ADT/TypeSwitch.h"
 
 #define GET_TYPEDEF_CLASSES
 #include "triton-shared/Dialect/TPtr/IR/TPtrTypes.cpp.inc"
@@ -37,6 +39,10 @@ void mlir::tptr::TPtrDialect::registerTypes() {
 /// Dialect creation, the instance will be owned by the context. This is the
 /// point of registration of custom types and operations for the dialect.
 void mlir::tptr::TPtrDialect::initialize() {
+  addAttributes<
+#define GET_ATTRDEF_LIST
+#include "triton-shared/Dialect/TPtr/IR/TPtrAttributes.cpp.inc"
+      >();
   registerTypes();
   addOperations<
 #define GET_OP_LIST
@@ -44,11 +50,51 @@ void mlir::tptr::TPtrDialect::initialize() {
       >();
 }
 
+LogicalResult tptr::DefaultMemorySpaceAttr::isValidLoad(
+    Type type, mlir::ptr::AtomicOrdering ordering, IntegerAttr alignment,
+    llvm::function_ref<InFlightDiagnostic()> emitError) const {
+  return success();
+}
+
+LogicalResult tptr::DefaultMemorySpaceAttr::isValidStore(
+    Type type, mlir::ptr::AtomicOrdering ordering, IntegerAttr alignment,
+    llvm::function_ref<InFlightDiagnostic()> emitError) const {
+  return success();
+}
+
+LogicalResult tptr::DefaultMemorySpaceAttr::isValidAtomicOp(
+    mlir::ptr::AtomicBinOp binOp, Type type, mlir::ptr::AtomicOrdering ordering,
+    IntegerAttr alignment,
+    llvm::function_ref<InFlightDiagnostic()> emitError) const {
+  return success();
+}
+
+LogicalResult tptr::DefaultMemorySpaceAttr::isValidAtomicXchg(
+    Type type, mlir::ptr::AtomicOrdering successOrdering,
+    mlir::ptr::AtomicOrdering failureOrdering, IntegerAttr alignment,
+    llvm::function_ref<InFlightDiagnostic()> emitError) const {
+  return success();
+}
+
+LogicalResult tptr::DefaultMemorySpaceAttr::isValidAddrSpaceCast(
+    Type tgt, Type src,
+    llvm::function_ref<InFlightDiagnostic()> emitError) const {
+  return success();
+}
+
+LogicalResult tptr::DefaultMemorySpaceAttr::isValidPtrIntCast(
+    Type intLikeTy, Type ptrLikeTy,
+    llvm::function_ref<InFlightDiagnostic()> emitError) const {
+  return success();
+}
 //===----------------------------------------------------------------------===//
 // TableGen'd op method definitions
 //===----------------------------------------------------------------------===//
 
 #define GET_OP_CLASSES
 #include "triton-shared/Dialect/TPtr/IR/TPtrOps.cpp.inc"
+
+#define GET_ATTRDEF_CLASSES
+#include "triton-shared/Dialect/TPtr/IR/TPtrAttributes.cpp.inc"
 
 #include "triton-shared/Dialect/TPtr/IR/TPtrDialect.cpp.inc"

--- a/python/examples/test_addptr.py
+++ b/python/examples/test_addptr.py
@@ -35,7 +35,7 @@ def test(device):
     # TODO: need to check some conditions otherwise the code below does not make any difference for the test
     src = triton.compiler.ASTSource(
         fn=addptr,
-        signature="*fp32,*fp32",
+        signature={"in0": "*fp32", "out0": "*fp32"},
     )
     ret = triton.compile(
         src,

--- a/python/examples/test_mask.py
+++ b/python/examples/test_mask.py
@@ -25,7 +25,7 @@ def test_mask(device):
 
     src = triton.compiler.ASTSource(
         fn=test,
-        signature="*fp32,*fp32,i32",
+        signature={"in0": "*fp32", "out0": "*fp32"},
     )
     ret = triton.compile(
         src,

--- a/python/examples/test_nested_loops.py
+++ b/python/examples/test_nested_loops.py
@@ -292,7 +292,7 @@ def test_nested3():
 
     src = triton.compiler.ASTSource(
         fn=nested3,
-        signature="*fp32,*fp32,i32,i32",
+        signature={"in_ptr": "*fp32", "out_ptr": "*fp32", "stride_m": "i32", "stride_n": "i32"},
     )
     ret = triton.compile(
         src,
@@ -330,7 +330,7 @@ def test_nested2_use_loop_results():
 
     src = triton.compiler.ASTSource(
         fn=nested2_use_loop_results,
-        signature="*fp32,*fp32,i32,i32",
+        signature={"in_ptr": "*fp32", "out_ptr": "*fp32", "stride_m": "i32", "stride_n": "i32"},
     )
     ret = triton.compile(
         src,
@@ -365,7 +365,7 @@ def test_nested2_complex_body():
 
     src = triton.compiler.ASTSource(
         fn=nested2_complex_body,
-        signature="*fp32,*fp32,i32,i32",
+        signature={"a_ptr": "*fp32", "c_ptr": "*fp32", "stride_m": "i32", "stride_n": "i32"},
     )
     ret = triton.compile(
         src,
@@ -404,7 +404,7 @@ def test_nested2_use_same_level_loop_result():
 
     src = triton.compiler.ASTSource(
         fn=nested_use_same_level_loop_results,
-        signature="*fp32,*fp32,i32,i32",
+        signature={"in_ptr": "*fp32", "out_ptr": "*fp32", "stride_m": "i32", "stride_n": "i32"},
     )
     ret = triton.compile(
         src,

--- a/python/examples/test_tensor_index_iterargs.py
+++ b/python/examples/test_tensor_index_iterargs.py
@@ -106,7 +106,7 @@ def test_integer_tensor(device):
     torch.testing.assert_close(input, output)
     src = triton.compiler.ASTSource(
         fn=test_1,
-        signature="*fp32",
+        signature={"out0": "*fp32"},
     )
     ret = triton.compile(
         src,

--- a/test/Conversion/ReconcilePtrCasts/ptr_into_memref.mlir
+++ b/test/Conversion/ReconcilePtrCasts/ptr_into_memref.mlir
@@ -6,19 +6,19 @@ module {
     %c1_i32 = arith.constant 1 : i32
     %c2 = arith.constant 2 : index
     %1 = builtin.unrealized_conversion_cast %arg1 : memref<*xi32> to !tt.ptr<i32>
-    %2 = builtin.unrealized_conversion_cast %1 : !tt.ptr<i32> to !ptr.ptr
+    %2 = builtin.unrealized_conversion_cast %1 : !tt.ptr<i32> to !ptr.ptr<#tptr.default_memory_space>
     %3 = builtin.unrealized_conversion_cast %arg0 : memref<*xi32> to !tt.ptr<i32>
-    %4 = builtin.unrealized_conversion_cast %3 : !tt.ptr<i32> to !ptr.ptr
+    %4 = builtin.unrealized_conversion_cast %3 : !tt.ptr<i32> to !ptr.ptr<#tptr.default_memory_space>
     %5 = arith.muli %c1_i32, %0 : i32
-    %6 = tptr.ptradd %4 %5 : !ptr.ptr, i32 to !ptr.ptr
-    %7 = builtin.unrealized_conversion_cast %6 : !ptr.ptr to !tt.ptr<i64>
+    %6 = tptr.ptradd %4 %5 : !ptr.ptr<#tptr.default_memory_space>, i32 to !ptr.ptr<#tptr.default_memory_space>
+    %7 = builtin.unrealized_conversion_cast %6 : !ptr.ptr<#tptr.default_memory_space> to !tt.ptr<i64>
     %8 = builtin.unrealized_conversion_cast %7 : !tt.ptr<i64> to memref<*xi64>
     %reinterpret_cast = memref.reinterpret_cast %8 to offset: [%c2], sizes: [16], strides: [1] : memref<*xi64> to memref<16xi64, strided<[1], offset: ?>>
     %alloc = memref.alloc() : memref<16xi64>
     memref.copy %reinterpret_cast, %alloc : memref<16xi64, strided<[1], offset: ?>> to memref<16xi64>
     %9 = bufferization.to_tensor %alloc restrict writable : memref<16xi64> to tensor<16xi64>
-    %10 = tptr.ptradd %2 %5 : !ptr.ptr, i32 to !ptr.ptr
-    %11 = builtin.unrealized_conversion_cast %10 : !ptr.ptr to !tt.ptr<i64>
+    %10 = tptr.ptradd %2 %5 : !ptr.ptr<#tptr.default_memory_space>, i32 to !ptr.ptr<#tptr.default_memory_space>
+    %11 = builtin.unrealized_conversion_cast %10 : !ptr.ptr<#tptr.default_memory_space> to !tt.ptr<i64>
     %12 = builtin.unrealized_conversion_cast %11 : !tt.ptr<i64> to memref<*xi64>
     %reinterpret_cast_0 = memref.reinterpret_cast %12 to offset: [%c2], sizes: [16], strides: [1] : memref<*xi64> to memref<16xi64, strided<[1], offset: ?>>
     bufferization.materialize_in_destination %9 in writable %reinterpret_cast_0 : (tensor<16xi64>, memref<16xi64, strided<[1], offset: ?>>) -> ()

--- a/test/Conversion/TritonToPtr/cast_with_int_ptr.mlir
+++ b/test/Conversion/TritonToPtr/cast_with_int_ptr.mlir
@@ -55,49 +55,49 @@ module {
 // CHECK-DAG:       [[CST_2_:%.+]] = arith.constant 2 : i32
 // CHECK-DAG:       [[CST_3_:%.+]] = arith.constant 3 : i32
 // CHECK-DAG:       [[CST_4_:%.+]] = arith.constant 4 : i32
-// CHECK-DAG:       [[VAR_5_:%.+]] = builtin.unrealized_conversion_cast [[PARAM_1_]] : !tt.ptr<i32> to !ptr.ptr
-// CHECK-DAG:       [[VAR_6_:%.+]] = builtin.unrealized_conversion_cast [[PARAM_0_]] : !tt.ptr<i32> to !ptr.ptr
+// CHECK-DAG:       [[VAR_5_:%.+]] = builtin.unrealized_conversion_cast [[PARAM_1_]] : !tt.ptr<i32> to !ptr.ptr<#tptr.default_memory_space>
+// CHECK-DAG:       [[VAR_6_:%.+]] = builtin.unrealized_conversion_cast [[PARAM_0_]] : !tt.ptr<i32> to !ptr.ptr<#tptr.default_memory_space>
 // CHECK:           [[VAR_7_:%.+]] = arith.muli [[CST_111_]], [[VAR_4_]] : i32
-// CHECK-DAG:       [[VAR_8_:%.+]] = tptr.ptradd [[VAR_6_]] [[VAR_7_]] : !ptr.ptr, i32 to !ptr.ptr
+// CHECK-DAG:       [[VAR_8_:%.+]] = tptr.ptradd [[VAR_6_]] [[VAR_7_]] : <#tptr.default_memory_space>, i32 to <#tptr.default_memory_space>
 // CHECK-DAG:       [[VAR_9_:%.+]] = arith.muli [[CST_10_]], [[VAR_3_]] : i32
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_10_:%.+]] = tptr.ptradd [[VAR_8_]] [[VAR_9_]] : !ptr.ptr, i32 to !ptr.ptr
-// CHECK-DAG:       [[VAR_11_:%.+]] = tptr.ptrtoint [[VAR_5_]] : !ptr.ptr to i64
+// CHECK-DAG:       [[VAR_10_:%.+]] = tptr.ptradd [[VAR_8_]] [[VAR_9_]] : <#tptr.default_memory_space>, i32 to <#tptr.default_memory_space>
+// CHECK-DAG:       [[VAR_11_:%.+]] = tptr.ptrtoint [[VAR_5_]] : <#tptr.default_memory_space> to i64
 // CHECK:           [[VAR_12_:%.+]] = arith.muli [[VAR_11_]], [[VAR_2_]] : i64
-// CHECK-DAG:       [[VAR_13_:%.+]] = tptr.ptradd [[VAR_5_]] [[VAR_12_]] : !ptr.ptr, i64 to !ptr.ptr
+// CHECK-DAG:       [[VAR_13_:%.+]] = tptr.ptradd [[VAR_5_]] [[VAR_12_]] : <#tptr.default_memory_space>, i64 to <#tptr.default_memory_space>
 // CHECK-DAG:       [[VAR_14_:%.+]] = arith.muli [[CST_9_]], [[VAR_4_]] : i32
-// CHECK:           [[VAR_15_:%.+]] = tptr.ptradd [[VAR_13_]] [[VAR_14_]] : !ptr.ptr, i32 to !ptr.ptr
-// CHECK:           [[VAR_16_:%.+]] = tptr.ptrtoint [[VAR_15_]] : !ptr.ptr to i64
+// CHECK:           [[VAR_15_:%.+]] = tptr.ptradd [[VAR_13_]] [[VAR_14_]] : <#tptr.default_memory_space>, i32 to <#tptr.default_memory_space>
+// CHECK:           [[VAR_16_:%.+]] = tptr.ptrtoint [[VAR_15_]] : <#tptr.default_memory_space> to i64
 // CHECK-DAG:       [[VAR_17_:%.+]] = arith.remsi [[VAR_16_]], [[CST_10_1_]] : i64
 // CHECK-DAG:       [[VAR_18_:%.+]] = arith.muli [[CST_1_]], [[VAR_4_]] : i32
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_19_:%.+]] = tptr.ptradd [[VAR_10_]] [[VAR_18_]] : !ptr.ptr, i32 to !ptr.ptr
+// CHECK-DAG:       [[VAR_19_:%.+]] = tptr.ptradd [[VAR_10_]] [[VAR_18_]] : <#tptr.default_memory_space>, i32 to <#tptr.default_memory_space>
 // CHECK-DAG:       [[VAR_20_:%.+]] = arith.muli [[VAR_17_]], [[VAR_2_]] : i64
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_21_:%.+]] = tptr.ptradd [[VAR_19_]] [[VAR_20_]] : !ptr.ptr, i64 to !ptr.ptr
+// CHECK-DAG:       [[VAR_21_:%.+]] = tptr.ptradd [[VAR_19_]] [[VAR_20_]] : <#tptr.default_memory_space>, i64 to <#tptr.default_memory_space>
 // CHECK-DAG:       [[VAR_22_:%.+]] = arith.muli [[CST_2_]], [[VAR_1_]] : i32
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_23_:%.+]] = tptr.ptradd [[VAR_21_]] [[VAR_22_]] : !ptr.ptr, i32 to !ptr.ptr
+// CHECK-DAG:       [[VAR_23_:%.+]] = tptr.ptradd [[VAR_21_]] [[VAR_22_]] : <#tptr.default_memory_space>, i32 to <#tptr.default_memory_space>
 // CHECK-DAG:       [[VAR_24_:%.+]] = arith.muli [[PARAM_2_]], [[VAR_1_]] : i32
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_25_:%.+]] = tptr.ptradd [[VAR_23_]] [[VAR_24_]] : !ptr.ptr, i32 to !ptr.ptr
+// CHECK-DAG:       [[VAR_25_:%.+]] = tptr.ptradd [[VAR_23_]] [[VAR_24_]] : <#tptr.default_memory_space>, i32 to <#tptr.default_memory_space>
 // CHECK-DAG:       [[VAR_26_:%.+]] = arith.muli [[CST_3_]], [[VAR_1_]] : i32
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_27_:%.+]] = tptr.ptradd [[VAR_25_]] [[VAR_26_]] : !ptr.ptr, i32 to !ptr.ptr
+// CHECK-DAG:       [[VAR_27_:%.+]] = tptr.ptradd [[VAR_25_]] [[VAR_26_]] : <#tptr.default_memory_space>, i32 to <#tptr.default_memory_space>
 // CHECK-DAG:       [[VAR_28_:%.+]] = arith.muli [[CST_4_]], [[VAR_0_]] : i32
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_29_:%.+]] = tptr.ptradd [[VAR_27_]] [[VAR_28_]] : !ptr.ptr, i32 to !ptr.ptr
+// CHECK-DAG:       [[VAR_29_:%.+]] = tptr.ptradd [[VAR_27_]] [[VAR_28_]] : <#tptr.default_memory_space>, i32 to <#tptr.default_memory_space>
 // CHECK-DAG:       [[VAR_30_:%.+]] = arith.muli [[PARAM_2_]], [[VAR_0_]] : i32
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_31_:%.+]] = tptr.ptradd [[VAR_29_]] [[VAR_30_]] : !ptr.ptr, i32 to !ptr.ptr
+// CHECK-DAG:       [[VAR_31_:%.+]] = tptr.ptradd [[VAR_29_]] [[VAR_30_]] : <#tptr.default_memory_space>, i32 to <#tptr.default_memory_space>
 // CHECK-DAG:       [[VAR_32_:%.+]] = arith.muli [[CST_3_]], [[VAR_0_]] : i32
-// CHECK:           [[VAR_33_:%.+]] = tptr.ptradd [[VAR_31_]] [[VAR_32_]] : !ptr.ptr, i32 to !ptr.ptr
-// CHECK:           [[VAR_34_:%.+]] = tptr.to_memref [[VAR_33_]] : !ptr.ptr to memref<1xi32>
+// CHECK:           [[VAR_33_:%.+]] = tptr.ptradd [[VAR_31_]] [[VAR_32_]] : <#tptr.default_memory_space>, i32 to <#tptr.default_memory_space>
+// CHECK:           [[VAR_34_:%.+]] = tptr.to_memref [[VAR_33_]] : <#tptr.default_memory_space> to memref<1xi32>
 // CHECK-DAG:       [[LOAD_VAR_34_MEM_:%.+]] = memref.load [[VAR_34_]]{{.}}[[CST_0_]]{{.}} : memref<1xi32>
 // CHECK-DAG:       [[VAR_36_:%.+]] = arith.extsi [[PARAM_2_]] : i32 to i64
 // CHECK:           [[VAR_37_:%.+]] = arith.addi [[VAR_17_]], [[VAR_36_]] : i64
-// CHECK:           [[VAR_38_:%.+]] = tptr.inttoptr [[VAR_37_]] : i64 to !ptr.ptr
-// CHECK:           [[VAR_39_:%.+]] = tptr.to_memref [[VAR_38_]] : !ptr.ptr to memref<1xi32>
+// CHECK:           [[VAR_38_:%.+]] = tptr.inttoptr [[VAR_37_]] : i64 to <#tptr.default_memory_space>
+// CHECK:           [[VAR_39_:%.+]] = tptr.to_memref [[VAR_38_]] : <#tptr.default_memory_space> to memref<1xi32>
 // CHECK:           memref.store [[LOAD_VAR_34_MEM_]], [[VAR_39_]]{{.}}[[CST_0_]]{{.}} : memref<1xi32>
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/TritonToPtr/cat_and_where_on_ptrs.mlir
+++ b/test/Conversion/TritonToPtr/cat_and_where_on_ptrs.mlir
@@ -56,9 +56,9 @@ module {
 // CHECK-DAG:       [[CST_0_2_:%.+]] = arith.constant 0 : i8
 // CHECK-DAG:       [[CST_5_:%.+]] = arith.constant 5 : i32
 // CHECK-DAG:       [[CST_4_:%.+]] = arith.constant 4 : i32
-// CHECK-DAG:       [[VAR_2_:%.+]] = builtin.unrealized_conversion_cast [[PARAM_2_]] : !tt.ptr<i1> to !ptr.ptr
-// CHECK-DAG:       [[VAR_3_:%.+]] = builtin.unrealized_conversion_cast [[PARAM_1_]] : !tt.ptr<i32> to !ptr.ptr
-// CHECK-DAG:       [[VAR_4_:%.+]] = builtin.unrealized_conversion_cast [[PARAM_0_]] : !tt.ptr<i32> to !ptr.ptr
+// CHECK-DAG:       [[VAR_2_:%.+]] = builtin.unrealized_conversion_cast [[PARAM_2_]] : !tt.ptr<i1> to !ptr.ptr<#tptr.default_memory_space>
+// CHECK-DAG:       [[VAR_3_:%.+]] = builtin.unrealized_conversion_cast [[PARAM_1_]] : !tt.ptr<i32> to !ptr.ptr<#tptr.default_memory_space>
+// CHECK-DAG:       [[VAR_4_:%.+]] = builtin.unrealized_conversion_cast [[PARAM_0_]] : !tt.ptr<i32> to !ptr.ptr<#tptr.default_memory_space>
 // CHECK-DAG:       [[VAR_5_:%.+]] = tensor.empty() : tensor<16xi8>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_6_:%.+]] = linalg.fill ins([[CST_0_2_]] : i8) outs([[VAR_5_]] : tensor<16xi8>) -> tensor<16xi8>
@@ -79,33 +79,33 @@ module {
 // CHECK:             [[VAR_36_1_:%.+]] = arith.index_cast [[VAR_35_1_]] : index to i32
 // CHECK:             linalg.yield [[VAR_36_1_]] : i32
 // CHECK:           } -> tensor<8xi32>
-// CHECK:           [[VAR_13_:%.+]] = tensor.empty() : tensor<8x!ptr.ptr>
-// CHECK:           [[VAR_14_:%.+]] = linalg.fill ins([[VAR_4_]] : !ptr.ptr) outs([[VAR_13_]] : tensor<8x!ptr.ptr>) -> tensor<8x!ptr.ptr>
-// CHECK:           [[VAR_15_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_14_]], [[VAR_12_]] : tensor<8x!ptr.ptr>, tensor<8xi32>) outs([[VAR_14_]] : tensor<8x!ptr.ptr>) {
-// CHECK:           ^bb0([[IN_2_:%.+]]: !ptr.ptr, [[IN_3_:%.+]]: i32, [[IN_4_:%.+]]: !ptr.ptr):
+// CHECK:           [[VAR_13_:%.+]] = tensor.empty() : tensor<8x!ptr.ptr<#tptr.default_memory_space>>
+// CHECK:           [[VAR_14_:%.+]] = linalg.fill ins([[VAR_4_]] : !ptr.ptr<#tptr.default_memory_space>) outs([[VAR_13_]] : tensor<8x!ptr.ptr<#tptr.default_memory_space>>) -> tensor<8x!ptr.ptr<#tptr.default_memory_space>>
+// CHECK:           [[VAR_15_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_14_]], [[VAR_12_]] : tensor<8x!ptr.ptr<#tptr.default_memory_space>>, tensor<8xi32>) outs([[VAR_14_]] : tensor<8x!ptr.ptr<#tptr.default_memory_space>>) {
+// CHECK:           ^bb0([[IN_2_:%.+]]: !ptr.ptr<#tptr.default_memory_space>, [[IN_3_:%.+]]: i32, [[IN_4_:%.+]]: !ptr.ptr<#tptr.default_memory_space>):
 // CHECK:             [[VAR_35_2_:%.+]] = arith.muli [[IN_3_]], [[VAR_1_]] : i32
-// CHECK:             [[VAR_36_2_:%.+]] = tptr.ptradd [[IN_2_]] [[VAR_35_2_]] : !ptr.ptr, i32 to !ptr.ptr
-// CHECK:             linalg.yield [[VAR_36_2_]] : !ptr.ptr
-// CHECK:           } -> tensor<8x!ptr.ptr>
-// CHECK:           [[VAR_16_:%.+]] = linalg.fill ins([[VAR_3_]] : !ptr.ptr) outs([[VAR_13_]] : tensor<8x!ptr.ptr>) -> tensor<8x!ptr.ptr>
-// CHECK:           [[VAR_17_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_16_]], [[VAR_12_]] : tensor<8x!ptr.ptr>, tensor<8xi32>) outs([[VAR_16_]] : tensor<8x!ptr.ptr>) {
-// CHECK:           ^bb0([[IN_5_:%.+]]: !ptr.ptr, [[IN_6_:%.+]]: i32, [[IN_7_:%.+]]: !ptr.ptr):
+// CHECK:             [[VAR_36_2_:%.+]] = tptr.ptradd [[IN_2_]] [[VAR_35_2_]] : <#tptr.default_memory_space>, i32 to <#tptr.default_memory_space>
+// CHECK:             linalg.yield [[VAR_36_2_]] : !ptr.ptr<#tptr.default_memory_space>
+// CHECK:           } -> tensor<8x!ptr.ptr<#tptr.default_memory_space>>
+// CHECK:           [[VAR_16_:%.+]] = linalg.fill ins([[VAR_3_]] : !ptr.ptr<#tptr.default_memory_space>) outs([[VAR_13_]] : tensor<8x!ptr.ptr<#tptr.default_memory_space>>) -> tensor<8x!ptr.ptr<#tptr.default_memory_space>>
+// CHECK:           [[VAR_17_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_16_]], [[VAR_12_]] : tensor<8x!ptr.ptr<#tptr.default_memory_space>>, tensor<8xi32>) outs([[VAR_16_]] : tensor<8x!ptr.ptr<#tptr.default_memory_space>>) {
+// CHECK:           ^bb0([[IN_5_:%.+]]: !ptr.ptr<#tptr.default_memory_space>, [[IN_6_:%.+]]: i32, [[IN_7_:%.+]]: !ptr.ptr<#tptr.default_memory_space>):
 // CHECK:             [[VAR_35_3_:%.+]] = arith.muli [[IN_6_]], [[VAR_1_]] : i32
-// CHECK:             [[VAR_36_3_:%.+]] = tptr.ptradd [[IN_5_]] [[VAR_35_3_]] : !ptr.ptr, i32 to !ptr.ptr
-// CHECK:             linalg.yield [[VAR_36_3_]] : !ptr.ptr
-// CHECK:           } -> tensor<8x!ptr.ptr>
-// CHECK:           [[VAR_18_:%.+]] = tensor.empty() : tensor<16x!ptr.ptr>
-// CHECK:           [[VAR_inserted_slice_:%.+]] = tensor.insert_slice [[VAR_15_]] into [[VAR_18_]][0] [8] [1] : tensor<8x!ptr.ptr> into tensor<16x!ptr.ptr>
-// CHECK:           [[VAR_inserted_slice_0_:%.+]] = tensor.insert_slice [[VAR_17_]] into [[VAR_inserted_slice_]][8] [8] [1] : tensor<8x!ptr.ptr> into tensor<16x!ptr.ptr>
-// CHECK:           [[VAR_19_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_inserted_slice_0_]], [[VAR_10_]] : tensor<16x!ptr.ptr>, tensor<16xi32>) outs([[VAR_inserted_slice_0_]] : tensor<16x!ptr.ptr>) {
-// CHECK:           ^bb0([[IN_8_:%.+]]: !ptr.ptr, [[IN_9_:%.+]]: i32, [[IN_10_:%.+]]: !ptr.ptr):
+// CHECK:             [[VAR_36_3_:%.+]] = tptr.ptradd [[IN_5_]] [[VAR_35_3_]] : <#tptr.default_memory_space>, i32 to <#tptr.default_memory_space>
+// CHECK:             linalg.yield [[VAR_36_3_]] : !ptr.ptr<#tptr.default_memory_space>
+// CHECK:           } -> tensor<8x!ptr.ptr<#tptr.default_memory_space>>
+// CHECK:           [[VAR_18_:%.+]] = tensor.empty() : tensor<16x!ptr.ptr<#tptr.default_memory_space>>
+// CHECK:           [[VAR_inserted_slice_:%.+]] = tensor.insert_slice [[VAR_15_]] into [[VAR_18_]][0] [8] [1] : tensor<8x!ptr.ptr<#tptr.default_memory_space>> into tensor<16x!ptr.ptr<#tptr.default_memory_space>>
+// CHECK:           [[VAR_inserted_slice_0_:%.+]] = tensor.insert_slice [[VAR_17_]] into [[VAR_inserted_slice_]][8] [8] [1] : tensor<8x!ptr.ptr<#tptr.default_memory_space>> into tensor<16x!ptr.ptr<#tptr.default_memory_space>>
+// CHECK:           [[VAR_19_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_inserted_slice_0_]], [[VAR_10_]] : tensor<16x!ptr.ptr<#tptr.default_memory_space>>, tensor<16xi32>) outs([[VAR_inserted_slice_0_]] : tensor<16x!ptr.ptr<#tptr.default_memory_space>>) {
+// CHECK:           ^bb0([[IN_8_:%.+]]: !ptr.ptr<#tptr.default_memory_space>, [[IN_9_:%.+]]: i32, [[IN_10_:%.+]]: !ptr.ptr<#tptr.default_memory_space>):
 // CHECK:             [[VAR_35_4_:%.+]] = arith.muli [[IN_9_]], [[VAR_1_]] : i32
-// CHECK:             [[VAR_36_4_:%.+]] = tptr.ptradd [[IN_8_]] [[VAR_35_4_]] : !ptr.ptr, i32 to !ptr.ptr
-// CHECK:             linalg.yield [[VAR_36_4_]] : !ptr.ptr
-// CHECK:           } -> tensor<16x!ptr.ptr>
-// CHECK:           [[VAR_20_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_19_]] : tensor<16x!ptr.ptr>) outs([[VAR_7_]] : tensor<16xi32>) {
-// CHECK:           ^bb0([[IN_11_:%.+]]: !ptr.ptr, [[IN_12_:%.+]]: i32):
-// CHECK:             [[VAR_35_5_:%.+]] = tptr.to_memref [[IN_11_]] : !ptr.ptr to memref<1xi32>
+// CHECK:             [[VAR_36_4_:%.+]] = tptr.ptradd [[IN_8_]] [[VAR_35_4_]] : <#tptr.default_memory_space>, i32 to <#tptr.default_memory_space>
+// CHECK:             linalg.yield [[VAR_36_4_]] : !ptr.ptr<#tptr.default_memory_space>
+// CHECK:           } -> tensor<16x!ptr.ptr<#tptr.default_memory_space>>
+// CHECK:           [[VAR_20_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_19_]] : tensor<16x!ptr.ptr<#tptr.default_memory_space>>) outs([[VAR_7_]] : tensor<16xi32>) {
+// CHECK:           ^bb0([[IN_11_:%.+]]: !ptr.ptr<#tptr.default_memory_space>, [[IN_12_:%.+]]: i32):
+// CHECK:             [[VAR_35_5_:%.+]] = tptr.to_memref [[IN_11_]] : <#tptr.default_memory_space> to memref<1xi32>
 // CHECK:             [[VAR_36_4_:%.+]] = memref.load [[VAR_35_5_]]{{.}}[[CST_0_1_]]{{.}} : memref<1xi32>
 // CHECK:             linalg.yield [[VAR_36_4_]] : i32
 // CHECK:           } -> tensor<16xi32>
@@ -114,33 +114,33 @@ module {
 // CHECK:             [[VAR_35_6_:%.+]] = arith.muli [[IN_13_]], [[IN_14_]] : i32
 // CHECK:             linalg.yield [[VAR_35_6_]] : i32
 // CHECK:           } -> tensor<16xi32>
-// CHECK:           [[VAR_22_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_inserted_slice_0_]], [[VAR_21_]] : tensor<16x!ptr.ptr>, tensor<16xi32>) outs([[VAR_inserted_slice_0_]] : tensor<16x!ptr.ptr>) {
-// CHECK:           ^bb0([[IN_16_:%.+]]: !ptr.ptr, [[IN_17_:%.+]]: i32, [[IN_18_:%.+]]: !ptr.ptr):
+// CHECK:           [[VAR_22_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_inserted_slice_0_]], [[VAR_21_]] : tensor<16x!ptr.ptr<#tptr.default_memory_space>>, tensor<16xi32>) outs([[VAR_inserted_slice_0_]] : tensor<16x!ptr.ptr<#tptr.default_memory_space>>) {
+// CHECK:           ^bb0([[IN_16_:%.+]]: !ptr.ptr<#tptr.default_memory_space>, [[IN_17_:%.+]]: i32, [[IN_18_:%.+]]: !ptr.ptr<#tptr.default_memory_space>):
 // CHECK:             [[VAR_35_7_:%.+]] = arith.muli [[IN_17_]], [[VAR_1_]] : i32
-// CHECK:             [[VAR_36_5_:%.+]] = tptr.ptradd [[IN_16_]] [[VAR_35_7_]] : !ptr.ptr, i32 to !ptr.ptr
-// CHECK:             linalg.yield [[VAR_36_5_]] : !ptr.ptr
-// CHECK:           } -> tensor<16x!ptr.ptr>
+// CHECK:             [[VAR_36_5_:%.+]] = tptr.ptradd [[IN_16_]] [[VAR_35_7_]] : <#tptr.default_memory_space>, i32 to <#tptr.default_memory_space>
+// CHECK:             linalg.yield [[VAR_36_5_]] : !ptr.ptr<#tptr.default_memory_space>
+// CHECK:           } -> tensor<16x!ptr.ptr<#tptr.default_memory_space>>
 // CHECK:           [[VAR_23_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_20_]], [[VAR_8_]] : tensor<16xi32>, tensor<16xi32>) outs([[VAR_20_]] : tensor<16xi32>) {
 // CHECK:           ^bb0([[IN_19_:%.+]]: i32, [[IN_20_:%.+]]: i32, [[IN_21_:%.+]]: i32):
 // CHECK:             [[VAR_35_8_:%.+]] = arith.muli [[IN_19_]], [[IN_20_]] : i32
 // CHECK:             linalg.yield [[VAR_35_8_]] : i32
 // CHECK:           } -> tensor<16xi32>
-// CHECK:           [[VAR_24_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_inserted_slice_0_]], [[VAR_23_]] : tensor<16x!ptr.ptr>, tensor<16xi32>) outs([[VAR_inserted_slice_0_]] : tensor<16x!ptr.ptr>) {
-// CHECK:           ^bb0([[IN_22_:%.+]]: !ptr.ptr, [[IN_23_:%.+]]: i32, [[IN_24_:%.+]]: !ptr.ptr):
+// CHECK:           [[VAR_24_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_inserted_slice_0_]], [[VAR_23_]] : tensor<16x!ptr.ptr<#tptr.default_memory_space>>, tensor<16xi32>) outs([[VAR_inserted_slice_0_]] : tensor<16x!ptr.ptr<#tptr.default_memory_space>>) {
+// CHECK:           ^bb0([[IN_22_:%.+]]: !ptr.ptr<#tptr.default_memory_space>, [[IN_23_:%.+]]: i32, [[IN_24_:%.+]]: !ptr.ptr<#tptr.default_memory_space>):
 // CHECK:             [[VAR_35_9_:%.+]] = arith.muli [[IN_23_]], [[VAR_1_]] : i32
-// CHECK:             [[VAR_36_6_:%.+]] = tptr.ptradd [[IN_22_]] [[VAR_35_9_]] : !ptr.ptr, i32 to !ptr.ptr
-// CHECK:             linalg.yield [[VAR_36_6_]] : !ptr.ptr
-// CHECK:           } -> tensor<16x!ptr.ptr>
-// CHECK:           [[VAR_25_:%.+]] = linalg.fill ins([[VAR_2_]] : !ptr.ptr) outs([[VAR_18_]] : tensor<16x!ptr.ptr>) -> tensor<16x!ptr.ptr>
-// CHECK:           [[VAR_26_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_25_]], [[VAR_10_]] : tensor<16x!ptr.ptr>, tensor<16xi32>) outs([[VAR_25_]] : tensor<16x!ptr.ptr>) {
-// CHECK:           ^bb0([[IN_25_:%.+]]: !ptr.ptr, [[IN_26_:%.+]]: i32, [[IN_27_:%.+]]: !ptr.ptr):
+// CHECK:             [[VAR_36_6_:%.+]] = tptr.ptradd [[IN_22_]] [[VAR_35_9_]] : <#tptr.default_memory_space>, i32 to <#tptr.default_memory_space>
+// CHECK:             linalg.yield [[VAR_36_6_]] : !ptr.ptr<#tptr.default_memory_space>
+// CHECK:           } -> tensor<16x!ptr.ptr<#tptr.default_memory_space>>
+// CHECK:           [[VAR_25_:%.+]] = linalg.fill ins([[VAR_2_]] : !ptr.ptr<#tptr.default_memory_space>) outs([[VAR_18_]] : tensor<16x!ptr.ptr<#tptr.default_memory_space>>) -> tensor<16x!ptr.ptr<#tptr.default_memory_space>>
+// CHECK:           [[VAR_26_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_25_]], [[VAR_10_]] : tensor<16x!ptr.ptr<#tptr.default_memory_space>>, tensor<16xi32>) outs([[VAR_25_]] : tensor<16x!ptr.ptr<#tptr.default_memory_space>>) {
+// CHECK:           ^bb0([[IN_25_:%.+]]: !ptr.ptr<#tptr.default_memory_space>, [[IN_26_:%.+]]: i32, [[IN_27_:%.+]]: !ptr.ptr<#tptr.default_memory_space>):
 // CHECK:             [[VAR_35_10_:%.+]] = arith.muli [[IN_26_]], [[VAR_0_]] : i32
-// CHECK:             [[VAR_36_7_:%.+]] = tptr.ptradd [[IN_25_]] [[VAR_35_10_]] : !ptr.ptr, i32 to !ptr.ptr
-// CHECK:             linalg.yield [[VAR_36_7_]] : !ptr.ptr
-// CHECK:           } -> tensor<16x!ptr.ptr>
-// CHECK:           [[VAR_27_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_26_]] : tensor<16x!ptr.ptr>) outs([[VAR_5_]] : tensor<16xi8>) {
-// CHECK:           ^bb0([[IN_28_:%.+]]: !ptr.ptr, [[IN_29_:%.+]]: i8):
-// CHECK:             [[VAR_35_11_:%.+]] = tptr.to_memref [[IN_28_]] : !ptr.ptr to memref<1xi8>
+// CHECK:             [[VAR_36_7_:%.+]] = tptr.ptradd [[IN_25_]] [[VAR_35_10_]] : <#tptr.default_memory_space>, i32 to <#tptr.default_memory_space>
+// CHECK:             linalg.yield [[VAR_36_7_]] : !ptr.ptr<#tptr.default_memory_space>
+// CHECK:           } -> tensor<16x!ptr.ptr<#tptr.default_memory_space>>
+// CHECK:           [[VAR_27_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_26_]] : tensor<16x!ptr.ptr<#tptr.default_memory_space>>) outs([[VAR_5_]] : tensor<16xi8>) {
+// CHECK:           ^bb0([[IN_28_:%.+]]: !ptr.ptr<#tptr.default_memory_space>, [[IN_29_:%.+]]: i8):
+// CHECK:             [[VAR_35_11_:%.+]] = tptr.to_memref [[IN_28_]] : <#tptr.default_memory_space> to memref<1xi8>
 // CHECK:             [[VAR_36_7_:%.+]] = memref.load [[VAR_35_11_]]{{.}}[[CST_0_1_]]{{.}} : memref<1xi8>
 // CHECK:             linalg.yield [[VAR_36_7_]] : i8
 // CHECK:           } -> tensor<16xi8>
@@ -150,20 +150,20 @@ module {
 // CHECK:             [[VAR_35_12_:%.+]] = arith.cmpi ne, [[IN_30_]], [[IN_31_]] : i8
 // CHECK:             linalg.yield [[VAR_35_12_]] : i1
 // CHECK:           } -> tensor<16xi1>
-// CHECK:           [[VAR_30_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_29_]], [[VAR_22_]], [[VAR_24_]] : tensor<16xi1>, tensor<16x!ptr.ptr>, tensor<16x!ptr.ptr>) outs([[VAR_22_]] : tensor<16x!ptr.ptr>) {
-// CHECK:           ^bb0([[IN_33_:%.+]]: i1, [[IN_34_:%.+]]: !ptr.ptr, [[IN_35_:%.+]]: !ptr.ptr, [[IN_36_:%.+]]: !ptr.ptr):
-// CHECK:             [[VAR_35_13_:%.+]] = arith.select [[IN_33_]], [[IN_34_]], [[IN_35_]] : !ptr.ptr
-// CHECK:             linalg.yield [[VAR_35_13_]] : !ptr.ptr
-// CHECK:           } -> tensor<16x!ptr.ptr>
-// CHECK:           [[VAR_31_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_30_]], [[VAR_10_]] : tensor<16x!ptr.ptr>, tensor<16xi32>) outs([[VAR_30_]] : tensor<16x!ptr.ptr>) {
-// CHECK:           ^bb0([[IN_37_:%.+]]: !ptr.ptr, [[IN_38_:%.+]]: i32, [[IN_39_:%.+]]: !ptr.ptr):
+// CHECK:           [[VAR_30_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_29_]], [[VAR_22_]], [[VAR_24_]] : tensor<16xi1>, tensor<16x!ptr.ptr<#tptr.default_memory_space>>, tensor<16x!ptr.ptr<#tptr.default_memory_space>>) outs([[VAR_22_]] : tensor<16x!ptr.ptr<#tptr.default_memory_space>>) {
+// CHECK:           ^bb0([[IN_33_:%.+]]: i1, [[IN_34_:%.+]]: !ptr.ptr<#tptr.default_memory_space>, [[IN_35_:%.+]]: !ptr.ptr<#tptr.default_memory_space>, [[IN_36_:%.+]]: !ptr.ptr<#tptr.default_memory_space>):
+// CHECK:             [[VAR_35_13_:%.+]] = arith.select [[IN_33_]], [[IN_34_]], [[IN_35_]] : !ptr.ptr<#tptr.default_memory_space>
+// CHECK:             linalg.yield [[VAR_35_13_]] : !ptr.ptr<#tptr.default_memory_space>
+// CHECK:           } -> tensor<16x!ptr.ptr<#tptr.default_memory_space>>
+// CHECK:           [[VAR_31_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_30_]], [[VAR_10_]] : tensor<16x!ptr.ptr<#tptr.default_memory_space>>, tensor<16xi32>) outs([[VAR_30_]] : tensor<16x!ptr.ptr<#tptr.default_memory_space>>) {
+// CHECK:           ^bb0([[IN_37_:%.+]]: !ptr.ptr<#tptr.default_memory_space>, [[IN_38_:%.+]]: i32, [[IN_39_:%.+]]: !ptr.ptr<#tptr.default_memory_space>):
 // CHECK:             [[VAR_35_14_:%.+]] = arith.muli [[IN_38_]], [[VAR_1_]] : i32
-// CHECK:             [[VAR_36_8_:%.+]] = tptr.ptradd [[IN_37_]] [[VAR_35_14_]] : !ptr.ptr, i32 to !ptr.ptr
-// CHECK:             linalg.yield [[VAR_36_8_]] : !ptr.ptr
-// CHECK:           } -> tensor<16x!ptr.ptr>
-// CHECK:           [[VAR_32_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_31_]], [[VAR_29_]] : tensor<16x!ptr.ptr>, tensor<16xi1>) outs([[VAR_7_]] : tensor<16xi32>) {
-// CHECK:           ^bb0([[IN_40_:%.+]]: !ptr.ptr, [[IN_41_:%.+]]: i1, [[IN_42_:%.+]]: i32):
-// CHECK-DAG:         [[VAR_35_15_:%.+]] = tptr.to_memref [[IN_40_]] : !ptr.ptr to memref<1xi32>
+// CHECK:             [[VAR_36_8_:%.+]] = tptr.ptradd [[IN_37_]] [[VAR_35_14_]] : <#tptr.default_memory_space>, i32 to <#tptr.default_memory_space>
+// CHECK:             linalg.yield [[VAR_36_8_]] : !ptr.ptr<#tptr.default_memory_space>
+// CHECK:           } -> tensor<16x!ptr.ptr<#tptr.default_memory_space>>
+// CHECK:           [[VAR_32_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_31_]], [[VAR_29_]] : tensor<16x!ptr.ptr<#tptr.default_memory_space>>, tensor<16xi1>) outs([[VAR_7_]] : tensor<16xi32>) {
+// CHECK:           ^bb0([[IN_40_:%.+]]: !ptr.ptr<#tptr.default_memory_space>, [[IN_41_:%.+]]: i1, [[IN_42_:%.+]]: i32):
+// CHECK-DAG:         [[VAR_35_15_:%.+]] = tptr.to_memref [[IN_40_]] : <#tptr.default_memory_space> to memref<1xi32>
 // CHECK-DAG:         [[VAR_36_9_:%.+]] = scf.if [[IN_41_]] -> (i32) {
 // CHECK:               [[LOAD_VAR_35_15_MEM_:%.+]] = memref.load [[VAR_35_15_]]{{.}}[[CST_0_1_]]{{.}} : memref<1xi32>
 // CHECK:               scf.yield [[LOAD_VAR_35_15_MEM_]] : i32
@@ -172,17 +172,17 @@ module {
 // CHECK:             }
 // CHECK:             linalg.yield [[VAR_36_9_]] : i32
 // CHECK:           } -> tensor<16xi32>
-// CHECK:           [[VAR_33_:%.+]] = linalg.fill ins([[VAR_3_]] : !ptr.ptr) outs([[VAR_18_]] : tensor<16x!ptr.ptr>) -> tensor<16x!ptr.ptr>
-// CHECK:           [[VAR_34_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_33_]], [[VAR_10_]] : tensor<16x!ptr.ptr>, tensor<16xi32>) outs([[VAR_33_]] : tensor<16x!ptr.ptr>) {
-// CHECK:           ^bb0([[IN_43_:%.+]]: !ptr.ptr, [[IN_44_:%.+]]: i32, [[IN_45_:%.+]]: !ptr.ptr):
+// CHECK:           [[VAR_33_:%.+]] = linalg.fill ins([[VAR_3_]] : !ptr.ptr<#tptr.default_memory_space>) outs([[VAR_18_]] : tensor<16x!ptr.ptr<#tptr.default_memory_space>>) -> tensor<16x!ptr.ptr<#tptr.default_memory_space>>
+// CHECK:           [[VAR_34_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_33_]], [[VAR_10_]] : tensor<16x!ptr.ptr<#tptr.default_memory_space>>, tensor<16xi32>) outs([[VAR_33_]] : tensor<16x!ptr.ptr<#tptr.default_memory_space>>) {
+// CHECK:           ^bb0([[IN_43_:%.+]]: !ptr.ptr<#tptr.default_memory_space>, [[IN_44_:%.+]]: i32, [[IN_45_:%.+]]: !ptr.ptr<#tptr.default_memory_space>):
 // CHECK:             [[VAR_35_16_:%.+]] = arith.muli [[IN_44_]], [[VAR_1_]] : i32
-// CHECK:             [[VAR_36_10_:%.+]] = tptr.ptradd [[IN_43_]] [[VAR_35_16_]] : !ptr.ptr, i32 to !ptr.ptr
-// CHECK:             linalg.yield [[VAR_36_10_]] : !ptr.ptr
-// CHECK:           } -> tensor<16x!ptr.ptr>
-// CHECK:           linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_34_]], [[VAR_32_]], [[VAR_29_]] : tensor<16x!ptr.ptr>, tensor<16xi32>, tensor<16xi1>) {
-// CHECK:           ^bb0([[IN_46_:%.+]]: !ptr.ptr, [[IN_47_:%.+]]: i32, [[IN_48_:%.+]]: i1):
+// CHECK:             [[VAR_36_10_:%.+]] = tptr.ptradd [[IN_43_]] [[VAR_35_16_]] : <#tptr.default_memory_space>, i32 to <#tptr.default_memory_space>
+// CHECK:             linalg.yield [[VAR_36_10_]] : !ptr.ptr<#tptr.default_memory_space>
+// CHECK:           } -> tensor<16x!ptr.ptr<#tptr.default_memory_space>>
+// CHECK:           linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_34_]], [[VAR_32_]], [[VAR_29_]] : tensor<16x!ptr.ptr<#tptr.default_memory_space>>, tensor<16xi32>, tensor<16xi1>) {
+// CHECK:           ^bb0([[IN_46_:%.+]]: !ptr.ptr<#tptr.default_memory_space>, [[IN_47_:%.+]]: i32, [[IN_48_:%.+]]: i1):
 // CHECK:             scf.if [[IN_48_]] {
-// CHECK:               [[VAR_35_17_:%.+]] = tptr.to_memref [[IN_46_]] : !ptr.ptr to memref<1xi32>
+// CHECK:               [[VAR_35_17_:%.+]] = tptr.to_memref [[IN_46_]] : <#tptr.default_memory_space> to memref<1xi32>
 // CHECK:               memref.store [[IN_47_]], [[VAR_35_17_]]{{.}}[[CST_0_1_]]{{.}} : memref<1xi32>
 // CHECK:             }
 // CHECK:             linalg.yield

--- a/test/Conversion/TritonToPtr/dynamic_masked_load_store.mlir
+++ b/test/Conversion/TritonToPtr/dynamic_masked_load_store.mlir
@@ -31,6 +31,7 @@ module {
   }
 }
 
+
 // CHECK-COUNT-7: linalg.generic
 
 // CHECK: [[MASK:%.+]] = linalg.generic
@@ -39,9 +40,9 @@ module {
 // CHECK:     linalg.yield [[YIELD]] : i1
 // CHECK: } -> tensor<16xi1>
 
-// CHECK:  linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins(%{{.+}}, [[MASK]] : tensor<16x!ptr.ptr>, tensor<16xi1>)
-// CHECK:  ^bb0(%in: !ptr.ptr, %in_0: i1, %out: i32):
-// CHECK:    [[MEMREF:%.+]] = tptr.to_memref %in : !ptr.ptr to memref<1xi32>
+// CHECK:  linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins(%{{.+}}, [[MASK]] : tensor<16x!ptr.ptr<#tptr.default_memory_space>>, tensor<16xi1>)
+// CHECK:  ^bb0(%in: !ptr.ptr<#tptr.default_memory_space>, %in_0: i1, %out: i32):
+// CHECK:    [[MEMREF:%.+]] = tptr.to_memref %in : <#tptr.default_memory_space> to memref<1xi32>
 // CHECK:    [[SCF_IF:%.+]] = scf.if %in_0 -> (i32) {
 // CHECK:      [[LOAD:%.+]] = memref.load [[MEMREF]][%c0] : memref<1xi32>
 // CHECK:      scf.yield [[LOAD]] : i32
@@ -52,9 +53,9 @@ module {
 // CHECK:  } -> tensor<16xi32>
 
 // CHECK:  linalg.generic
-// CHECK:  ^bb0(%in: !ptr.ptr, %in_0: i32, %in_1: i1):
+// CHECK:  ^bb0(%in: !ptr.ptr<#tptr.default_memory_space>, %in_0: i32, %in_1: i1):
 // CHECK:    scf.if %in_1 {
-// CHECK:      [[MEMREF:%.+]] = tptr.to_memref %in : !ptr.ptr to memref<1xi32>
+// CHECK:      [[MEMREF:%.+]] = tptr.to_memref %in : <#tptr.default_memory_space> to memref<1xi32>
 // CHECK:      memref.store %in_0, [[MEMREF]][%c0] : memref<1xi32>
 // CHECK:    }
 // CHECK:    linalg.yield

--- a/test/Conversion/TritonToPtr/masked_load_store.mlir
+++ b/test/Conversion/TritonToPtr/masked_load_store.mlir
@@ -29,8 +29,8 @@ module {
 }
 
 // CHECK:  linalg.generic
-// CHECK:  ^bb0(%in: !ptr.ptr, %in_0: i1, %out: i32):
-// CHECK:    [[MEMREF:%.+]] = tptr.to_memref %in : !ptr.ptr to memref<1xi32>
+// CHECK:  ^bb0(%in: !ptr.ptr<#tptr.default_memory_space>, %in_0: i1, %out: i32):
+// CHECK:    [[MEMREF:%.+]] = tptr.to_memref %in : <#tptr.default_memory_space> to memref<1xi32>
 // CHECK:    [[SCF_IF:%.+]] = scf.if %in_0 -> (i32) {
 // CHECK:      [[LOAD:%.+]] = memref.load [[MEMREF]][%c0] : memref<1xi32>
 // CHECK:      scf.yield [[LOAD]] : i32
@@ -41,9 +41,9 @@ module {
 // CHECK:  } -> tensor<16xi32>
 
 // CHECK:  linalg.generic
-// CHECK:  ^bb0(%in: !ptr.ptr, %in_0: i32, %in_1: i1):
+// CHECK:  ^bb0(%in: !ptr.ptr<#tptr.default_memory_space>, %in_0: i32, %in_1: i1):
 // CHECK:    scf.if %in_1 {
-// CHECK:      [[MEMREF:%.+]] = tptr.to_memref %in : !ptr.ptr to memref<1xi32>
+// CHECK:      [[MEMREF:%.+]] = tptr.to_memref %in : <#tptr.default_memory_space> to memref<1xi32>
 // CHECK:      memref.store %in_0, [[MEMREF]][%c0] : memref<1xi32>
 // CHECK:    }
 // CHECK:    linalg.yield

--- a/test/Conversion/TritonToPtr/regular_load_store.mlir
+++ b/test/Conversion/TritonToPtr/regular_load_store.mlir
@@ -27,8 +27,8 @@ module {
 // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
 // CHECK-DAG:       [[VAR_0_:%.+]] = tptr.type_offset f32  : i32
 // CHECK-DAG:       [[VAR_1_:%.+]] = tptr.type_offset i32  : i32
-// CHECK-DAG:       [[VAR_2_:%.+]] = builtin.unrealized_conversion_cast [[PARAM_1_]] : !tt.ptr<f32> to !ptr.ptr
-// CHECK-DAG:       [[VAR_3_:%.+]] = builtin.unrealized_conversion_cast [[PARAM_0_]] : !tt.ptr<i32> to !ptr.ptr
+// CHECK-DAG:       [[VAR_2_:%.+]] = builtin.unrealized_conversion_cast [[PARAM_1_]] : !tt.ptr<f32> to !ptr.ptr<#tptr.default_memory_space>
+// CHECK-DAG:       [[VAR_3_:%.+]] = builtin.unrealized_conversion_cast [[PARAM_0_]] : !tt.ptr<i32> to !ptr.ptr<#tptr.default_memory_space>
 // CHECK-DAG:       [[VAR_4_:%.+]] = tensor.empty() : tensor<1024xi32>
 // CHECK:           [[VAR_5_:%.+]] = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel"]} outs([[VAR_4_]] : tensor<1024xi32>) {
 // CHECK:           ^bb0([[IN_0_:%.+]]: i32):
@@ -36,24 +36,24 @@ module {
 // CHECK:             [[VAR_15_:%.+]] = arith.index_cast [[VAR_14_]] : index to i32
 // CHECK:             linalg.yield [[VAR_15_]] : i32
 // CHECK:           } -> tensor<1024xi32>
-// CHECK:           [[VAR_6_:%.+]] = tensor.empty() : tensor<1024x!ptr.ptr>
-// CHECK:           [[VAR_7_:%.+]] = linalg.fill ins([[VAR_3_]] : !ptr.ptr) outs([[VAR_6_]] : tensor<1024x!ptr.ptr>) -> tensor<1024x!ptr.ptr>
-// CHECK:           [[VAR_8_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_7_]], [[VAR_5_]] : tensor<1024x!ptr.ptr>, tensor<1024xi32>) outs([[VAR_7_]] : tensor<1024x!ptr.ptr>) {
-// CHECK:           ^bb0([[IN_1_:%.+]]: !ptr.ptr, [[IN_2_:%.+]]: i32, [[IN_3_:%.+]]: !ptr.ptr):
+// CHECK:           [[VAR_6_:%.+]] = tensor.empty() : tensor<1024x!ptr.ptr<#tptr.default_memory_space>>
+// CHECK:           [[VAR_7_:%.+]] = linalg.fill ins([[VAR_3_]] : !ptr.ptr<#tptr.default_memory_space>) outs([[VAR_6_]] : tensor<1024x!ptr.ptr<#tptr.default_memory_space>>) -> tensor<1024x!ptr.ptr<#tptr.default_memory_space>>
+// CHECK:           [[VAR_8_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_7_]], [[VAR_5_]] : tensor<1024x!ptr.ptr<#tptr.default_memory_space>>, tensor<1024xi32>) outs([[VAR_7_]] : tensor<1024x!ptr.ptr<#tptr.default_memory_space>>) {
+// CHECK:           ^bb0([[IN_1_:%.+]]: !ptr.ptr<#tptr.default_memory_space>, [[IN_2_:%.+]]: i32, [[IN_3_:%.+]]: !ptr.ptr<#tptr.default_memory_space>):
 // CHECK:             [[VAR_14_1_:%.+]] = arith.muli [[IN_2_]], [[VAR_1_]] : i32
-// CHECK:             [[VAR_15_1_:%.+]] = tptr.ptradd [[IN_1_]] [[VAR_14_1_]] : !ptr.ptr, i32 to !ptr.ptr
-// CHECK:             linalg.yield [[VAR_15_1_]] : !ptr.ptr
-// CHECK:           } -> tensor<1024x!ptr.ptr>
-// CHECK:           [[VAR_9_:%.+]] = linalg.fill ins([[VAR_2_]] : !ptr.ptr) outs([[VAR_6_]] : tensor<1024x!ptr.ptr>) -> tensor<1024x!ptr.ptr>
-// CHECK:           [[VAR_10_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_9_]], [[VAR_5_]] : tensor<1024x!ptr.ptr>, tensor<1024xi32>) outs([[VAR_9_]] : tensor<1024x!ptr.ptr>) {
-// CHECK:           ^bb0([[IN_4_:%.+]]: !ptr.ptr, [[IN_5_:%.+]]: i32, [[IN_6_:%.+]]: !ptr.ptr):
+// CHECK:             [[VAR_15_1_:%.+]] = tptr.ptradd [[IN_1_]] [[VAR_14_1_]] : <#tptr.default_memory_space>, i32 to <#tptr.default_memory_space>
+// CHECK:             linalg.yield [[VAR_15_1_]] : !ptr.ptr<#tptr.default_memory_space>
+// CHECK:           } -> tensor<1024x!ptr.ptr<#tptr.default_memory_space>>
+// CHECK:           [[VAR_9_:%.+]] = linalg.fill ins([[VAR_2_]] : !ptr.ptr<#tptr.default_memory_space>) outs([[VAR_6_]] : tensor<1024x!ptr.ptr<#tptr.default_memory_space>>) -> tensor<1024x!ptr.ptr<#tptr.default_memory_space>>
+// CHECK:           [[VAR_10_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_9_]], [[VAR_5_]] : tensor<1024x!ptr.ptr<#tptr.default_memory_space>>, tensor<1024xi32>) outs([[VAR_9_]] : tensor<1024x!ptr.ptr<#tptr.default_memory_space>>) {
+// CHECK:           ^bb0([[IN_4_:%.+]]: !ptr.ptr<#tptr.default_memory_space>, [[IN_5_:%.+]]: i32, [[IN_6_:%.+]]: !ptr.ptr<#tptr.default_memory_space>):
 // CHECK:             [[VAR_14_2_:%.+]] = arith.muli [[IN_5_]], [[VAR_0_]] : i32
-// CHECK:             [[VAR_15_2_:%.+]] = tptr.ptradd [[IN_4_]] [[VAR_14_2_]] : !ptr.ptr, i32 to !ptr.ptr
-// CHECK:             linalg.yield [[VAR_15_2_]] : !ptr.ptr
-// CHECK:           } -> tensor<1024x!ptr.ptr>
-// CHECK:           [[VAR_11_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<1024x!ptr.ptr>) outs([[VAR_4_]] : tensor<1024xi32>) {
-// CHECK:           ^bb0([[IN_7_:%.+]]: !ptr.ptr, [[IN_8_:%.+]]: i32):
-// CHECK:             [[VAR_14_3_:%.+]] = tptr.to_memref [[IN_7_]] : !ptr.ptr to memref<1xi32>
+// CHECK:             [[VAR_15_2_:%.+]] = tptr.ptradd [[IN_4_]] [[VAR_14_2_]] : <#tptr.default_memory_space>, i32 to <#tptr.default_memory_space>
+// CHECK:             linalg.yield [[VAR_15_2_]] : !ptr.ptr<#tptr.default_memory_space>
+// CHECK:           } -> tensor<1024x!ptr.ptr<#tptr.default_memory_space>>
+// CHECK:           [[VAR_11_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]] : tensor<1024x!ptr.ptr<#tptr.default_memory_space>>) outs([[VAR_4_]] : tensor<1024xi32>) {
+// CHECK:           ^bb0([[IN_7_:%.+]]: !ptr.ptr<#tptr.default_memory_space>, [[IN_8_:%.+]]: i32):
+// CHECK:             [[VAR_14_3_:%.+]] = tptr.to_memref [[IN_7_]] : <#tptr.default_memory_space> to memref<1xi32>
 // CHECK:             [[VAR_15_2_:%.+]] = memref.load [[VAR_14_3_]]{{.}}[[CST_0_]]{{.}} : memref<1xi32>
 // CHECK:             linalg.yield [[VAR_15_2_]] : i32
 // CHECK:           } -> tensor<1024xi32>
@@ -63,9 +63,9 @@ module {
 // CHECK:             [[VAR_14_4_:%.+]] = arith.bitcast [[IN_9_]] : i32 to f32
 // CHECK:             linalg.yield [[VAR_14_4_]] : f32
 // CHECK:           } -> tensor<1024xf32>
-// CHECK:           linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_10_]], [[VAR_13_]] : tensor<1024x!ptr.ptr>, tensor<1024xf32>) {
-// CHECK:           ^bb0([[IN_11_:%.+]]: !ptr.ptr, [[IN_12_:%.+]]: f32):
-// CHECK:             [[VAR_14_5_:%.+]] = tptr.to_memref [[IN_11_]] : !ptr.ptr to memref<1xf32>
+// CHECK:           linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_10_]], [[VAR_13_]] : tensor<1024x!ptr.ptr<#tptr.default_memory_space>>, tensor<1024xf32>) {
+// CHECK:           ^bb0([[IN_11_:%.+]]: !ptr.ptr<#tptr.default_memory_space>, [[IN_12_:%.+]]: f32):
+// CHECK:             [[VAR_14_5_:%.+]] = tptr.to_memref [[IN_11_]] : <#tptr.default_memory_space> to memref<1xf32>
 // CHECK:             memref.store [[IN_12_]], [[VAR_14_5_]]{{.}}[[CST_0_]]{{.}} : memref<1xf32>
 // CHECK:             linalg.yield
 // CHECK:           }

--- a/test/Conversion/TritonToPtr/triton_tensor_ptr_ops.mlir
+++ b/test/Conversion/TritonToPtr/triton_tensor_ptr_ops.mlir
@@ -47,8 +47,8 @@ module {
 // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
 // CHECK-DAG:       [[VAR_1_:%.+]] = tptr.type_offset i32  : i32
 // CHECK-DAG:       [[CST_2_:%.+]] = arith.constant 2 : i32
-// CHECK-DAG:       [[VAR_2_:%.+]] = builtin.unrealized_conversion_cast [[PARAM_1_]] : !tt.ptr<i32> to !ptr.ptr
-// CHECK-DAG:       [[VAR_3_:%.+]] = builtin.unrealized_conversion_cast [[PARAM_0_]] : !tt.ptr<i32> to !ptr.ptr
+// CHECK-DAG:       [[VAR_2_:%.+]] = builtin.unrealized_conversion_cast [[PARAM_1_]] : !tt.ptr<i32> to !ptr.ptr<#tptr.default_memory_space>
+// CHECK-DAG:       [[VAR_3_:%.+]] = builtin.unrealized_conversion_cast [[PARAM_0_]] : !tt.ptr<i32> to !ptr.ptr<#tptr.default_memory_space>
 // CHECK-DAG:       [[VAR_4_:%.+]] = tensor.empty() : tensor<16xi32>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_5_:%.+]] = linalg.fill ins([[CST_2_]] : i32) outs([[VAR_4_]] : tensor<16xi32>) -> tensor<16xi32>
@@ -58,17 +58,17 @@ module {
 // CHECK:             [[VAR_23_:%.+]] = arith.index_cast [[VAR_22_]] : index to i32
 // CHECK:             linalg.yield [[VAR_23_]] : i32
 // CHECK:           } -> tensor<16xi32>
-// CHECK:           [[VAR_7_:%.+]] = tensor.empty() : tensor<16x!ptr.ptr>
-// CHECK:           [[VAR_8_:%.+]] = linalg.fill ins([[VAR_3_]] : !ptr.ptr) outs([[VAR_7_]] : tensor<16x!ptr.ptr>) -> tensor<16x!ptr.ptr>
-// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]], [[VAR_6_]] : tensor<16x!ptr.ptr>, tensor<16xi32>) outs([[VAR_8_]] : tensor<16x!ptr.ptr>) {
-// CHECK:           ^bb0([[IN_1_:%.+]]: !ptr.ptr, [[IN_2_:%.+]]: i32, [[IN_3_:%.+]]: !ptr.ptr):
+// CHECK:           [[VAR_7_:%.+]] = tensor.empty() : tensor<16x!ptr.ptr<#tptr.default_memory_space>>
+// CHECK:           [[VAR_8_:%.+]] = linalg.fill ins([[VAR_3_]] : !ptr.ptr<#tptr.default_memory_space>) outs([[VAR_7_]] : tensor<16x!ptr.ptr<#tptr.default_memory_space>>) -> tensor<16x!ptr.ptr<#tptr.default_memory_space>>
+// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_8_]], [[VAR_6_]] : tensor<16x!ptr.ptr<#tptr.default_memory_space>>, tensor<16xi32>) outs([[VAR_8_]] : tensor<16x!ptr.ptr<#tptr.default_memory_space>>) {
+// CHECK:           ^bb0([[IN_1_:%.+]]: !ptr.ptr<#tptr.default_memory_space>, [[IN_2_:%.+]]: i32, [[IN_3_:%.+]]: !ptr.ptr<#tptr.default_memory_space>):
 // CHECK:             [[VAR_22_1_:%.+]] = arith.muli [[IN_2_]], [[VAR_1_]] : i32
-// CHECK:             [[VAR_23_1_:%.+]] = tptr.ptradd [[IN_1_]] [[VAR_22_1_]] : !ptr.ptr, i32 to !ptr.ptr
-// CHECK:             linalg.yield [[VAR_23_1_]] : !ptr.ptr
-// CHECK:           } -> tensor<16x!ptr.ptr>
-// CHECK:           [[VAR_10_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_9_]] : tensor<16x!ptr.ptr>) outs([[VAR_4_]] : tensor<16xi32>) {
-// CHECK:           ^bb0([[IN_4_:%.+]]: !ptr.ptr, [[IN_5_:%.+]]: i32):
-// CHECK:             [[VAR_22_2_:%.+]] = tptr.to_memref [[IN_4_]] : !ptr.ptr to memref<1xi32>
+// CHECK:             [[VAR_23_1_:%.+]] = tptr.ptradd [[IN_1_]] [[VAR_22_1_]] : <#tptr.default_memory_space>, i32 to <#tptr.default_memory_space>
+// CHECK:             linalg.yield [[VAR_23_1_]] : !ptr.ptr<#tptr.default_memory_space>
+// CHECK:           } -> tensor<16x!ptr.ptr<#tptr.default_memory_space>>
+// CHECK:           [[VAR_10_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_9_]] : tensor<16x!ptr.ptr<#tptr.default_memory_space>>) outs([[VAR_4_]] : tensor<16xi32>) {
+// CHECK:           ^bb0([[IN_4_:%.+]]: !ptr.ptr<#tptr.default_memory_space>, [[IN_5_:%.+]]: i32):
+// CHECK:             [[VAR_22_2_:%.+]] = tptr.to_memref [[IN_4_]] : <#tptr.default_memory_space> to memref<1xi32>
 // CHECK:             [[VAR_23_1_:%.+]] = memref.load [[VAR_22_2_]]{{.}}[[CST_0_]]{{.}} : memref<1xi32>
 // CHECK:             linalg.yield [[VAR_23_1_]] : i32
 // CHECK:           } -> tensor<16xi32>
@@ -78,27 +78,27 @@ module {
 // CHECK:             [[VAR_22_3_:%.+]] = arith.extsi [[IN_6_]] : i32 to i64
 // CHECK:             linalg.yield [[VAR_22_3_]] : i64
 // CHECK:           } -> tensor<16xi64>
-// CHECK:           [[VAR_13_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_12_]] : tensor<16xi64>) outs([[VAR_7_]] : tensor<16x!ptr.ptr>) {
-// CHECK:           ^bb0([[IN_8_:%.+]]: i64, [[IN_9_:%.+]]: !ptr.ptr):
-// CHECK:             [[VAR_22_4_:%.+]] = tptr.inttoptr [[IN_8_]] : i64 to !ptr.ptr
-// CHECK:             linalg.yield [[VAR_22_4_]] : !ptr.ptr
-// CHECK:           } -> tensor<16x!ptr.ptr>
-// CHECK:           [[VAR_14_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_13_]] : tensor<16x!ptr.ptr>) outs([[VAR_4_]] : tensor<16xi32>) {
-// CHECK:           ^bb0([[IN_10_:%.+]]: !ptr.ptr, [[IN_11_:%.+]]: i32):
-// CHECK:             [[VAR_22_5_:%.+]] = tptr.to_memref [[IN_10_]] : !ptr.ptr to memref<1xi32>
+// CHECK:           [[VAR_13_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_12_]] : tensor<16xi64>) outs([[VAR_7_]] : tensor<16x!ptr.ptr<#tptr.default_memory_space>>) {
+// CHECK:           ^bb0([[IN_8_:%.+]]: i64, [[IN_9_:%.+]]: !ptr.ptr<#tptr.default_memory_space>):
+// CHECK:             [[VAR_22_4_:%.+]] = tptr.inttoptr [[IN_8_]] : i64 to <#tptr.default_memory_space>
+// CHECK:             linalg.yield [[VAR_22_4_]] : !ptr.ptr<#tptr.default_memory_space>
+// CHECK:           } -> tensor<16x!ptr.ptr<#tptr.default_memory_space>>
+// CHECK:           [[VAR_14_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_13_]] : tensor<16x!ptr.ptr<#tptr.default_memory_space>>) outs([[VAR_4_]] : tensor<16xi32>) {
+// CHECK:           ^bb0([[IN_10_:%.+]]: !ptr.ptr<#tptr.default_memory_space>, [[IN_11_:%.+]]: i32):
+// CHECK:             [[VAR_22_5_:%.+]] = tptr.to_memref [[IN_10_]] : <#tptr.default_memory_space> to memref<1xi32>
 // CHECK:             [[VAR_23_1_1_:%.+]] = memref.load [[VAR_22_5_]]{{.}}[[CST_0_]]{{.}} : memref<1xi32>
 // CHECK:             linalg.yield [[VAR_23_1_1_]] : i32
 // CHECK:           } -> tensor<16xi32>
-// CHECK:           [[VAR_15_:%.+]] = linalg.fill ins([[VAR_2_]] : !ptr.ptr) outs([[VAR_7_]] : tensor<16x!ptr.ptr>) -> tensor<16x!ptr.ptr>
-// CHECK:           [[VAR_16_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_15_]], [[VAR_6_]] : tensor<16x!ptr.ptr>, tensor<16xi32>) outs([[VAR_15_]] : tensor<16x!ptr.ptr>) {
-// CHECK:           ^bb0([[IN_12_:%.+]]: !ptr.ptr, [[IN_13_:%.+]]: i32, [[IN_14_:%.+]]: !ptr.ptr):
+// CHECK:           [[VAR_15_:%.+]] = linalg.fill ins([[VAR_2_]] : !ptr.ptr<#tptr.default_memory_space>) outs([[VAR_7_]] : tensor<16x!ptr.ptr<#tptr.default_memory_space>>) -> tensor<16x!ptr.ptr<#tptr.default_memory_space>>
+// CHECK:           [[VAR_16_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_15_]], [[VAR_6_]] : tensor<16x!ptr.ptr<#tptr.default_memory_space>>, tensor<16xi32>) outs([[VAR_15_]] : tensor<16x!ptr.ptr<#tptr.default_memory_space>>) {
+// CHECK:           ^bb0([[IN_12_:%.+]]: !ptr.ptr<#tptr.default_memory_space>, [[IN_13_:%.+]]: i32, [[IN_14_:%.+]]: !ptr.ptr<#tptr.default_memory_space>):
 // CHECK:             [[VAR_22_6_:%.+]] = arith.muli [[IN_13_]], [[VAR_1_]] : i32
-// CHECK:             [[VAR_23_2_:%.+]] = tptr.ptradd [[IN_12_]] [[VAR_22_6_]] : !ptr.ptr, i32 to !ptr.ptr
-// CHECK:             linalg.yield [[VAR_23_2_]] : !ptr.ptr
-// CHECK:           } -> tensor<16x!ptr.ptr>
-// CHECK:           [[VAR_17_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_16_]] : tensor<16x!ptr.ptr>) outs([[VAR_11_]] : tensor<16xi64>) {
-// CHECK:           ^bb0([[IN_15_:%.+]]: !ptr.ptr, [[IN_16_:%.+]]: i64):
-// CHECK:             [[VAR_22_7_:%.+]] = tptr.ptrtoint [[IN_15_]] : !ptr.ptr to i64
+// CHECK:             [[VAR_23_2_:%.+]] = tptr.ptradd [[IN_12_]] [[VAR_22_6_]] : <#tptr.default_memory_space>, i32 to <#tptr.default_memory_space>
+// CHECK:             linalg.yield [[VAR_23_2_]] : !ptr.ptr<#tptr.default_memory_space>
+// CHECK:           } -> tensor<16x!ptr.ptr<#tptr.default_memory_space>>
+// CHECK:           [[VAR_17_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_16_]] : tensor<16x!ptr.ptr<#tptr.default_memory_space>>) outs([[VAR_11_]] : tensor<16xi64>) {
+// CHECK:           ^bb0([[IN_15_:%.+]]: !ptr.ptr<#tptr.default_memory_space>, [[IN_16_:%.+]]: i64):
+// CHECK:             [[VAR_22_7_:%.+]] = tptr.ptrtoint [[IN_15_]] : <#tptr.default_memory_space> to i64
 // CHECK:             linalg.yield [[VAR_22_7_]] : i64
 // CHECK:           } -> tensor<16xi64>
 // CHECK:           [[VAR_18_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_14_]] : tensor<16xi32>) outs([[VAR_11_]] : tensor<16xi64>) {
@@ -111,20 +111,20 @@ module {
 // CHECK:             [[VAR_22_9_:%.+]] = arith.addi [[IN_19_]], [[IN_20_]] : i64
 // CHECK:             linalg.yield [[VAR_22_9_]] : i64
 // CHECK:           } -> tensor<16xi64>
-// CHECK:           [[VAR_20_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_16_]], [[VAR_5_]] : tensor<16x!ptr.ptr>, tensor<16xi32>) outs([[VAR_16_]] : tensor<16x!ptr.ptr>) {
-// CHECK:           ^bb0([[IN_22_:%.+]]: !ptr.ptr, [[IN_23_:%.+]]: i32, [[IN_24_:%.+]]: !ptr.ptr):
+// CHECK:           [[VAR_20_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_16_]], [[VAR_5_]] : tensor<16x!ptr.ptr<#tptr.default_memory_space>>, tensor<16xi32>) outs([[VAR_16_]] : tensor<16x!ptr.ptr<#tptr.default_memory_space>>) {
+// CHECK:           ^bb0([[IN_22_:%.+]]: !ptr.ptr<#tptr.default_memory_space>, [[IN_23_:%.+]]: i32, [[IN_24_:%.+]]: !ptr.ptr<#tptr.default_memory_space>):
 // CHECK:             [[VAR_22_10_:%.+]] = arith.muli [[IN_23_]], [[VAR_0_]] : i32
-// CHECK:             [[VAR_23_3_:%.+]] = tptr.ptradd [[IN_22_]] [[VAR_22_10_]] : !ptr.ptr, i32 to !ptr.ptr
-// CHECK:             linalg.yield [[VAR_23_3_]] : !ptr.ptr
-// CHECK:           } -> tensor<16x!ptr.ptr>
+// CHECK:             [[VAR_23_3_:%.+]] = tptr.ptradd [[IN_22_]] [[VAR_22_10_]] : <#tptr.default_memory_space>, i32 to <#tptr.default_memory_space>
+// CHECK:             linalg.yield [[VAR_23_3_]] : !ptr.ptr<#tptr.default_memory_space>
+// CHECK:           } -> tensor<16x!ptr.ptr<#tptr.default_memory_space>>
 // CHECK:           [[VAR_21_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_19_]] : tensor<16xi64>) outs([[VAR_4_]] : tensor<16xi32>) {
 // CHECK:           ^bb0([[IN_25_:%.+]]: i64, [[IN_26_:%.+]]: i32):
 // CHECK:             [[VAR_22_11_:%.+]] = arith.trunci [[IN_25_]] : i64 to i32
 // CHECK:             linalg.yield [[VAR_22_11_]] : i32
 // CHECK:           } -> tensor<16xi32>
-// CHECK:           linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_20_]], [[VAR_21_]] : tensor<16x!ptr.ptr>, tensor<16xi32>) {
-// CHECK:           ^bb0([[IN_27_:%.+]]: !ptr.ptr, [[IN_28_:%.+]]: i32):
-// CHECK:             [[VAR_22_12_:%.+]] = tptr.to_memref [[IN_27_]] : !ptr.ptr to memref<1xi32>
+// CHECK:           linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_20_]], [[VAR_21_]] : tensor<16x!ptr.ptr<#tptr.default_memory_space>>, tensor<16xi32>) {
+// CHECK:           ^bb0([[IN_27_:%.+]]: !ptr.ptr<#tptr.default_memory_space>, [[IN_28_:%.+]]: i32):
+// CHECK:             [[VAR_22_12_:%.+]] = tptr.to_memref [[IN_27_]] : <#tptr.default_memory_space> to memref<1xi32>
 // CHECK:             memref.store [[IN_28_]], [[VAR_22_12_]]{{.}}[[CST_0_]]{{.}} : memref<1xi32>
 // CHECK:             linalg.yield
 // CHECK:           }


### PR DESCRIPTION
The main change needed for this update is that MemorySpaceAttrInterface is now required when creating a Ptr type. Unfortunately, there is no built-in implementation of the interface, so to use Ptr type now we must also implement this interface. I have added a new DefaultMemorySpaceAttr into the TPtr dialect that does this.