### PR TITLE
Update triton (beyond) 784b550

### DIFF
--- a/.github/workflows/test-plugin.yml
+++ b/.github/workflows/test-plugin.yml
@@ -74,7 +74,7 @@ jobs:
         TRITON_BUILD_WITH_CLANG_LLD=true TRITON_BUILD_WITH_CCACHE=true python3 -m pip install --no-build-isolation -vvv '.[tests]'
 
     - name: Run shared middle-layer lit tests
-      working-directory: triton_shared/triton/python
+      working-directory: triton_shared/triton
       run: |
         python3 -m pip install lit
         LIT_TEST_DIR="build/$(ls build | grep -i cmake)/third_party/triton_shared/test"
@@ -89,7 +89,7 @@ jobs:
         python3 -m pip install pytest
 
     - name: Prepare CPU backend environment
-      working-directory: triton_shared/triton/python
+      working-directory: triton_shared/triton
       run: |
         CMAKE_BUILD_DIR=$(ls $(pwd)/build | grep -i cmake)
         LLVM_BINARY_DIR=$(find  ${HOME}/.triton/llvm/ -name bin | head -1)

--- a/.github/workflows/test-plugin.yml
+++ b/.github/workflows/test-plugin.yml
@@ -64,7 +64,7 @@ jobs:
         python3 -m pre_commit run --all-files --verbose
 
     - name: Build/Install Triton
-      working-directory: triton_shared/triton/python
+      working-directory: triton_shared/triton
       run: |
         python3 -m pip install --upgrade pip
         python3 -m pip install cmake==3.24 ninja pytest-xdist pybind11 setuptools

--- a/.github/workflows/test-plugin.yml
+++ b/.github/workflows/test-plugin.yml
@@ -138,7 +138,7 @@ jobs:
         python3 -m pre_commit run --all-files --verbose
 
     - name: Build/Install Triton
-      working-directory: triton_shared/triton/python
+      working-directory: triton_shared/triton
       run: |
         python3 -m pip install --upgrade pip
         python3 -m pip install cmake==3.24 ninja pytest-xdist pybind11 setuptools
@@ -148,7 +148,7 @@ jobs:
         TRITON_BUILD_WITH_CLANG_LLD=true TRITON_BUILD_WITH_CCACHE=true python3 -m pip install --no-build-isolation -vvv '.[tests]'
 
     - name: Run shared middle-layer lit tests
-      working-directory: triton_shared/triton/python
+      working-directory: triton_shared/triton
       run: |
         python3 -m pip install lit
         LIT_TEST_DIR="build/$(ls build | grep -i cmake)/third_party/triton_shared/test"
@@ -163,7 +163,7 @@ jobs:
         python3 -m pip install pytest
 
     - name: Prepare CPU backend environment
-      working-directory: triton_shared/triton/python
+      working-directory: triton_shared/triton
       run: |
         CMAKE_BUILD_DIR=$(ls $(pwd)/build | grep -i cmake)
         LLVM_BINARY_DIR=$(find  ${HOME}/.triton/llvm/ -name bin | head -1)

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "triton"]
 	path = triton
-	url = https://github.com/triton-lang/triton.git
+	url = https://github.com/bmyerz0/triton.git

--- a/backend/driver.py
+++ b/backend/driver.py
@@ -349,7 +349,8 @@ class CPUUtils(object):
           None,       # module
           kernel_obj, # function
           None,       # n_regs
-          None        # n_spills
+          None,        # n_spills
+          1024*1024*1024, # n_max_threads
         )
 
 


### PR DESCRIPTION
In the work on #264 we found setup.py was broken...
one issue has been fixed in triton but another we are waiting on

- [ ] update readme with new directory (setup.py now in triton/ not triton/python)
- [ ] merge https://github.com/triton-lang/triton/pull/6730 and update triton submodule accordingly