### PR TITLE
Skip handling ptr_to_int on tensor

### DIFF
--- a/lib/Conversion/TritonToUnstructured/TritonToUnstructuredPass.cpp
+++ b/lib/Conversion/TritonToUnstructured/TritonToUnstructuredPass.cpp
@@ -294,6 +294,10 @@ public:
             llvm::TypeSwitch<Operation *, LogicalResult>(user)
 
                 .Case<triton::PtrToIntOp>([&](triton::PtrToIntOp op) {
+                  if (isa<RankedTensorType>(op.getType())) {
+                    return failure();
+                  }
+
                   auto offsetInfo = offsetMap.at(op.getSrc());
 
                   OpBuilder b{op};


### PR DESCRIPTION
Since the triton-to-unstructured pass only handles tensor of pointers with single base, we want to skip handling ptr_to_int on tensor. This is because we do not know whether the tensor would contain a single base at compile time.