### PR TITLE
Add option to control Gather/Scatter support

### DIFF
--- a/include/triton-shared/AnalysisStructured/PtrAnalysis.h
+++ b/include/triton-shared/AnalysisStructured/PtrAnalysis.h
@@ -144,7 +144,7 @@ class PtrAnalysis {
       llvm::function_ref<Value(scf::ForOp op, size_t)> getReplacementVal);
 
   DenseSet<Value> maybeStructuredArgs;
-  bool enableMakeGatherScatterTensorPtr;
+  const bool enableMakeGatherScatterTensorPtr;
 
 public:
   PtrAnalysis(bool enableMakeGatherScatterTensorPtr)

--- a/include/triton-shared/AnalysisStructured/PtrAnalysis.h
+++ b/include/triton-shared/AnalysisStructured/PtrAnalysis.h
@@ -144,8 +144,11 @@ class PtrAnalysis {
       llvm::function_ref<Value(scf::ForOp op, size_t)> getReplacementVal);
 
   DenseSet<Value> maybeStructuredArgs;
+  bool enableMakeGatherScatterTensorPtr;
 
 public:
+  PtrAnalysis(bool enableMakeGatherScatterTensorPtr)
+      : enableMakeGatherScatterTensorPtr(enableMakeGatherScatterTensorPtr) {}
   void initializeMaybeStructuredArgs(Operation *op);
 
   llvm::SmallDenseMap<Value, PtrState> knownPtrs;

