### PR TITLE
Use memref.load/store for scalar load/store operations

### DIFF
--- a/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
+++ b/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
@@ -350,9 +350,10 @@ public:
     if (!isa<ShapedType>(op.getResult().getType())) {
       auto sMemRef = PtrAnalysis::getScalarMemRef(op.getPtr(), adaptor.getPtr(),
                                                   loc, rewriter);
-      auto zeroMap = AffineMap::getConstantMap(0, rewriter.getContext());
-      auto loadOp = rewriter.create<affine::AffineLoadOp>(
-          op.getLoc(), sMemRef, zeroMap, std::nullopt);
+      auto index =
+          rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(0))
+              .getResult();
+      auto loadOp = rewriter.create<memref::LoadOp>(loc, sMemRef, index);
       rewriter.replaceOp(op, loadOp.getResult());
       return success();
     }
@@ -510,9 +511,10 @@ struct StoreConverter : public OpConversionPattern<triton::StoreOp> {
     if (!isa<ShapedType>(val.getType())) {
       auto sMemRef =
           PtrAnalysis::getScalarMemRef(op.getPtr(), ptr, loc, rewriter);
-      auto zeroMap = AffineMap::getConstantMap(0, rewriter.getContext());
-      rewriter.create<affine::AffineStoreOp>(loc, val, sMemRef, zeroMap,
-                                             std::nullopt);
+      auto index =
+          rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(0))
+              .getResult();
+      rewriter.create<memref::StoreOp>(loc, val, sMemRef, index);
       rewriter.eraseOp(op);
       return success();
     }

--- a/lib/Conversion/UnstructuredToMemref/UnstructuredToMemrefPass.cpp
+++ b/lib/Conversion/UnstructuredToMemref/UnstructuredToMemrefPass.cpp
@@ -100,11 +100,10 @@ struct ScalarLoadConverter : public OpConversionPattern<tts::GatherOp> {
         basePtr, getAsOpFoldResult(loadIndex) /*offset*/,
         ArrayRef<OpFoldResult>{rewriter.getIndexAttr(1)} /*sizes*/,
         ArrayRef<OpFoldResult>{rewriter.getIndexAttr(1)} /*strides*/);
-
-    auto zeroMap = AffineMap::getConstantMap(0, rewriter.getContext());
-
-    auto scalarLoadOp = rewriter.create<affine::AffineLoadOp>(
-        loc, memref, zeroMap, std::nullopt);
+    auto index =
+        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(0))
+            .getResult();
+    auto scalarLoadOp = rewriter.create<memref::LoadOp>(loc, memref, index);
 
     rewriter.replaceOp(gatherOp, scalarLoadOp.getResult());
 
@@ -147,10 +146,10 @@ struct ScalarStoreConverter : public OpConversionPattern<tts::ScatterOp> {
         ArrayRef<OpFoldResult>{rewriter.getIndexAttr(1)} /*strides*/);
 
     auto storeVal = scatterOp.getValue();
-    auto zeroMap = AffineMap::getConstantMap(0, rewriter.getContext());
-
-    rewriter.create<affine::AffineStoreOp>(loc, storeVal, memref, zeroMap,
-                                           std::nullopt);
+    auto index =
+        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(0))
+            .getResult();
+    rewriter.create<memref::StoreOp>(loc, storeVal, memref, index);
     rewriter.eraseOp(scatterOp);
 
     return success();