--- a/include/triton-shared/Conversion/TritonToLinalgExperimental/Passes.td
+++ b/include/triton-shared/Conversion/TritonToLinalgExperimental/Passes.td
@@ -13,6 +13,10 @@ include "mlir/Pass/PassBase.td"
 def TritonToLinalgExperimental : Pass<"triton-to-linalg-experimental", "mlir::ModuleOp"> {
   let summary = "Convert Triton to Linalg dialect";
   let constructor = "triton::createTritonToLinalgExperimentalPass()";
+  let options = [
+      Option<"enableMakeGatherScatterTensorPtr", "enable-make-gather-scatter", "bool", /*default*/"true",
+             "Enable make_gather_scatter_tptr support">
+  ];
 }
 
 def ReconcilePtrCasts : Pass<"reconcile-ptr-casts", "mlir::ModuleOp"> {

--- a/include/triton-shared/Conversion/TritonToStructured/Passes.td
+++ b/include/triton-shared/Conversion/TritonToStructured/Passes.td
@@ -7,6 +7,8 @@ def TritonToStructured : Pass<"triton-to-structured", "mlir::ModuleOp"> {
   let summary = "Convert Triton non-block pointer to TritonStructured dialect";
   let constructor = "triton::createTritonToStructuredPass()";
   let options = [
+      Option<"enableMakeGatherScatterTensorPtr", "enable-make-gather-scatter", "bool", /*default*/"true",
+             "Enable make_gather_scatter_tptr support">,
       Option<"runPrepassOnly", "run-prepass-only", "bool", /*default*/"false",
              "Only run the pre-processing pass which inserts tts.get_structured_state ops used in scf.for">,
       Option<"skipPrepass", "skip-prepass", "bool", /*default*/"false",

--- a/include/triton-shared/Conversion/TritonToStructured/TritonToStructured.h
+++ b/include/triton-shared/Conversion/TritonToStructured/TritonToStructured.h
@@ -9,7 +9,11 @@
 namespace mlir {
 namespace triton {
 
-std::unique_ptr<OperationPass<ModuleOp>> createTritonToStructuredPass();
+#define GEN_PASS_DECL_TRITONTOSTRUCTURED
+#include "triton-shared/Conversion/TritonToStructured/Passes.h.inc"
+
+std::unique_ptr<OperationPass<ModuleOp>>
+createTritonToStructuredPass(bool enableMakeGatherScatterTensorPtr = true);
 
 } // namespace triton
 } // namespace mlir

--- a/lib/AnalysisStructured/PtrAnalysis.cpp
+++ b/lib/AnalysisStructured/PtrAnalysis.cpp
@@ -1026,8 +1026,11 @@ LogicalResult PtrAnalysis::rewriteAddptrOp(triton::AddPtrOp op) {
       // continuous dimensions.
       if (state.getRank() == 1)
         return failure();
-      auto maketptrOp = state.createTTSMakeGatherScatterTensorPtrOp(builder, op.getLoc());
-      ptrMap.map(op.getResult(), maketptrOp.getResult());
+      if (enableMakeGatherScatterTensorPtr) {
+        auto maketptrOp =
+            state.createTTSMakeGatherScatterTensorPtrOp(builder, op.getLoc());
+        ptrMap.map(op.getResult(), maketptrOp.getResult());
+      }
     }
   } else {
     // record the ptr as we have visited and built up the state for this scalar

--- a/lib/AnalysisStructured/PtrAnalysis.cpp
+++ b/lib/AnalysisStructured/PtrAnalysis.cpp
@@ -506,10 +506,18 @@ LogicalResult PtrAnalysis::visitOperandAdd(arith::AddIOp addOp, PtrState &state,
   // Need to clear the modulo and use the operand as offset directly.
   if (!lhsState.isStructured() && rhsState.hasModulo()) {
     // TODO: support modulo in this case.
-    if (rhsState.rebuildAsGatherScatter(addOp.getRhs(), lhsState.getNonStructuredDim()).failed())
+    if (!enableMakeGatherScatterTensorPtr ||
+        rhsState
+            .rebuildAsGatherScatter(addOp.getRhs(),
+                                    lhsState.getNonStructuredDim())
+            .failed())
       return failure();
   } else if (lhsState.hasModulo() && !rhsState.isStructured()) {
-    if (lhsState.rebuildAsGatherScatter(addOp.getLhs(), rhsState.getNonStructuredDim()).failed())
+    if (!enableMakeGatherScatterTensorPtr ||
+        lhsState
+            .rebuildAsGatherScatter(addOp.getLhs(),
+                                    rhsState.getNonStructuredDim())
+            .failed())
       return failure();
   }
 
@@ -533,13 +541,15 @@ LogicalResult PtrAnalysis::visitOperandMul(arith::MulIOp mulOp, PtrState &state,
   // Need to clear the modulo and use the operand as offset directly.
   if (!lhsState.isStructured() && rhsState.hasModulo()) {
     // TODO: support modulo in this case.
-    if (rhsState
+    if (!enableMakeGatherScatterTensorPtr ||
+        rhsState
             .rebuildAsGatherScatter(mulOp.getRhs(),
                                     lhsState.getNonStructuredDim())
             .failed())
       return failure();
   } else if (lhsState.hasModulo() && !rhsState.isStructured()) {
-    if (lhsState
+    if (!enableMakeGatherScatterTensorPtr ||
+        lhsState
             .rebuildAsGatherScatter(mulOp.getLhs(),
                                     rhsState.getNonStructuredDim())
             .failed())
@@ -581,7 +591,7 @@ LogicalResult PtrAnalysis::visitOperandRem(arith::RemSIOp remOp,
   if (state.hasModulo()) {
     remOp->emitRemark(
         "PtrAnalysis: do not support multiple modulo within an expression");
-    if (state.getRank() == 1)
+    if (state.getRank() == 1 && enableMakeGatherScatterTensorPtr)
       // Build the state from the current operation as an unstructured state,
       // but only when there is a single dimension involved.
       return state.rebuildAsGatherScatter(remOp.getResult(), 0);
@@ -1003,6 +1013,8 @@ LogicalResult PtrAnalysis::visitOperand(Value operand, PtrState &state,
                     "unsupported operation\n";
     operand.dump();
 
+    if (!enableMakeGatherScatterTensorPtr)
+      return failure();
     return state.rebuildAsUnsupportedOp(operand);
   }
 }

--- a/lib/AnalysisStructured/PtrAnalysis.cpp
+++ b/lib/AnalysisStructured/PtrAnalysis.cpp
@@ -1021,16 +1021,16 @@ LogicalResult PtrAnalysis::rewriteAddptrOp(triton::AddPtrOp op) {
     if (state.isStructured()) {
       auto maketptrOp = state.createTTSMakeTensorPtrOp(builder, op.getLoc());
       ptrMap.map(op.getResult(), maketptrOp.getResult());
-    } else {
+    } else if (enableMakeGatherScatterTensorPtr) {
       // If there is only one dimension, return failure since there are no
       // continuous dimensions.
       if (state.getRank() == 1)
         return failure();
-      if (enableMakeGatherScatterTensorPtr) {
-        auto maketptrOp =
-            state.createTTSMakeGatherScatterTensorPtrOp(builder, op.getLoc());
-        ptrMap.map(op.getResult(), maketptrOp.getResult());
-      }
+      auto maketptrOp =
+          state.createTTSMakeGatherScatterTensorPtrOp(builder, op.getLoc());
+      ptrMap.map(op.getResult(), maketptrOp.getResult());
+    } else {
+      return failure();
     }
   } else {
     // record the ptr as we have visited and built up the state for this scalar

--- a/lib/Conversion/TritonToLinalgExperimental/TritonToLinalgExperimentalPass.cpp
+++ b/lib/Conversion/TritonToLinalgExperimental/TritonToLinalgExperimentalPass.cpp
@@ -51,7 +51,7 @@ public:
   void runOnOperation() override {
     auto moduleOp = getOperation();
     PassManager pm(&getContext(), moduleOp.getOperationName());
-    pm.addPass(createTritonToStructuredPass());
+    pm.addPass(createTritonToStructuredPass(enableMakeGatherScatterTensorPtr));
 
     // Erase dead code and fold constants created during lowering
     pm.addPass(createCSEPass());

--- a/lib/Conversion/TritonToStructured/TritonToStructuredPass.cpp
+++ b/lib/Conversion/TritonToStructured/TritonToStructuredPass.cpp
@@ -46,11 +46,18 @@ using namespace triton;
 #define GEN_PASS_CLASSES
 #include "triton-shared/Conversion/TritonToStructured/Passes.h.inc"
 
+namespace mlir {
+  namespace triton {
+  #define GEN_PASS_DEF_TRITONTOSTRUCTURED
+    #include "triton-shared/Conversion/TritonToStructured/Passes.h.inc"
+  } // namespace triton
+} // namespace mlir
+
 namespace {
 
 class TritonToStructuredPass
-    : public TritonToStructuredBase<TritonToStructuredPass> {
-
+    : public triton::impl::TritonToStructuredBase<TritonToStructuredPass> {
+  using TritonToStructuredBase<TritonToStructuredPass>::TritonToStructuredBase;
   static TupleType getStructuredStateTupleType(MLIRContext *context, Type t) {
     SmallVector<Type> tupleTypes{t};
     auto [offsetTypes, strideTypes] =
@@ -335,6 +342,8 @@ public:
 } // namespace
 
 std::unique_ptr<OperationPass<ModuleOp>>
-triton::createTritonToStructuredPass() {
-  return std::make_unique<TritonToStructuredPass>();
+triton::createTritonToStructuredPass(bool enableMakeGatherScatterTensorPtr) {
+  TritonToStructuredOptions options;
+  options.enableMakeGatherScatterTensorPtr = enableMakeGatherScatterTensorPtr;
+  return std::make_unique<TritonToStructuredPass>(options);
 }

--- a/lib/Conversion/TritonToStructured/TritonToStructuredPass.cpp
+++ b/lib/Conversion/TritonToStructured/TritonToStructuredPass.cpp
@@ -316,7 +316,7 @@ public:
     }
 
     auto moduleOp = getOperation();
-    mlir::tts::PtrAnalysis ptrAnalysis;
+    mlir::tts::PtrAnalysis ptrAnalysis(enableMakeGatherScatterTensorPtr);
     ptrAnalysis.initializeMaybeStructuredArgs(moduleOp);
 
     if (failed(ptrAnalysis.rewriteOp(moduleOp, useUnsafeMask))) {

--- a/test/Conversion/StructuredToMemref/gather_scatter_ptr_to_linalg.mlir
+++ b/test/Conversion/StructuredToMemref/gather_scatter_ptr_to_linalg.mlir
@@ -1,5 +1,12 @@
 // RUN: triton-shared-opt --triton-to-linalg-experimental %s | FileCheck %s
 
+// RUN: triton-shared-opt --triton-to-linalg-experimental="enable-make-gather-scatter=false" %s | FileCheck %s --check-prefix=NO_GATHER
+
+// Make sure no extract_slice when enable-make-gather-scatter=false..
+// NO_GATHER-LABLE: func.func @row_gather2(
+// NO_GATHER-NOT: extract_slice
+
+
 // Make sure extract_slice is generated correctly.
 
 // CHECK: #[[$ATTR_0:.+]] = affine_map<(d0) -> (d0)>

--- a/test/Conversion/TritonToStructured/gather_scatter_ptr.mlir
+++ b/test/Conversion/TritonToStructured/gather_scatter_ptr.mlir
@@ -1,5 +1,11 @@
 // RUN: triton-shared-opt --triton-to-structured --remove-dead-values --canonicalize %s | FileCheck %s
 
+// RUN: triton-shared-opt --triton-to-structured="enable-make-gather-scatter=false" --remove-dead-values --canonicalize %s | FileCheck %s --check-prefix=NO_GATHER
+
+// Make sure no tts.make_gather_scatter_tptr generated when enable-make-gather-scatter=false.
+// NO_GATHER-LABEL:   tt.func public @row_gather2(
+// NO_GATHER-NOT:     tts.make_gather_scatter_tptr
+
 // Make sure tts.make_indirect_tptr is generated with correct indirect_dim and indirect_offset.
 
 // CHECK-LABEL:   tt.func public @row_gather2(


### PR DESCRIPTION
A new option for TritonToStructured pass was added to control gather/scatter support. 

It is enabled by default.
Use --triton-to-structured="enable-make-gather-scatter=false" to disable it.