--- a/test/Conversion/StructuredToMemref/addptr_chain.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_chain.mlir
@@ -24,6 +24,7 @@ module {
 
 // CHECK-LABEL:  func.func @addptr
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32) {
+// CHECK-DAG:      %[[C0:.*]] = arith.constant 0 : index
 // CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : i32
 // CHECK-DAG:       [[CST_10_:%.+]] = arith.constant 10 : i32
 // CHECK-DAG:       [[CST_2_:%.+]] = arith.constant 2 : i32
@@ -33,14 +34,14 @@ module {
 // CHECK-DAG:         [[VAR_1_:%.+]] = arith.addi [[I_0_]], [[CST_2_]] : i32
 // CHECK:             [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
 // CHECK:             [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
-// CHECK-DAG:         [[LOAD_VAR_reinterpret_cast_MEM_:%.+]] = affine.load [[VAR_reinterpret_cast_]][0] : memref<1xf32, strided<[1], offset: ?>>
-// CHECK-DAG:         [[VAR_4_:%.+]] = arith.index_cast [[VAR_1_]] : i32 to index
+// CHECK:         [[LOAD_VAR_reinterpret_cast_MEM_:%.+]] = memref.load [[VAR_reinterpret_cast_]][%[[C0]]] : memref<1xf32, strided<[1], offset: ?>>
+// CHECK:         [[VAR_4_:%.+]] = arith.index_cast [[VAR_1_]] : i32 to index
 // CHECK:             [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_4_]]{{.}}, sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
-// CHECK-DAG:         [[LOAD_VAR_reinterpret_cast_0_MEM_:%.+]] = affine.load [[VAR_reinterpret_cast_0_]][0] : memref<1xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[LOAD_VAR_reinterpret_cast_0_MEM_:%.+]] = memref.load [[VAR_reinterpret_cast_0_]][%[[C0]]] : memref<1xf32, strided<[1], offset: ?>>
 // CHECK-DAG:         [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
-// CHECK:             affine.store [[LOAD_VAR_reinterpret_cast_MEM_]], [[VAR_reinterpret_cast_1_]][0] : memref<1xf32, strided<[1], offset: ?>>
+// CHECK:             memref.store [[LOAD_VAR_reinterpret_cast_MEM_]], [[VAR_reinterpret_cast_1_]][%[[C0]]] : memref<1xf32, strided<[1], offset: ?>>
 // CHECK:             [[VAR_reinterpret_cast_2_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_4_]]{{.}}, sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
-// CHECK:             affine.store [[LOAD_VAR_reinterpret_cast_0_MEM_]], [[VAR_reinterpret_cast_2_]][0] : memref<1xf32, strided<[1], offset: ?>>
+// CHECK:             memref.store [[LOAD_VAR_reinterpret_cast_0_MEM_]], [[VAR_reinterpret_cast_2_]][%[[C0]]] : memref<1xf32, strided<[1], offset: ?>>
 // CHECK:           }
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/StructuredToMemref/addptr_scalar_loopback.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_scalar_loopback.mlir
@@ -16,10 +16,11 @@ module {
 
 // CHECK-LABEL:  func.func @kernel
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: memref<*xbf16>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:      %[[C0:.*]] = arith.constant 0 : index
 // CHECK:           [[VAR_0_:%.+]] = arith.index_cast [[PARAM_2_]] : i32 to index
 // CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_0_]]{{.}}, sizes: [1], strides: [1] : memref<*xbf16> to memref<1xbf16, strided<[1], offset: ?>>
 // CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_0_]]{{.}}, sizes: [1], strides: [1] : memref<*xbf16> to memref<1xbf16, strided<[1], offset: ?>>
-// CHECK-DAG:           [[LOAD_VAR_reinterpret_cast_MEM_:%.+]] = affine.load [[VAR_reinterpret_cast_]][0] : memref<1xbf16, strided<[1], offset: ?>>
-// CHECK:           affine.store [[LOAD_VAR_reinterpret_cast_MEM_]], [[VAR_reinterpret_cast_0_]][0] : memref<1xbf16, strided<[1], offset: ?>>
+// CHECK-DAG:           [[LOAD_VAR_reinterpret_cast_MEM_:%.+]] = memref.load [[VAR_reinterpret_cast_]][%[[C0]]] : memref<1xbf16, strided<[1], offset: ?>>
+// CHECK:           memref.store [[LOAD_VAR_reinterpret_cast_MEM_]], [[VAR_reinterpret_cast_0_]][%[[C0]]] : memref<1xbf16, strided<[1], offset: ?>>
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/StructuredToMemref/convert_addi_reduce.mlir
+++ b/test/Conversion/StructuredToMemref/convert_addi_reduce.mlir
@@ -15,7 +15,7 @@ module {
 
 // CHECK-LABEL:  func.func @addi
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xi32>, [[PARAM_1_:%.+]]: i32, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32) {
-// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
+// CHECK-DAG:       %[[CST_0_:.+]] = arith.constant 0 : index
 // CHECK-DAG:       [[CST_0_1_:%.+]] = arith.constant 0 : i32
 // CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<4096xi32>
 // CHECK-NOT: separator of consecutive DAGs
@@ -28,7 +28,7 @@ module {
 // CHECK:               linalg.yield [[VAR_3_]] : i32
 // CHECK:             }
 // CHECK-DAG:       [[VAR_extracted_:%.+]] = tensor.extract [[VAR_reduced_]][] : tensor<i32>
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[CST_0_]]{{.}}, sizes: [1], strides: [1] : memref<*xi32> to memref<1xi32, strided<[1], offset: ?>>
-// CHECK:           affine.store [[VAR_extracted_]], [[VAR_reinterpret_cast_]][0] : memref<1xi32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [%[[CST_0_]]], sizes: [1], strides: [1] : memref<*xi32> to memref<1xi32, strided<[1], offset: ?>>
+// CHECK:           memref.store [[VAR_extracted_]], [[VAR_reinterpret_cast_]][%[[CST_0_]]] : memref<1xi32, strided<[1], offset: ?>>
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/StructuredToMemref/convert_argmin_argmax.mlir
+++ b/test/Conversion/StructuredToMemref/convert_argmin_argmax.mlir
@@ -30,6 +30,7 @@ module {
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
 // CHECK-LABEL:  func.func @argmax_012
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xi32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:      %[[C0:.*]] = arith.constant 0 : index
 // CHECK-DAG:       [[CST_minus_1_:%.+]] = arith.constant -1 : i32
 // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0xFF800000 : f32
 // CHECK-DAG:       [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[PARAM_2_]] : i32
@@ -66,7 +67,7 @@ module {
 // CHECK-DAG:       [[VAR_extracted_:%.+]] = tensor.extract [[VAR_reduced_]]#1[] : tensor<i32>
 // CHECK-DAG:       [[VAR_9_:%.+]] = arith.index_cast [[PARAM_6_]] : i32 to index
 // CHECK:           [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_9_]]{{.}}, sizes: [1], strides: [1] : memref<*xi32> to memref<1xi32, strided<[1], offset: ?>>
-// CHECK:           affine.store [[VAR_extracted_]], [[VAR_reinterpret_cast_0_]][0] : memref<1xi32, strided<[1], offset: ?>>
+// CHECK:           memref.store [[VAR_extracted_]], [[VAR_reinterpret_cast_0_]][%[[C0]]] : memref<1xi32, strided<[1], offset: ?>>
 // CHECK:           return
 // CHECK:         }
 
@@ -102,6 +103,7 @@ module {
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
 // CHECK-LABEL:  func.func @argmin_012
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xi32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:      %[[C0:.*]] = arith.constant 0 : index
 // CHECK-DAG:       [[CST_minus_1_:%.+]] = arith.constant -1 : i32
 // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0x7F800000 : f32
 // CHECK-DAG:       [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[PARAM_2_]] : i32
@@ -138,6 +140,6 @@ module {
 // CHECK-DAG:       [[VAR_extracted_:%.+]] = tensor.extract [[VAR_reduced_]]#1[] : tensor<i32>
 // CHECK-DAG:       [[VAR_9_:%.+]] = arith.index_cast [[PARAM_6_]] : i32 to index
 // CHECK:           [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_9_]]{{.}}, sizes: [1], strides: [1] : memref<*xi32> to memref<1xi32, strided<[1], offset: ?>>
-// CHECK:           affine.store [[VAR_extracted_]], [[VAR_reinterpret_cast_0_]][0] : memref<1xi32, strided<[1], offset: ?>>
+// CHECK:           memref.store [[VAR_extracted_]], [[VAR_reinterpret_cast_0_]][%[[C0]]] : memref<1xi32, strided<[1], offset: ?>>
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/StructuredToMemref/early_return.mlir
+++ b/test/Conversion/StructuredToMemref/early_return.mlir
@@ -35,6 +35,7 @@ module {
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
 // CHECK-LABEL:  func.func @test_1
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32) {
+// CHECK-DAG:      %[[C0:.*]] = arith.constant 0 : index
 // CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : i32
 // CHECK-DAG:       [[CST_minus_1_dot_000000_:%.+]] = arith.constant -1.000000e+00 : f32
 // CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<4xi32>
@@ -42,7 +43,7 @@ module {
 // CHECK-DAG:       [[VAR_1_:%.+]] = linalg.fill ins([[CST_1_]] : i32) outs([[VAR_0_]] : tensor<4xi32>) -> tensor<4xi32>
 // CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[PARAM_5_]] : i32 to index
 // CHECK:           [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
-// CHECK:           [[LOAD_VAR_reinterpret_cast_MEM_:%.+]] = affine.load [[VAR_reinterpret_cast_]][0] : memref<1xf32, strided<[1], offset: ?>>
+// CHECK:           [[LOAD_VAR_reinterpret_cast_MEM_:%.+]] = memref.load [[VAR_reinterpret_cast_]][%[[C0]]] : memref<1xf32, strided<[1], offset: ?>>
 // CHECK:           [[VAR_4_:%.+]] = arith.cmpf oeq, [[LOAD_VAR_reinterpret_cast_MEM_]], [[CST_minus_1_dot_000000_]] : f32
 // CHECK:           cf.cond_br [[VAR_4_]], ^bb1, ^bb2
 // CHECK:         ^bb1:  // pred: ^bb0

--- a/test/Conversion/StructuredToMemref/kernel-05-layer-norm-fwd.mlir
+++ b/test/Conversion/StructuredToMemref/kernel-05-layer-norm-fwd.mlir
@@ -91,6 +91,7 @@ module {
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
 // CHECK-LABEL:  func.func @_layer_norm_fwd_fused_0123456789
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: memref<*xf32>, [[PARAM_3_:%.+]]: memref<*xf32>, [[PARAM_4_:%.+]]: memref<*xf32>, [[PARAM_5_:%.+]]: memref<*xf32>, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: f32, [[PARAM_9_:%.+]]: i32, [[PARAM_10_:%.+]]: i32, [[PARAM_11_:%.+]]: i32, [[PARAM_12_:%.+]]: i32, [[PARAM_13_:%.+]]: i32, [[PARAM_14_:%.+]]: i32) {
+// CHECK-DAG:      %[[C0:.*]] = arith.constant 0 : index
 // CHECK-DAG:       [[CST_1_dot_000000_:%.+]] = arith.constant 1.000000e+00 : f32
 // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : i32
 // CHECK-DAG:       [[CST_256_:%.+]] = arith.constant 256 : i32
@@ -212,9 +213,9 @@ module {
 // CHECK-DAG:       [[VAR_17_:%.+]] = arith.divf [[CST_1_dot_000000_]], [[VAR_16_]] : f32
 // CHECK-DAG:       [[VAR_18_:%.+]] = arith.index_cast [[PARAM_12_]] : i32 to index
 // CHECK:           [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_4_]] to offset: {{.}}[[VAR_18_]]{{.}}, sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
-// CHECK:           affine.store [[VAR_10_]], [[VAR_reinterpret_cast_]][0] : memref<1xf32, strided<[1], offset: ?>>
+// CHECK:           memref.store [[VAR_10_]], [[VAR_reinterpret_cast_]][%[[C0]]] : memref<1xf32, strided<[1], offset: ?>>
 // CHECK:           [[VAR_reinterpret_cast_4_:%.+]] = memref.reinterpret_cast [[PARAM_5_]] to offset: {{.}}[[VAR_18_]]{{.}}, sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
-// CHECK:           affine.store [[VAR_17_]], [[VAR_reinterpret_cast_4_]][0] : memref<1xf32, strided<[1], offset: ?>>
+// CHECK:           memref.store [[VAR_17_]], [[VAR_reinterpret_cast_4_]][%[[C0]]] : memref<1xf32, strided<[1], offset: ?>>
 // CHECK:           [[VAR_19_:%.+]] = linalg.fill ins([[VAR_17_]] : f32) outs([[VAR_0_]] : tensor<256xf32>) -> tensor<256xf32>
 // CHECK:           scf.for [[VAR_arg15_1_:%.+]] = [[CST_0_]] to [[PARAM_7_]] step [[CST_256_]]  : i32 {
 // CHECK:             [[VAR_20_5_:%.+]] = arith.index_cast [[VAR_arg15_1_]] : i32 to index

--- a/test/Conversion/StructuredToMemref/scalar_store_loop.mlir
+++ b/test/Conversion/StructuredToMemref/scalar_store_loop.mlir
@@ -19,16 +19,16 @@ module {
 
 // CHECK-LABEL:  func.func @reduce_kernel_2d_0d
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32> {tt.divisibility = 16 : i32}, [[PARAM_1_:%.+]]: i32, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32) {
-// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
+// CHECK-DAG:       %[[CST_0_:.+]] = arith.constant 0 : index
 // CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : index
 // CHECK-DAG:       [[CST_1_1_:%.+]] = arith.constant 1 : i32
 // CHECK-DAG:       [[CST_0_1_:%.+]] = arith.constant 0 : i32
 // CHECK-DAG:       [[CST_8_:%.+]] = arith.constant 8 : i32
 // CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_0_:%.+]]:2 = scf.for [[VAR_arg7_:%.+]] = [[CST_0_1_]] to [[CST_8_]] step [[CST_1_1_]] iter_args([[VAR_arg8_:%.+]] = [[VAR_reinterpret_cast_]], [[VAR_arg9_:%.+]] = [[CST_0_]]) -> (memref<1xf32, strided<[1], offset: ?>>, index)  : i32 {
+// CHECK-DAG:       [[VAR_0_:%.+]]:2 = scf.for [[VAR_arg7_:%.+]] = [[CST_0_1_]] to [[CST_8_]] step [[CST_1_1_]] iter_args([[VAR_arg8_:%.+]] = [[VAR_reinterpret_cast_]], [[VAR_arg9_:%.+]] = %[[CST_0_]]) -> (memref<1xf32, strided<[1], offset: ?>>, index)  : i32 {
 // CHECK-DAG:         [[VAR_1_:%.+]] = arith.sitofp [[VAR_arg7_]] : i32 to f32
-// CHECK:             affine.store [[VAR_1_]], [[VAR_arg8_]][0] : memref<1xf32, strided<[1], offset: ?>>
+// CHECK:             memref.store [[VAR_1_]], [[VAR_arg8_]][%[[CST_0_]]] : memref<1xf32, strided<[1], offset: ?>>
 // CHECK:             [[VAR_2_:%.+]] = arith.addi [[VAR_arg9_]], [[CST_1_]] : index
 // CHECK:             [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[VAR_arg8_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [1], strides: [1] : memref<1xf32, strided<[1], offset: ?>> to memref<1xf32, strided<[1], offset: ?>>
 // CHECK:             scf.yield [[VAR_reinterpret_cast_0_]], [[VAR_2_]] : memref<1xf32, strided<[1], offset: ?>>, index

--- a/test/Conversion/StructuredToMemref/scalar_store_loop_iterargs.mlir
+++ b/test/Conversion/StructuredToMemref/scalar_store_loop_iterargs.mlir
@@ -21,6 +21,7 @@ module {
 
 // CHECK-LABEL:  func.func @reduce_kernel_2d_0d1d2de3de
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32> {tt.divisibility = 16 : i32}, [[PARAM_1_:%.+]]: memref<*xf32> {tt.divisibility = 16 : i32}, [[PARAM_2_:%.+]]: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 16 : i32}, [[PARAM_3_:%.+]]: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 16 : i32}, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32, [[PARAM_10_:%.+]]: i32, [[PARAM_11_:%.+]]: i32, [[PARAM_12_:%.+]]: i32, [[PARAM_13_:%.+]]: i32, [[PARAM_14_:%.+]]: i32, [[PARAM_15_:%.+]]: i32) {
+// CHECK-DAG:      %[[C0:.*]] = arith.constant 0 : index
 // CHECK-DAG:       [[CST_5_:%.+]] = arith.constant 5 : i32
 // CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : i32
 // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : i32
@@ -30,7 +31,7 @@ module {
 // CHECK-DAG:       [[VAR_2_:%.+]]:3 = scf.for [[VAR_arg16_:%.+]] = [[CST_0_]] to [[CST_5_]] step [[CST_1_]] iter_args([[VAR_arg17_:%.+]] = [[PARAM_7_]], [[VAR_arg18_:%.+]] = [[VAR_0_]], [[VAR_arg19_:%.+]] = [[VAR_0_]]) -> (i32, index, index)  : i32 {
 // CHECK-DAG:         [[VAR_3_:%.+]] = arith.index_cast [[VAR_arg17_]] : i32 to index
 // CHECK:             [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_3_]]{{.}}, sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
-// CHECK:             affine.store [[VAR_1_]], [[VAR_reinterpret_cast_]][0] : memref<1xf32, strided<[1], offset: ?>>
+// CHECK:             memref.store [[VAR_1_]], [[VAR_reinterpret_cast_]][%[[C0]]] : memref<1xf32, strided<[1], offset: ?>>
 // CHECK:             [[VAR_4_:%.+]] = arith.index_cast [[VAR_arg16_]] : i32 to index
 // CHECK-DAG:         [[VAR_5_:%.+]] = arith.addi [[VAR_arg18_]], [[VAR_4_]] : index
 // CHECK-DAG:         [[VAR_6_:%.+]] = arith.addi [[VAR_arg17_]], [[VAR_arg16_]] : i32

--- a/test/Conversion/StructuredToMemref/scalar_store_nested_loop.mlir
+++ b/test/Conversion/StructuredToMemref/scalar_store_nested_loop.mlir
@@ -23,6 +23,7 @@ module {
 
 // CHECK-LABEL:  func.func @reduce_kernel_2d_0d
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32> {tt.divisibility = 16 : i32}, [[PARAM_1_:%.+]]: i32, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32, [[PARAM_10_:%.+]]: i32, [[PARAM_11_:%.+]]: i32, [[PARAM_12_:%.+]]: i32) {
+// CHECK-DAG:      %[[C0:.*]] = arith.constant 0 : index
 // CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : index
 // CHECK-DAG:       [[CST_1_1_:%.+]] = arith.constant 1 : i32
 // CHECK-DAG:       [[CST_8_:%.+]] = arith.constant 8 : i32
@@ -37,7 +38,7 @@ module {
 // CHECK-DAG:           [[VAR_4_:%.+]] = arith.sitofp [[VAR_3_]] : i32 to f32
 // CHECK-DAG:           [[VAR_5_:%.+]] = arith.index_cast [[VAR_arg17_]] : i32 to index
 // CHECK:               [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_5_]]{{.}}, sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
-// CHECK:               affine.store [[VAR_4_]], [[VAR_reinterpret_cast_]][0] : memref<1xf32, strided<[1], offset: ?>>
+// CHECK:               memref.store [[VAR_4_]], [[VAR_reinterpret_cast_]][%[[C0]]] : memref<1xf32, strided<[1], offset: ?>>
 // CHECK-DAG:           [[VAR_6_:%.+]] = arith.addi [[VAR_arg18_]], [[CST_1_]] : index
 // CHECK-DAG:           [[VAR_7_:%.+]] = arith.addi [[VAR_arg17_]], [[CST_1_1_]] : i32
 // CHECK:               scf.yield [[VAR_7_]], [[VAR_6_]] : i32, index

--- a/test/Conversion/StructuredToMemref/scalar_store_no_iterargs.mlir
+++ b/test/Conversion/StructuredToMemref/scalar_store_no_iterargs.mlir
@@ -17,6 +17,7 @@ module {
 
 // CHECK-LABEL:  func.func @reduce_kernel_2d_0d1d2de3de
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32> {tt.divisibility = 16 : i32}, [[PARAM_1_:%.+]]: memref<*xf32> {tt.divisibility = 16 : i32}, [[PARAM_2_:%.+]]: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 16 : i32}, [[PARAM_3_:%.+]]: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 16 : i32}, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32, [[PARAM_10_:%.+]]: i32, [[PARAM_11_:%.+]]: i32, [[PARAM_12_:%.+]]: i32, [[PARAM_13_:%.+]]: i32, [[PARAM_14_:%.+]]: i32, [[PARAM_15_:%.+]]: i32) {
+// CHECK-DAG:      %[[C0:.*]] = arith.constant 0 : index
 // CHECK-DAG:       [[CST_5_:%.+]] = arith.constant 5 : i32
 // CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : i32
 // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : i32
@@ -25,7 +26,7 @@ module {
 // CHECK:             [[VAR_1_:%.+]] = arith.addi [[PARAM_7_]], [[I_0_]] : i32
 // CHECK:             [[VAR_2_:%.+]] = arith.index_cast [[VAR_1_]] : i32 to index
 // CHECK:             [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_2_]]{{.}}, sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
-// CHECK:             affine.store [[VAR_0_]], [[VAR_reinterpret_cast_]][0] : memref<1xf32, strided<[1], offset: ?>>
+// CHECK:             memref.store [[VAR_0_]], [[VAR_reinterpret_cast_]][%[[C0]]] : memref<1xf32, strided<[1], offset: ?>>
 // CHECK:           }
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/TritonToLinalg/addptr_scalar_loopback.mlir
+++ b/test/Conversion/TritonToLinalg/addptr_scalar_loopback.mlir
@@ -16,12 +16,13 @@ module {
 
 // CHECK: module {
 // CHECK:   func.func @kernel(%arg0: memref<*xbf16>, %arg1: memref<*xbf16>, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32, %arg6: i32, %arg7: i32, %arg8: i32) {
+// CHECK-DAG:      %[[C0:.*]] = arith.constant 0 : index
 // CHECK:     %0 = arith.index_cast %arg2 : i32 to index
 // CHECK:     %reinterpret_cast = memref.reinterpret_cast %arg0 to offset: [%0], sizes: [1], strides: [1] : memref<*xbf16> to memref<1xbf16, strided<[1], offset: ?>>
 // CHECK:     %1 = arith.index_cast %arg2 : i32 to index
 // CHECK:     %reinterpret_cast_0 = memref.reinterpret_cast %arg1 to offset: [%1], sizes: [1], strides: [1] : memref<*xbf16> to memref<1xbf16, strided<[1], offset: ?>>
-// CHECK:     %2 = affine.load %reinterpret_cast[0] : memref<1xbf16, strided<[1], offset: ?>>
-// CHECK:     affine.store %2, %reinterpret_cast_0[0] : memref<1xbf16, strided<[1], offset: ?>>
+// CHECK:     %2 = memref.load %reinterpret_cast[%[[C0]]] : memref<1xbf16, strided<[1], offset: ?>>
+// CHECK:     memref.store %2, %reinterpret_cast_0[%[[C0]]] : memref<1xbf16, strided<[1], offset: ?>>
 // CHECK:     return
 // CHECK:   }
 // CHECK: }

--- a/test/Conversion/TritonToLinalg/convert_addi_reduce.mlir
+++ b/test/Conversion/TritonToLinalg/convert_addi_reduce.mlir
@@ -15,6 +15,7 @@ module {
 
 // CHECK-LABEL:   func.func @addi(
 // CHECK-SAME:              %[[VAL_0:.*]]: memref<*xi32>, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: i32, %[[VAL_5:.*]]: i32, %[[VAL_6:.*]]: i32) {
+// CHECK-DAG:      %[[C0:.*]] = arith.constant 0 : index
 // CHECK:           %[[VAL_7:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_8:.*]] = tensor.empty() : tensor<4096xi32>
 // CHECK:           %[[VAL_9:.*]] = linalg.fill ins(%[[VAL_7]] : i32) outs(%[[VAL_8]] : tensor<4096xi32>) -> tensor<4096xi32>
@@ -27,6 +28,6 @@ module {
 // CHECK:             }
 // CHECK:           %[[VAL_16:.*]] = tensor.extract %[[VAL_12]][] : tensor<i32>
 // CHECK:           %[[VAL_17:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: [0], sizes: [1], strides: [1] : memref<*xi32> to memref<1xi32, strided<[1]>>
-// CHECK:           affine.store %[[VAL_16]], %[[VAL_17]][0] : memref<1xi32, strided<[1]>>
+// CHECK:           memref.store %[[VAL_16]], %[[VAL_17]][%[[C0]]] : memref<1xi32, strided<[1]>>
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/TritonToLinalg/convert_argmin_argmax.mlir
+++ b/test/Conversion/TritonToLinalg/convert_argmin_argmax.mlir
@@ -30,6 +30,7 @@ module {
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
 // CHECK-LABEL:  func.func @argmax_012
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xi32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:      %[[C0:.*]] = arith.constant 0 : index
 // CHECK-DAG:       [[CST_minus_1_:%.+]] = arith.constant -1 : i32
 // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0xFF800000 : f32
 // CHECK-DAG:       [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[PARAM_2_]] : i32
@@ -65,7 +66,7 @@ module {
 // CHECK-DAG:       [[VAR_extracted_:%.+]] = tensor.extract [[VAR_reduced_]]#1[] : tensor<i32>
 // CHECK-DAG:       [[VAR_9_:%.+]] = arith.index_cast [[PARAM_6_]] : i32 to index
 // CHECK:           [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_9_]]{{.}}, sizes: [1], strides: [1] : memref<*xi32> to memref<1xi32, strided<[1], offset: ?>>
-// CHECK:           affine.store [[VAR_extracted_]], [[VAR_reinterpret_cast_0_]][0] : memref<1xi32, strided<[1], offset: ?>>
+// CHECK:           memref.store [[VAR_extracted_]], [[VAR_reinterpret_cast_0_]][%[[C0]]] : memref<1xi32, strided<[1], offset: ?>>
 // CHECK:           return
 // CHECK:         }
 
@@ -101,6 +102,7 @@ module {
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
 // CHECK-LABEL:  func.func @argmin_012
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xi32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:      %[[C0:.*]] = arith.constant 0 : index
 // CHECK-DAG:       [[CST_minus_1_:%.+]] = arith.constant -1 : i32
 // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0x7F800000 : f32
 // CHECK-DAG:       [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[PARAM_2_]] : i32
@@ -136,6 +138,6 @@ module {
 // CHECK-DAG:       [[VAR_extracted_:%.+]] = tensor.extract [[VAR_reduced_]]#1[] : tensor<i32>
 // CHECK-DAG:       [[VAR_9_:%.+]] = arith.index_cast [[PARAM_6_]] : i32 to index
 // CHECK:           [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_9_]]{{.}}, sizes: [1], strides: [1] : memref<*xi32> to memref<1xi32, strided<[1], offset: ?>>
-// CHECK:           affine.store [[VAR_extracted_]], [[VAR_reinterpret_cast_0_]][0] : memref<1xi32, strided<[1], offset: ?>>
+// CHECK:           memref.store [[VAR_extracted_]], [[VAR_reinterpret_cast_0_]][%[[C0]]] : memref<1xi32, strided<[1], offset: ?>>
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/TritonToLinalg/convert_minmax_fp_reduce.mlir
+++ b/test/Conversion/TritonToLinalg/convert_minmax_fp_reduce.mlir
@@ -15,6 +15,7 @@ module {
 
 // CHECK-LABEL:   func.func @maxnumf(
 // CHECK-SAME:       %arg0: memref<*xf32>, %[[ARG_1:.*]]: i32, %[[ARG_2:.*]]: i32, %[[ARG_3:.*]]: i32, %[[ARG_4:.*]]: i32, %[[ARG_5:.*]]: i32, %[[ARG_6:.*]]: i32)
+// CHECK-DAG:      %[[C0:.*]] = arith.constant 0 : index
 // CHECK:  %[[CST:.*]] = arith.constant 0xFF800000 : f32
 // CHECK:  %[[CST_0:.*]] = arith.constant 0.000000e+00 : f32
 // CHECK:  %[[VAL_0:.*]] = tensor.empty() : tensor<4096xf32>
@@ -28,7 +29,7 @@ module {
 // CHECK:    }
 // CHECK:  %[[VAL_6:.*]] = tensor.extract %[[VAL_4]][] : tensor<f32>
 // CHECK:  %[[VAL_7:.*]] = memref.[[VAL_7]] %arg0 to offset: [0], sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1]>>
-// CHECK:  affine.store %[[VAL_6]], %[[VAL_7]][0] : memref<1xf32, strided<[1]>>
+// CHECK:  memref.store %[[VAL_6]], %[[VAL_7]][%[[C0]]] : memref<1xf32, strided<[1]>>
 // CHECK:  return
 // CHECK:}
 
@@ -50,6 +51,7 @@ module {
 
 // CHECK-LABEL:   func.func @minnumf(
 // CHECK-SAME:       %arg0: memref<*xf32>, %[[ARG_1:.*]]: i32, %[[ARG_2:.*]]: i32, %[[ARG_3:.*]]: i32, %[[ARG_4:.*]]: i32, %[[ARG_5:.*]]: i32, %[[ARG_6:.*]]: i32)
+// CHECK-DAG:      %[[C0:.*]] = arith.constant 0 : index
 // CHECK:  %[[CST:.*]] = arith.constant 0x7F800000 : f32
 // CHECK:  %[[CST_0:.*]] = arith.constant 0.000000e+00 : f32
 // CHECK:  %[[VAL_0:.*]] = tensor.empty() : tensor<4096xf32>
@@ -63,6 +65,6 @@ module {
 // CHECK:    }
 // CHECK:  %[[VAL_6:.*]] = tensor.extract %[[VAL_4]][] : tensor<f32>
 // CHECK:  %[[VAL_7:.*]] = memref.[[VAL_7]] %arg0 to offset: [0], sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1]>>
-// CHECK:  affine.store %[[VAL_6]], %[[VAL_7]][0] : memref<1xf32, strided<[1]>>
+// CHECK:  memref.store %[[VAL_6]], %[[VAL_7]][%[[C0]]] : memref<1xf32, strided<[1]>>
 // CHECK:  return
 // CHECK:}

--- a/test/Conversion/TritonToLinalg/convert_minmax_reduce.mlir
+++ b/test/Conversion/TritonToLinalg/convert_minmax_reduce.mlir
@@ -14,6 +14,7 @@ module {
 }
 
 // CHECK:  func.func @minmax_sgt(%[[VAL_0:.*]]: memref<*xi32>, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: i32, %[[VAL_5:.*]]: i32, %[[VAL_6:.*]]: i32) {
+// CHECK-DAG:      %[[C0:.*]] = arith.constant 0 : index
 // CHECK:    %[[VAL_7:.*]] = tensor.empty() : tensor<4096xi32>
 // CHECK:    %[[VAL_8:.*]] = linalg.fill ins(%c0{{.*}} : i32) outs(%[[VAL_7]] : tensor<4096xi32>) -> tensor<4096xi32>
 // CHECK:    %[[VAL_9:.*]] = bufferization.alloc_tensor() : tensor<i32>
@@ -25,7 +26,7 @@ module {
 // CHECK:      }
 // CHECK:    %[[VAL_12:.*]] = tensor.extract %[[VAL_11]][] : tensor<i32>
 // CHECK:    %[[VAL_13:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: [0], sizes: [1], strides: [1] : memref<*xi32> to memref<1xi32, strided<[1]>>
-// CHECK:    affine.store %[[VAL_12]], %[[VAL_13]][0] : memref<1xi32, strided<[1]>>
+// CHECK:    memref.store %[[VAL_12]], %[[VAL_13]][%[[C0]]] : memref<1xi32, strided<[1]>>
 // CHECK:    return
 // CHECK:  }
 
@@ -46,6 +47,7 @@ module {
 }
 
 // CHECK:  func.func @minmax_ugt(%[[VAL_0:.*]]: memref<*xi32>, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: i32, %[[VAL_5:.*]]: i32, %[[VAL_6:.*]]: i32) {
+// CHECK-DAG:      %[[C0:.*]] = arith.constant 0 : index
 // CHECK:    %[[VAL_7:.*]] = tensor.empty() : tensor<4096xi32>
 // CHECK:    %[[VAL_8:.*]] = linalg.fill ins(%c0{{.*}} : i32) outs(%[[VAL_7]] : tensor<4096xi32>) -> tensor<4096xi32>
 // CHECK:    %[[VAL_9:.*]] = bufferization.alloc_tensor() : tensor<i32>
@@ -57,7 +59,7 @@ module {
 // CHECK:      }
 // CHECK:    %[[VAL_12:.*]] = tensor.extract %[[VAL_11]][] : tensor<i32>
 // CHECK:    %[[VAL_13:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: [0], sizes: [1], strides: [1] : memref<*xi32> to memref<1xi32, strided<[1]>>
-// CHECK:    affine.store %[[VAL_12]], %[[VAL_13]][0] : memref<1xi32, strided<[1]>>
+// CHECK:    memref.store %[[VAL_12]], %[[VAL_13]][%[[C0]]] : memref<1xi32, strided<[1]>>
 // CHECK:    return
 // CHECK:  }
 
@@ -78,6 +80,7 @@ module {
 }
 
 // CHECK:  func.func @minmax_slt(%[[VAL_0:.*]]: memref<*xi32>, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: i32, %[[VAL_5:.*]]: i32, %[[VAL_6:.*]]: i32) {
+// CHECK-DAG:      %[[C0:.*]] = arith.constant 0 : index
 // CHECK:    %[[VAL_7:.*]] = tensor.empty() : tensor<4096xi32>
 // CHECK:    %[[VAL_8:.*]] = linalg.fill ins(%c0{{.*}} : i32) outs(%[[VAL_7]] : tensor<4096xi32>) -> tensor<4096xi32>
 // CHECK:    %[[VAL_9:.*]] = bufferization.alloc_tensor() : tensor<i32>
@@ -89,7 +92,7 @@ module {
 // CHECK:      }
 // CHECK:    %[[VAL_12:.*]] = tensor.extract %[[VAL_11]][] : tensor<i32>
 // CHECK:    %[[VAL_13:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: [0], sizes: [1], strides: [1] : memref<*xi32> to memref<1xi32, strided<[1]>>
-// CHECK:    affine.store %[[VAL_12]], %[[VAL_13]][0] : memref<1xi32, strided<[1]>>
+// CHECK:    memref.store %[[VAL_12]], %[[VAL_13]][%[[C0]]] : memref<1xi32, strided<[1]>>
 // CHECK:    return
 // CHECK:  }
 
@@ -110,6 +113,7 @@ module {
 }
 
 // CHECK:  func.func @minmax_ult(%[[VAL_0:.*]]: memref<*xi32>, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: i32, %[[VAL_5:.*]]: i32, %[[VAL_6:.*]]: i32) {
+// CHECK-DAG:      %[[C0:.*]] = arith.constant 0 : index
 // CHECK:    %[[VAL_7:.*]] = tensor.empty() : tensor<4096xi32>
 // CHECK:    %[[VAL_8:.*]] = linalg.fill ins(%c0{{.*}} : i32) outs(%[[VAL_7]] : tensor<4096xi32>) -> tensor<4096xi32>
 // CHECK:    %[[VAL_9:.*]] = bufferization.alloc_tensor() : tensor<i32>
@@ -121,6 +125,6 @@ module {
 // CHECK:      }
 // CHECK:    %[[VAL_12:.*]] = tensor.extract %[[VAL_11]][] : tensor<i32>
 // CHECK:    %[[VAL_13:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: [0], sizes: [1], strides: [1] : memref<*xi32> to memref<1xi32, strided<[1]>>
-// CHECK:    affine.store %[[VAL_12]], %[[VAL_13]][0] : memref<1xi32, strided<[1]>>
+// CHECK:    memref.store %[[VAL_12]], %[[VAL_13]][%[[C0]]] : memref<1xi32, strided<[1]>>
 // CHECK:    return
 // CHECK:  }

--- a/test/Conversion/TritonToLinalg/reducesum_scalar.mlir
+++ b/test/Conversion/TritonToLinalg/reducesum_scalar.mlir
@@ -17,6 +17,7 @@ module {
 }
 // CHECK-LABEL:   func.func @kernel(
 // CHECK-SAME:                      %[[VAL_0:.*]]: memref<*xbf16>, %[[VAL_1:.*]]: memref<*xbf16>, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: i32) {
+// CHECK-DAG:      %[[C0:.*]] = arith.constant 0 : index
 // CHECK:           %[[VAL_5:.*]] = arith.constant 0.000000e+00 : f32
 // CHECK:           %[[VAL_6:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: [0], sizes: [128], strides: [1] : memref<*xbf16> to memref<128xbf16, strided<[1]>>
 // CHECK:           %[[VAL_7:.*]] = memref.alloc() : memref<128xbf16>
@@ -33,6 +34,6 @@ module {
 // CHECK:           %[[VAL_16:.*]] = tensor.extract %[[VAL_11]][] : tensor<f32>
 // CHECK:           %[[VAL_17:.*]] = arith.truncf %[[VAL_16]] : f32 to bf16
 // CHECK:           %[[VAL_18:.*]] = memref.reinterpret_cast %[[VAL_1]] to offset: [0], sizes: [1], strides: [1] : memref<*xbf16> to memref<1xbf16, strided<[1]>>
-// CHECK:           affine.store %[[VAL_17]], %[[VAL_18]][0] : memref<1xbf16, strided<[1]>>
+// CHECK:           memref.store %[[VAL_17]], %[[VAL_18]][%[[C0]]] : memref<1xbf16, strided<[1]>>
 // CHECK:           return
 // CHECK:         }


### PR DESCRIPTION
Currently, scalar load/store operations are lowered to affine.load/store and memref.load/store in different places.

This change aims to consolidate these operations into memref.load/store to improve consistency.