### PR TITLE
Update triton to 7568a

### DIFF
--- a/lib/Conversion/StructuredToMemref/StructuredToMemrefPass.cpp
+++ b/lib/Conversion/StructuredToMemref/StructuredToMemrefPass.cpp
@@ -103,13 +103,6 @@ public:
       return builder.create<UnrealizedConversionCastOp>(loc, resultType, inputs)
           .getResult(0);
     });
-
-    addArgumentMaterialization([&](OpBuilder &builder, Type resultType,
-                                   ValueRange inputs,
-                                   Location loc) -> Value {
-      return builder.create<UnrealizedConversionCastOp>(loc, resultType, inputs)
-          .getResult(0);
-    });
   }
 };
 

--- a/lib/Conversion/TritonPtrToMemref/TritonPtrToMemrefPass.cpp
+++ b/lib/Conversion/TritonPtrToMemref/TritonPtrToMemrefPass.cpp
@@ -66,7 +66,6 @@ public:
           .getResult(0);
     };
     addSourceMaterialization(createUnrealizedCast);
-    addArgumentMaterialization(createUnrealizedCast);
   }
 };
 

--- a/lib/Conversion/TritonToLinalgExperimental/TritonToPtrPass.cpp
+++ b/lib/Conversion/TritonToLinalgExperimental/TritonToPtrPass.cpp
@@ -436,7 +436,6 @@ public:
     };
     addTargetMaterialization(createCast);
     addSourceMaterialization(createCast);
-    addArgumentMaterialization(createCast);
   }
 };
 

--- a/lib/Conversion/TritonToStructured/TritonToStructuredPass.cpp
+++ b/lib/Conversion/TritonToStructured/TritonToStructuredPass.cpp
@@ -192,11 +192,11 @@ public:
     // offset_0, offset_1,..., stride_0, stride_1,...} type back to the "pointer
     // tuple type".
     //
-    // Because we actually want to get rid of the tuple type, return `inputs[0]`
-    // which corresponds to a "triton pointer type". This approach will work as
-    // intended because the ops that currently take "pointer tuple type" are
-    // `unrealized_conversion_cast` ops which will get removed below during
-    // reconcile-unrealized-conversion-casts.
+    // Because we actually want to get rid of the tuple type, return a cast of
+    // `inputs[0]` which corresponds to a "triton pointer type". This approach
+    // will work as intended because the ops that currently take "pointer tuple
+    // type" are `unrealized_conversion_cast` ops which will get removed below
+    // during reconcile-unrealized-conversion-casts.
     converter.addSourceMaterialization([](OpBuilder &builder, Type resultType,
                                           ValueRange inputs, Location loc) {
       return builder

--- a/lib/Conversion/TritonToStructured/TritonToStructuredPass.cpp
+++ b/lib/Conversion/TritonToStructured/TritonToStructuredPass.cpp
@@ -226,7 +226,7 @@ public:
                                           Location loc) {
       auto placeholder = builder.create<tts::GetStructuredStateOp>(
           loc, inputs.front().getDefiningOp()->getOperand(0));
-      assert(llvm::equal(placeholder.getResultTypes(), resultTypes) && "wtf");
+      assert(llvm::equal(placeholder.getResultTypes(), resultTypes));
       return placeholder.getResults();
     });
 

--- a/lib/Dialect/TPtr/IR/TPtrDialect.cpp
+++ b/lib/Dialect/TPtr/IR/TPtrDialect.cpp
@@ -50,42 +50,42 @@ void mlir::tptr::TPtrDialect::initialize() {
       >();
 }
 
-LogicalResult tptr::DefaultMemorySpaceAttr::isValidLoad(
+bool tptr::DefaultMemorySpaceAttr::isValidLoad(
     Type type, mlir::ptr::AtomicOrdering ordering, IntegerAttr alignment,
     llvm::function_ref<InFlightDiagnostic()> emitError) const {
-  return success();
+  return true;
 }
 
-LogicalResult tptr::DefaultMemorySpaceAttr::isValidStore(
+bool tptr::DefaultMemorySpaceAttr::isValidStore(
     Type type, mlir::ptr::AtomicOrdering ordering, IntegerAttr alignment,
     llvm::function_ref<InFlightDiagnostic()> emitError) const {
-  return success();
+  return true;
 }
 
-LogicalResult tptr::DefaultMemorySpaceAttr::isValidAtomicOp(
+bool tptr::DefaultMemorySpaceAttr::isValidAtomicOp(
     mlir::ptr::AtomicBinOp binOp, Type type, mlir::ptr::AtomicOrdering ordering,
     IntegerAttr alignment,
     llvm::function_ref<InFlightDiagnostic()> emitError) const {
-  return success();
+  return true;
 }
 
-LogicalResult tptr::DefaultMemorySpaceAttr::isValidAtomicXchg(
+bool tptr::DefaultMemorySpaceAttr::isValidAtomicXchg(
     Type type, mlir::ptr::AtomicOrdering successOrdering,
     mlir::ptr::AtomicOrdering failureOrdering, IntegerAttr alignment,
     llvm::function_ref<InFlightDiagnostic()> emitError) const {
-  return success();
+  return true;
 }
 
-LogicalResult tptr::DefaultMemorySpaceAttr::isValidAddrSpaceCast(
+bool tptr::DefaultMemorySpaceAttr::isValidAddrSpaceCast(
     Type tgt, Type src,
     llvm::function_ref<InFlightDiagnostic()> emitError) const {
-  return success();
+  return true;
 }
 
-LogicalResult tptr::DefaultMemorySpaceAttr::isValidPtrIntCast(
+bool tptr::DefaultMemorySpaceAttr::isValidPtrIntCast(
     Type intLikeTy, Type ptrLikeTy,
     llvm::function_ref<InFlightDiagnostic()> emitError) const {
-  return success();
+  return true;
 }
 //===----------------------------------------------------------------------===//
 // TableGen'd op method definitions

--- a/test/Conversion/StructuredToMemref/tensor_indices_loop_iterargs_nested.mlir
+++ b/test/Conversion/StructuredToMemref/tensor_indices_loop_iterargs_nested.mlir
@@ -42,13 +42,13 @@ module {
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
 // CHECK-LABEL:  func.func @tensor_indices_nested
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32) {
-// CHECK-DAG:       [[CST_2_:%.+]] = arith.constant 2 : i32
 // CHECK-DAG:       [[CST_4_:%.+]] = arith.constant 4 : i32
 // CHECK-DAG:       [[CST_3_:%.+]] = arith.constant 3 : i32
-// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : i32
 // CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : i32
-// CHECK-DAG:       [[CST_0_1_:%.+]] = arith.constant 0 : index
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
 // CHECK-DAG:       [[CST_4_1_:%.+]] = arith.constant 4 : index
+// CHECK-DAG:       [[CST_0_1_:%.+]] = arith.constant 0 : i32
+// CHECK-DAG:       [[CST_2_:%.+]] = arith.constant 2 : i32
 // CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<4xi32>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_1_:%.+]] = linalg.fill ins([[CST_4_]] : i32) outs([[VAR_0_]] : tensor<4xi32>) -> tensor<4xi32>
@@ -58,7 +58,7 @@ module {
 // CHECK:             [[VAR_5_:%.+]] = arith.index_cast [[VAR_4_]] : index to i32
 // CHECK:             linalg.yield [[VAR_5_]] : i32
 // CHECK:           } -> tensor<4xi32>
-// CHECK-DAG:       [[VAR_3_:%.+]]:4 = scf.for [[VAR_arg8_:%.+]] = [[CST_0_]] to [[CST_2_]] step [[CST_1_]] iter_args([[VAR_arg9_:%.+]] = [[VAR_2_]], [[VAR_arg10_:%.+]] = [[CST_0_1_]], [[VAR_arg11_:%.+]] = [[VAR_2_]], [[VAR_arg12_:%.+]] = [[CST_0_1_]]) -> (tensor<4xi32>, index, tensor<4xi32>, index)  : i32 {
+// CHECK-DAG:       [[VAR_3_:%.+]]:4 = scf.for [[VAR_arg8_:%.+]] = [[CST_0_1_]] to [[CST_2_]] step [[CST_1_]] iter_args([[VAR_arg9_:%.+]] = [[VAR_2_]], [[VAR_arg10_:%.+]] = [[CST_0_]], [[VAR_arg11_:%.+]] = [[VAR_2_]], [[VAR_arg12_:%.+]] = [[CST_0_]]) -> (tensor<4xi32>, index, tensor<4xi32>, index)  : i32 {
 // CHECK-DAG:         [[VAR_4_1_:%.+]] = arith.muli [[VAR_arg8_]], [[CST_2_]] : i32
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:         [[VAR_5_1_:%.+]] = arith.index_cast [[VAR_4_1_]] : i32 to index
@@ -72,7 +72,7 @@ module {
 // CHECK-DAG:         [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_8_]]{{.}}, sizes: [4], strides: [1] : memref<*xf32> to memref<4xf32, strided<[1], offset: ?>>
 // CHECK-DAG:         [[RES_:%.+]] = memref.alloc() : memref<4xf32>
 // CHECK:             memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<4xf32, strided<[1], offset: ?>> to memref<4xf32>
-// CHECK-DAG:         [[VAR_9_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<4xf32>
+// CHECK-DAG:         [[VAR_9_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<4xf32> to tensor<4xf32>
 // CHECK-DAG:         [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_arg12_]]{{.}}, sizes: [4], strides: [1] : memref<*xf32> to memref<4xf32, strided<[1], offset: ?>>
 // CHECK:             bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_0_]] : (tensor<4xf32>, memref<4xf32, strided<[1], offset: ?>>) -> ()
 // CHECK:             [[VAR_10_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_7_]], [[VAR_1_]] : tensor<4xi32>, tensor<4xi32>) outs([[VAR_7_]] : tensor<4xi32>) {
@@ -80,15 +80,14 @@ module {
 // CHECK:               [[VAR_15_1_:%.+]] = arith.addi [[IN_4_]], [[IN_5_]] : i32
 // CHECK:               linalg.yield [[VAR_15_1_]] : i32
 // CHECK:             } -> tensor<4xi32>
-// CHECK:             [[VAR_11_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_arg11_]], [[VAR_1_]] : tensor<4xi32>, tensor<4xi32>) outs([[VAR_arg11_]] : tensor<4xi32>) {
+// CHECK-DAG:         [[VAR_11_:%.+]] = arith.addi [[VAR_8_]], [[CST_4_1_]] : index
+// CHECK-DAG:         [[VAR_12_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_arg11_]], [[VAR_1_]] : tensor<4xi32>, tensor<4xi32>) outs([[VAR_arg11_]] : tensor<4xi32>) {
 // CHECK:             ^bb0([[IN_7_:%.+]]: i32, [[IN_8_:%.+]]: i32, [[IN_9_:%.+]]: i32):
 // CHECK:               [[VAR_15_2_:%.+]] = arith.addi [[IN_7_]], [[IN_8_]] : i32
 // CHECK:               linalg.yield [[VAR_15_2_]] : i32
 // CHECK:             } -> tensor<4xi32>
-// CHECK-DAG:         [[VAR_12_:%.+]] = arith.addi [[VAR_8_]], [[CST_4_1_]] : index
-// CHECK-DAG:         [[VAR_13_:%.+]] = arith.addi [[VAR_arg12_]], [[CST_4_1_]] : index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_14_:%.+]]:4 = scf.for [[VAR_arg13_:%.+]] = [[CST_0_]] to [[CST_3_]] step [[CST_1_]] iter_args([[VAR_arg14_:%.+]] = [[VAR_10_]], [[VAR_arg15_:%.+]] = [[VAR_12_]], [[VAR_arg16_:%.+]] = [[VAR_11_]], [[VAR_arg17_:%.+]] = [[VAR_13_]]) -> (tensor<4xi32>, index, tensor<4xi32>, index)  : i32 {
+// CHECK:             [[VAR_13_:%.+]] = arith.addi [[VAR_arg12_]], [[CST_4_1_]] : index
+// CHECK-DAG:         [[VAR_14_:%.+]]:4 = scf.for [[VAR_arg13_:%.+]] = [[CST_0_1_]] to [[CST_3_]] step [[CST_1_]] iter_args([[VAR_arg14_:%.+]] = [[VAR_10_]], [[VAR_arg15_:%.+]] = [[VAR_11_]], [[VAR_arg16_:%.+]] = [[VAR_12_]], [[VAR_arg17_:%.+]] = [[VAR_13_]]) -> (tensor<4xi32>, index, tensor<4xi32>, index)  : i32 {
 // CHECK-DAG:           [[VAR_15_3_:%.+]] = arith.muli [[VAR_arg13_]], [[CST_3_]] : i32
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:           [[VAR_16_:%.+]] = arith.index_cast [[VAR_15_3_]] : i32 to index
@@ -102,7 +101,7 @@ module {
 // CHECK-DAG:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_19_]]{{.}}, sizes: [4], strides: [1] : memref<*xf32> to memref<4xf32, strided<[1], offset: ?>>
 // CHECK-DAG:           [[RES_1_:%.+]] = memref.alloc() : memref<4xf32>
 // CHECK:               memref.copy [[VAR_reinterpret_cast_1_]], [[RES_1_]] : memref<4xf32, strided<[1], offset: ?>> to memref<4xf32>
-// CHECK-DAG:           [[VAR_20_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<4xf32>
+// CHECK-DAG:           [[VAR_20_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<4xf32> to tensor<4xf32>
 // CHECK-DAG:           [[VAR_reinterpret_cast_3_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_arg17_]]{{.}}, sizes: [4], strides: [1] : memref<*xf32> to memref<4xf32, strided<[1], offset: ?>>
 // CHECK:               bufferization.materialize_in_destination [[VAR_20_]] in writable [[VAR_reinterpret_cast_3_]] : (tensor<4xf32>, memref<4xf32, strided<[1], offset: ?>>) -> ()
 // CHECK:               [[VAR_21_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_18_]], [[VAR_1_]] : tensor<4xi32>, tensor<4xi32>) outs([[VAR_18_]] : tensor<4xi32>) {
@@ -110,14 +109,14 @@ module {
 // CHECK:                 [[VAR_25_1_:%.+]] = arith.addi [[IN_13_]], [[IN_14_]] : i32
 // CHECK:                 linalg.yield [[VAR_25_1_]] : i32
 // CHECK:               } -> tensor<4xi32>
-// CHECK:               [[VAR_22_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_arg16_]], [[VAR_1_]] : tensor<4xi32>, tensor<4xi32>) outs([[VAR_arg16_]] : tensor<4xi32>) {
+// CHECK-DAG:           [[VAR_22_:%.+]] = arith.addi [[VAR_19_]], [[CST_4_1_]] : index
+// CHECK-DAG:           [[VAR_23_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_arg16_]], [[VAR_1_]] : tensor<4xi32>, tensor<4xi32>) outs([[VAR_arg16_]] : tensor<4xi32>) {
 // CHECK:               ^bb0([[IN_16_:%.+]]: i32, [[IN_17_:%.+]]: i32, [[IN_18_:%.+]]: i32):
 // CHECK:                 [[VAR_25_2_:%.+]] = arith.addi [[IN_16_]], [[IN_17_]] : i32
 // CHECK:                 linalg.yield [[VAR_25_2_]] : i32
 // CHECK:               } -> tensor<4xi32>
-// CHECK-DAG:           [[VAR_23_:%.+]] = arith.addi [[VAR_19_]], [[CST_4_1_]] : index
-// CHECK-DAG:           [[VAR_24_:%.+]] = arith.addi [[VAR_arg17_]], [[CST_4_1_]] : index
-// CHECK:               scf.yield [[VAR_21_]], [[VAR_23_]], [[VAR_22_]], [[VAR_24_]] : tensor<4xi32>, index, tensor<4xi32>, index
+// CHECK:               [[VAR_24_:%.+]] = arith.addi [[VAR_arg17_]], [[CST_4_1_]] : index
+// CHECK:               scf.yield [[VAR_21_]], [[VAR_22_]], [[VAR_23_]], [[VAR_24_]] : tensor<4xi32>, index, tensor<4xi32>, index
 // CHECK:             }
 // CHECK:             scf.yield [[VAR_14_]]#0, [[VAR_14_]]#1, [[VAR_14_]]#2, [[VAR_14_]]#3 : tensor<4xi32>, index, tensor<4xi32>, index
 // CHECK:           }

--- a/test/Conversion/TritonToStructured/tensor_indices_loop_iterargs_not_used_ptranalysis_prepass.mlir
+++ b/test/Conversion/TritonToStructured/tensor_indices_loop_iterargs_not_used_ptranalysis_prepass.mlir
@@ -28,16 +28,15 @@ module {
 // CHECK-DAG:       [[VAR_cst_:%.+]] = arith.constant dense<4> : tensor<4xi32>
 // CHECK-DAG:       [[VAR_0_:%.+]] = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32>
 // CHECK-DAG:       [[VAR_1_:%.+]] = tt.splat [[arg0_]] : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
-// CHECK:           [[structured_:%.+]], [[offsets_:%.+]], [[VAR_strides_:%.+]] = "tts.get_structured_state"([[VAR_0_]]) <{resultSegmentSizes = array<i32: 1, 1, 1>}> : (tensor<4xi32>) -> (tensor<4xi32>, index, index)
-// CHECK:           [[structured_0_:%.+]], [[offsets_1_:%.+]], [[VAR_strides_2_:%.+]] = "tts.get_structured_state"([[VAR_0_]]) <{resultSegmentSizes = array<i32: 1, 1, 1>}> : (tensor<4xi32>) -> (tensor<4xi32>, index, index)
-// CHECK-DAG:       [[VAR_2_:%.+]]:6 = scf.for [[VAR_arg1_:%.+]] = [[CST_0_]] to [[CST_2_]] step [[CST_1_]] iter_args([[VAR_arg2_:%.+]] = [[structured_]], [[VAR_arg3_:%.+]] = [[offsets_]], [[VAR_arg4_:%.+]] = [[VAR_strides_]], [[VAR_arg5_:%.+]] = [[structured_0_]], [[VAR_arg6_:%.+]] = [[offsets_1_]], [[VAR_arg7_:%.+]] = [[VAR_strides_2_]]) -> (tensor<4xi32>, index, index, tensor<4xi32>, index, index)  : i32 {
+// CHECK-DAG:       [[structured_:%.+]], [[offsets_:%.+]], [[VAR_strides_:%.+]] = "tts.get_structured_state"([[VAR_0_]]) <{resultSegmentSizes = array<i32: 1, 1, 1>}> : (tensor<4xi32>) -> (tensor<4xi32>, index, index)
+// CHECK-DAG:       [[VAR_2_:%.+]]:6 = scf.for [[VAR_arg1_:%.+]] = [[CST_0_]] to [[CST_2_]] step [[CST_1_]] iter_args([[VAR_arg2_:%.+]] = [[structured_]], [[VAR_arg3_:%.+]] = [[offsets_]], [[VAR_arg4_:%.+]] = [[VAR_strides_]], [[VAR_arg5_:%.+]] = [[structured_]], [[VAR_arg6_:%.+]] = [[offsets_]], [[VAR_arg7_:%.+]] = [[VAR_strides_]]) -> (tensor<4xi32>, index, index, tensor<4xi32>, index, index)  : i32 {
 // CHECK-DAG:         [[VAR_3_:%.+]] = tt.addptr [[VAR_1_]], [[VAR_arg2_]] : tensor<4x!tt.ptr<f32>>, tensor<4xi32>
 // CHECK-DAG:         [[VAR_4_:%.+]] = arith.sitofp [[VAR_arg5_]] : tensor<4xi32> to tensor<4xf32>
 // CHECK:             tt.store [[VAR_3_]], [[VAR_4_]] : tensor<4x!tt.ptr<f32>>
 // CHECK-DAG:         [[VAR_5_:%.+]] = arith.addi [[VAR_arg2_]], [[VAR_cst_]] : tensor<4xi32>
 // CHECK-DAG:         [[VAR_6_:%.+]] = arith.addi [[VAR_arg5_]], [[VAR_cst_]] : tensor<4xi32>
-// CHECK:             [[structured_3_:%.+]], [[offsets_4_:%.+]], [[VAR_strides_5_:%.+]] = "tts.get_structured_state"([[VAR_5_]]) <{resultSegmentSizes = array<i32: 1, 1, 1>}> : (tensor<4xi32>) -> (tensor<4xi32>, index, index)
-// CHECK:             [[structured_6_:%.+]], [[offsets_7_:%.+]], [[VAR_strides_8_:%.+]] = "tts.get_structured_state"([[VAR_6_]]) <{resultSegmentSizes = array<i32: 1, 1, 1>}> : (tensor<4xi32>) -> (tensor<4xi32>, index, index)
+// CHECK-DAG:         [[structured_3_:%.+]], [[offsets_4_:%.+]], [[VAR_strides_5_:%.+]] = "tts.get_structured_state"([[VAR_5_]]) <{resultSegmentSizes = array<i32: 1, 1, 1>}> : (tensor<4xi32>) -> (tensor<4xi32>, index, index)
+// CHECK-DAG:         [[structured_6_:%.+]], [[offsets_7_:%.+]], [[VAR_strides_8_:%.+]] = "tts.get_structured_state"([[VAR_6_]]) <{resultSegmentSizes = array<i32: 1, 1, 1>}> : (tensor<4xi32>) -> (tensor<4xi32>, index, index)
 // CHECK:             scf.yield [[structured_3_]], [[offsets_4_]], [[VAR_strides_5_]], [[structured_6_]], [[offsets_7_]], [[VAR_strides_8_]] : tensor<4xi32>, index, index, tensor<4xi32>, index, index
 // CHECK:           }
 // CHECK:           tt.return

--- a/test/Conversion/TritonToStructured/triton-to-structured-prepass.mlir
+++ b/test/Conversion/TritonToStructured/triton-to-structured-prepass.mlir
@@ -40,54 +40,8 @@ module {
   }
 }
 
-// CHECK:           tt.func public @nested1([[arg0_:.+]]: !tt.ptr<f32>, [[arg1_:.+]]: !tt.ptr<f32>, [[arg2_:.+]]: i32, [[arg3_:.+]]: i32, [[arg4_:.+]]: i32, [[arg5_:.+]]: i32, [[arg6_:.+]]: i32, [[arg7_:.+]]: i32) attributes {noinline = false} {
-// CHECK-DAG:         [[CST_1_:%.+]] = arith.constant 1 : i32
-// CHECK-DAG:         [[CST_2_:%.+]] = arith.constant 2 : i32
-// CHECK-DAG:         [[CST_0_:%.+]] = arith.constant 0 : i32
-// CHECK-DAG:         [[CST_32_:%.+]] = arith.constant 32 : i32
-// CHECK-DAG:         [[VAR_0_:%.+]] = tt.make_range {end = 2 : i32, start = 0 : i32} : tensor<2xi32>
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_1_:%.+]] = tt.expand_dims [[VAR_0_]] {axis = 1 : i32} : tensor<2xi32> -> tensor<2x1xi32>
-// CHECK-DAG:         [[VAR_2_:%.+]] = tt.splat [[arg4_]] : i32 -> tensor<2x1xi32>
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_3_:%.+]] = arith.muli [[VAR_1_]], [[VAR_2_]] : tensor<2x1xi32>
-// CHECK-DAG:         [[VAR_4_:%.+]] = tt.expand_dims [[VAR_0_]] {axis = 0 : i32} : tensor<2xi32> -> tensor<1x2xi32>
-// CHECK-DAG:         [[VAR_5_:%.+]] = tt.splat [[arg5_]] : i32 -> tensor<1x2xi32>
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_6_:%.+]] = arith.muli [[VAR_4_]], [[VAR_5_]] : tensor<1x2xi32>
-// CHECK-DAG:         [[VAR_7_:%.+]] = tt.broadcast [[VAR_3_]] : tensor<2x1xi32> -> tensor<2x2xi32>
-// CHECK:             [[VAR_8_:%.+]] = tt.broadcast [[VAR_6_]] : tensor<1x2xi32> -> tensor<2x2xi32>
-// CHECK-DAG:         [[VAR_9_:%.+]] = arith.addi [[VAR_7_]], [[VAR_8_]] : tensor<2x2xi32>
-// CHECK-DAG:         [[VAR_10_:%.+]] = tt.splat [[arg0_]] : !tt.ptr<f32> -> tensor<2x2x!tt.ptr<f32>>
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_11_:%.+]] = tt.addptr [[VAR_10_]], [[VAR_9_]] : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
-// CHECK-DAG:         [[VAR_12_:%.+]] = tt.splat [[arg6_]] : i32 -> tensor<2x1xi32>
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_13_:%.+]] = arith.muli [[VAR_12_]], [[VAR_1_]] : tensor<2x1xi32>
-// CHECK-DAG:         [[VAR_14_:%.+]] = tt.splat [[arg1_]] : !tt.ptr<f32> -> tensor<2x1x!tt.ptr<f32>>
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_15_:%.+]] = tt.addptr [[VAR_14_]], [[VAR_13_]] : tensor<2x1x!tt.ptr<f32>>, tensor<2x1xi32>
-// CHECK-DAG:         [[VAR_16_:%.+]] = tt.splat [[arg7_]] : i32 -> tensor<1x2xi32>
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_17_:%.+]] = arith.muli [[VAR_16_]], [[VAR_4_]] : tensor<1x2xi32>
-// CHECK-DAG:         [[VAR_18_:%.+]] = tt.broadcast [[VAR_15_]] : tensor<2x1x!tt.ptr<f32>> -> tensor<2x2x!tt.ptr<f32>>
-// CHECK:             [[VAR_19_:%.+]] = tt.broadcast [[VAR_17_]] : tensor<1x2xi32> -> tensor<2x2xi32>
-// CHECK-DAG:         [[VAR_20_:%.+]] = tt.addptr [[VAR_18_]], [[VAR_19_]] : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
-// CHECK-DAG:         [[VAR_21_:%.+]] = arith.muli [[arg5_]], [[CST_32_]] : i32
-// CHECK:             [[VAR_22_:%.+]] = tt.splat [[VAR_21_]] : i32 -> tensor<2x2xi32>
-// CHECK:             [[structuredPtr_:%.+]], [[offsets_:%.+]]:2, [[VAR_strides_:%.+]]:2 = "tts.get_structured_state"([[VAR_11_]]) <{resultSegmentSizes = array<i32: 1, 2, 2>}> : (tensor<2x2x!tt.ptr<f32>>) -> (tensor<2x2x!tt.ptr<f32>>, index, index, index, index)
-// CHECK:             [[structuredPtr_0_:%.+]], [[offsets_1_:%.+]]:2, [[VAR_strides_2_:%.+]]:2 = "tts.get_structured_state"([[VAR_20_]]) <{resultSegmentSizes = array<i32: 1, 2, 2>}> : (tensor<2x2x!tt.ptr<f32>>) -> (tensor<2x2x!tt.ptr<f32>>, index, index, index, index)
-// CHECK-DAG:         [[VAR_23_:%.+]]:10 = scf.for [[VAR_arg8_:%.+]] = [[CST_0_]] to [[CST_2_]] step [[CST_1_]] iter_args([[VAR_arg9_:%.+]] = [[structuredPtr_]], [[VAR_arg10_:%.+]] = [[offsets_]]#0, [[VAR_arg11_:%.+]] = [[offsets_]]#1, [[VAR_arg12_:%.+]] = [[VAR_strides_]]#0, [[VAR_arg13_:%.+]] = [[VAR_strides_]]#1, [[VAR_arg14_:%.+]] = [[structuredPtr_0_]], [[VAR_arg15_:%.+]] = [[offsets_1_]]#0, [[VAR_arg16_:%.+]] = [[offsets_1_]]#1, [[VAR_arg17_:%.+]] = [[VAR_strides_2_]]#0, [[VAR_arg18_:%.+]] = [[VAR_strides_2_]]#1) -> (tensor<2x2x!tt.ptr<f32>>, index, index, index, index, tensor<2x2x!tt.ptr<f32>>, index, index, index, index)  : i32 {
-// CHECK-DAG:           [[LOAD_VAR_arg9_MEM_:%.+]] = tt.load [[VAR_arg9_]] : tensor<2x2x!tt.ptr<f32>>
-// CHECK:               tt.store [[VAR_arg14_]], [[LOAD_VAR_arg9_MEM_]] : tensor<2x2x!tt.ptr<f32>>
-// CHECK-DAG:           [[VAR_25_:%.+]] = tt.addptr [[VAR_arg9_]], [[VAR_22_]] : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
-// CHECK-DAG:           [[VAR_26_:%.+]] = tt.addptr [[VAR_arg14_]], [[VAR_22_]] : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
-// CHECK:               [[structuredPtr_3_:%.+]], [[offsets_4_:%.+]]:2, [[VAR_strides_5_:%.+]]:2 = "tts.get_structured_state"([[VAR_25_]]) <{resultSegmentSizes = array<i32: 1, 2, 2>}> : (tensor<2x2x!tt.ptr<f32>>) -> (tensor<2x2x!tt.ptr<f32>>, index, index, index, index)
-// CHECK:               [[structuredPtr_6_:%.+]], [[offsets_7_:%.+]]:2, [[VAR_strides_8_:%.+]]:2 = "tts.get_structured_state"([[VAR_26_]]) <{resultSegmentSizes = array<i32: 1, 2, 2>}> : (tensor<2x2x!tt.ptr<f32>>) -> (tensor<2x2x!tt.ptr<f32>>, index, index, index, index)
-// CHECK:               scf.yield [[structuredPtr_3_]], [[offsets_4_]]#0, [[offsets_4_]]#1, [[VAR_strides_5_]]#0, [[VAR_strides_5_]]#1, [[structuredPtr_6_]], [[offsets_7_]]#0, [[offsets_7_]]#1, [[VAR_strides_8_]]#0, [[VAR_strides_8_]]#1 : tensor<2x2x!tt.ptr<f32>>, index, index, index, index, tensor<2x2x!tt.ptr<f32>>, index, index, index, index
-// CHECK:             }
-// CHECK:             tt.return
-// CHECK:           }
+// CHECK-COUNT-4: tts.get_structured_state
+// CHECK-NOT: tts.get_structured_state
 
 // ----
 
@@ -138,63 +92,8 @@ module {
   }
 }
 
-// CHECK:           tt.func public @nested2([[arg0_:.+]]: !tt.ptr<f32>, [[arg1_:.+]]: !tt.ptr<f32>, [[arg2_:.+]]: i32, [[arg3_:.+]]: i32, [[arg4_:.+]]: i32, [[arg5_:.+]]: i32, [[arg6_:.+]]: i32, [[arg7_]]: i32) attributes {noinline = false} {
-// CHECK-DAG:         [[CST_1_1_:%.+]] = arith.constant 1 : i32
-// CHECK-DAG:         [[CST_2_1_:%.+]] = arith.constant 2 : i32
-// CHECK-DAG:         [[CST_0_1_:%.+]] = arith.constant 0 : i32
-// CHECK-DAG:         [[CST_32_1_:%.+]] = arith.constant 32 : i32
-// CHECK-DAG:         [[VAR_0_1_:%.+]] = tt.make_range {end = 2 : i32, start = 0 : i32} : tensor<2xi32>
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_1_1_:%.+]] = tt.expand_dims [[VAR_0_1_]] {axis = 1 : i32} : tensor<2xi32> -> tensor<2x1xi32>
-// CHECK-DAG:         [[VAR_2_1_:%.+]] = tt.splat [[arg4_]] : i32 -> tensor<2x1xi32>
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_3_1_:%.+]] = arith.muli [[VAR_1_1_]], [[VAR_2_1_]] : tensor<2x1xi32>
-// CHECK-DAG:         [[VAR_4_1_:%.+]] = tt.expand_dims [[VAR_0_1_]] {axis = 0 : i32} : tensor<2xi32> -> tensor<1x2xi32>
-// CHECK-DAG:         [[VAR_5_1_:%.+]] = tt.splat [[arg5_]] : i32 -> tensor<1x2xi32>
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_6_1_:%.+]] = arith.muli [[VAR_4_1_]], [[VAR_5_1_]] : tensor<1x2xi32>
-// CHECK-DAG:         [[VAR_7_1_:%.+]] = tt.broadcast [[VAR_3_1_]] : tensor<2x1xi32> -> tensor<2x2xi32>
-// CHECK:             [[VAR_8_1_:%.+]] = tt.broadcast [[VAR_6_1_]] : tensor<1x2xi32> -> tensor<2x2xi32>
-// CHECK-DAG:         [[VAR_9_1_:%.+]] = arith.addi [[VAR_7_1_]], [[VAR_8_1_]] : tensor<2x2xi32>
-// CHECK-DAG:         [[VAR_10_1_:%.+]] = tt.splat [[arg0_]] : !tt.ptr<f32> -> tensor<2x2x!tt.ptr<f32>>
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_11_1_:%.+]] = tt.addptr [[VAR_10_1_]], [[VAR_9_1_]] : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
-// CHECK-DAG:         [[VAR_12_1_:%.+]] = tt.splat [[arg6_]] : i32 -> tensor<2x1xi32>
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_13_1_:%.+]] = arith.muli [[VAR_12_1_]], [[VAR_1_1_]] : tensor<2x1xi32>
-// CHECK-DAG:         [[VAR_14_1_:%.+]] = tt.splat [[arg1_]] : !tt.ptr<f32> -> tensor<2x1x!tt.ptr<f32>>
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_15_1_:%.+]] = tt.addptr [[VAR_14_1_]], [[VAR_13_1_]] : tensor<2x1x!tt.ptr<f32>>, tensor<2x1xi32>
-// CHECK-DAG:         [[VAR_16_1_:%.+]] = tt.splat [[arg7_]] : i32 -> tensor<1x2xi32>
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_17_1_:%.+]] = arith.muli [[VAR_16_1_]], [[VAR_4_1_]] : tensor<1x2xi32>
-// CHECK-DAG:         [[VAR_18_1_:%.+]] = tt.broadcast [[VAR_15_1_]] : tensor<2x1x!tt.ptr<f32>> -> tensor<2x2x!tt.ptr<f32>>
-// CHECK:             [[VAR_19_1_:%.+]] = tt.broadcast [[VAR_17_1_]] : tensor<1x2xi32> -> tensor<2x2xi32>
-// CHECK-DAG:         [[VAR_20_1_:%.+]] = tt.addptr [[VAR_18_1_]], [[VAR_19_1_]] : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
-// CHECK-DAG:         [[VAR_21_1_:%.+]] = arith.muli [[arg5_]], [[CST_32_1_]] : i32
-// CHECK:             [[VAR_22_1_:%.+]] = tt.splat [[VAR_21_1_]] : i32 -> tensor<2x2xi32>
-// CHECK:             [[structuredPtr_:%.+]], [[offsets_:%.+]]:2, [[VAR_strides_1_:%.+]]:2 = "tts.get_structured_state"([[VAR_11_1_]]) <{resultSegmentSizes = array<i32: 1, 2, 2>}> : (tensor<2x2x!tt.ptr<f32>>) -> (tensor<2x2x!tt.ptr<f32>>, index, index, index, index)
-// CHECK:             [[structuredPtr_0_:%.+]], [[offsets_1_:%.+]]:2, [[VAR_strides_2_1_:%.+]]:2 = "tts.get_structured_state"([[VAR_20_1_]]) <{resultSegmentSizes = array<i32: 1, 2, 2>}> : (tensor<2x2x!tt.ptr<f32>>) -> (tensor<2x2x!tt.ptr<f32>>, index, index, index, index)
-// CHECK-DAG:         [[VAR_23_1_:%.+]]:10 = scf.for [[VAR_arg8_1_:%.+]] = [[CST_0_1_]] to [[CST_2_1_]] step [[CST_1_1_]] iter_args([[VAR_arg9_1_:%.+]] = [[structuredPtr_]], [[VAR_arg10_1_:%.+]] = [[offsets_]]#0, [[VAR_arg11_1_:%.+]] = [[offsets_]]#1, [[VAR_arg12_1_:%.+]] = [[VAR_strides_1_]]#0, [[VAR_arg13_1_:%.+]] = [[VAR_strides_1_]]#1, [[VAR_arg14_1_:%.+]] = [[structuredPtr_0_]], [[VAR_arg15_1_:%.+]] = [[offsets_1_]]#0, [[VAR_arg16_1_:%.+]] = [[offsets_1_]]#1, [[VAR_arg17_1_:%.+]] = [[VAR_strides_2_1_]]#0, [[VAR_arg18_1_:%.+]] = [[VAR_strides_2_1_]]#1) -> (tensor<2x2x!tt.ptr<f32>>, index, index, index, index, tensor<2x2x!tt.ptr<f32>>, index, index, index, index)  : i32 {
-// CHECK-DAG:           [[LOAD_VAR_arg9_MEM_1_:%.+]] = tt.load [[VAR_arg9_1_]] : tensor<2x2x!tt.ptr<f32>>
-// CHECK:               tt.store [[VAR_arg14_1_]], [[LOAD_VAR_arg9_MEM_1_]] : tensor<2x2x!tt.ptr<f32>>
-// CHECK-DAG:           [[VAR_25_1_:%.+]] = tt.addptr [[VAR_arg9_1_]], [[VAR_22_1_]] : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
-// CHECK-DAG:           [[VAR_26_1_:%.+]] = tt.addptr [[VAR_arg14_1_]], [[VAR_22_1_]] : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
-// CHECK:               [[structuredPtr_3_:%.+]], [[offsets_4_:%.+]]:2, [[VAR_strides_5_1_:%.+]]:2 = "tts.get_structured_state"([[VAR_25_1_]]) <{resultSegmentSizes = array<i32: 1, 2, 2>}> : (tensor<2x2x!tt.ptr<f32>>) -> (tensor<2x2x!tt.ptr<f32>>, index, index, index, index)
-// CHECK:               [[structuredPtr_6_:%.+]], [[offsets_7_:%.+]]:2, [[VAR_strides_8_1_:%.+]]:2 = "tts.get_structured_state"([[VAR_26_1_]]) <{resultSegmentSizes = array<i32: 1, 2, 2>}> : (tensor<2x2x!tt.ptr<f32>>) -> (tensor<2x2x!tt.ptr<f32>>, index, index, index, index)
-// CHECK-DAG:           [[VAR_27_:%.+]]:10 = scf.for [[VAR_arg19_:%.+]] = [[CST_0_1_]] to [[CST_2_1_]] step [[CST_1_1_]] iter_args([[VAR_arg20_:%.+]] = [[structuredPtr_3_]], [[VAR_arg21_:%.+]] = [[offsets_4_]]#0, [[VAR_arg22_:%.+]] = [[offsets_4_]]#1, [[VAR_arg23_:%.+]] = [[VAR_strides_5_1_]]#0, [[VAR_arg24_:%.+]] = [[VAR_strides_5_1_]]#1, [[VAR_arg25_:%.+]] = [[structuredPtr_6_]], [[VAR_arg26_:%.+]] = [[offsets_7_]]#0, [[VAR_arg27_:%.+]] = [[offsets_7_]]#1, [[VAR_arg28_:%.+]] = [[VAR_strides_8_1_]]#0, [[VAR_arg29_:%.+]] = [[VAR_strides_8_1_]]#1) -> (tensor<2x2x!tt.ptr<f32>>, index, index, index, index, tensor<2x2x!tt.ptr<f32>>, index, index, index, index)  : i32 {
-// CHECK-DAG:             [[LOAD_VAR_arg20_MEM_:%.+]] = tt.load [[VAR_arg20_]] : tensor<2x2x!tt.ptr<f32>>
-// CHECK:                 tt.store [[VAR_arg25_]], [[LOAD_VAR_arg20_MEM_]] : tensor<2x2x!tt.ptr<f32>>
-// CHECK-DAG:             [[VAR_29_:%.+]] = tt.addptr [[VAR_arg20_]], [[VAR_22_1_]] : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
-// CHECK-DAG:             [[VAR_30_:%.+]] = tt.addptr [[VAR_arg25_]], [[VAR_22_1_]] : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
-// CHECK:                 [[structuredPtr_9_:%.+]], [[offsets_10_:%.+]]:2, [[VAR_strides_11_:%.+]]:2 = "tts.get_structured_state"([[VAR_29_]]) <{resultSegmentSizes = array<i32: 1, 2, 2>}> : (tensor<2x2x!tt.ptr<f32>>) -> (tensor<2x2x!tt.ptr<f32>>, index, index, index, index)
-// CHECK:                 [[structuredPtr_12_:%.+]], [[offsets_13_:%.+]]:2, [[VAR_strides_14_:%.+]]:2 = "tts.get_structured_state"([[VAR_30_]]) <{resultSegmentSizes = array<i32: 1, 2, 2>}> : (tensor<2x2x!tt.ptr<f32>>) -> (tensor<2x2x!tt.ptr<f32>>, index, index, index, index)
-// CHECK:                 scf.yield [[structuredPtr_9_]], [[offsets_10_]]#0, [[offsets_10_]]#1, [[VAR_strides_11_]]#0, [[VAR_strides_11_]]#1, [[structuredPtr_12_]], [[offsets_13_]]#0, [[offsets_13_]]#1, [[VAR_strides_14_]]#0, [[VAR_strides_14_]]#1 : tensor<2x2x!tt.ptr<f32>>, index, index, index, index, tensor<2x2x!tt.ptr<f32>>, index, index, index, index
-// CHECK:               }
-// CHECK:               scf.yield [[VAR_27_]]#0, [[VAR_27_]]#1, [[VAR_27_]]#2, [[VAR_27_]]#3, [[VAR_27_]]#4, [[VAR_27_]]#5, [[VAR_27_]]#6, [[VAR_27_]]#7, [[VAR_27_]]#8, [[VAR_27_]]#9 : tensor<2x2x!tt.ptr<f32>>, index, index, index, index, tensor<2x2x!tt.ptr<f32>>, index, index, index, index
-// CHECK:             }
-// CHECK:             tt.return
-// CHECK:           }
+// CHECK-COUNT-6: tts.get_structured_state
+// CHECK-NOT: tts.get_structured_state
 
 // ----
 
@@ -242,60 +141,8 @@ module {
   }
 }
 
-// CHECK:           tt.func public @nested2_use_loop_results([[arg0_]]: !tt.ptr<f32>, [[arg1_]]: !tt.ptr<f32>, [[arg2_]]: i32, [[arg3_]]: i32) attributes {noinline = false} {
-// CHECK-DAG:         [[CST_1_2_:%.+]] = arith.constant 1 : i32
-// CHECK-DAG:         [[CST_2_2_:%.+]] = arith.constant 2 : i32
-// CHECK-DAG:         [[CST_0_2_:%.+]] = arith.constant 0 : i32
-// CHECK-DAG:         [[CST_4_:%.+]] = arith.constant 4 : i32
-// CHECK-DAG:         [[VAR_0_2_:%.+]] = tt.make_range {end = 2 : i32, start = 0 : i32} : tensor<2xi32>
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_1_2_:%.+]] = tt.expand_dims [[VAR_0_2_]] {axis = 1 : i32} : tensor<2xi32> -> tensor<2x1xi32>
-// CHECK-DAG:         [[VAR_2_2_:%.+]] = tt.splat [[arg2_]] : i32 -> tensor<2x1xi32>
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_3_2_:%.+]] = arith.muli [[VAR_1_2_]], [[VAR_2_2_]] : tensor<2x1xi32>
-// CHECK-DAG:         [[VAR_4_2_:%.+]] = tt.expand_dims [[VAR_0_2_]] {axis = 0 : i32} : tensor<2xi32> -> tensor<1x2xi32>
-// CHECK-DAG:         [[VAR_5_2_:%.+]] = tt.splat [[arg3_]] : i32 -> tensor<1x2xi32>
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_6_2_:%.+]] = arith.muli [[VAR_4_2_]], [[VAR_5_2_]] : tensor<1x2xi32>
-// CHECK-DAG:         [[VAR_7_2_:%.+]] = tt.broadcast [[VAR_3_2_]] : tensor<2x1xi32> -> tensor<2x2xi32>
-// CHECK:             [[VAR_8_2_:%.+]] = tt.broadcast [[VAR_6_2_]] : tensor<1x2xi32> -> tensor<2x2xi32>
-// CHECK-DAG:         [[VAR_9_2_:%.+]] = arith.addi [[VAR_7_2_]], [[VAR_8_2_]] : tensor<2x2xi32>
-// CHECK-DAG:         [[VAR_10_2_:%.+]] = tt.splat [[arg0_]] : !tt.ptr<f32> -> tensor<2x2x!tt.ptr<f32>>
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_11_2_:%.+]] = tt.addptr [[VAR_10_2_]], [[VAR_9_2_]] : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
-// CHECK-DAG:         [[VAR_12_2_:%.+]] = tt.splat [[arg1_]] : !tt.ptr<f32> -> tensor<2x1x!tt.ptr<f32>>
-// CHECK:             [[VAR_13_2_:%.+]] = tt.addptr [[VAR_12_2_]], [[VAR_3_2_]] : tensor<2x1x!tt.ptr<f32>>, tensor<2x1xi32>
-// CHECK:             [[VAR_14_2_:%.+]] = tt.broadcast [[VAR_13_2_]] : tensor<2x1x!tt.ptr<f32>> -> tensor<2x2x!tt.ptr<f32>>
-// CHECK-DAG:         [[VAR_15_2_:%.+]] = tt.addptr [[VAR_14_2_]], [[VAR_8_2_]] : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
-// CHECK-DAG:         [[VAR_16_2_:%.+]] = arith.muli [[arg3_]], [[CST_4_]] : i32
-// CHECK:             [[VAR_17_2_:%.+]] = tt.splat [[VAR_16_2_]] : i32 -> tensor<2x2xi32>
-// CHECK:             [[structuredPtr_:%.+]], [[offsets_:%.+]]:2, [[VAR_strides_2_:%.+]]:2 = "tts.get_structured_state"([[VAR_11_2_]]) <{resultSegmentSizes = array<i32: 1, 2, 2>}> : (tensor<2x2x!tt.ptr<f32>>) -> (tensor<2x2x!tt.ptr<f32>>, index, index, index, index)
-// CHECK:             [[structuredPtr_0_:%.+]], [[offsets_1_:%.+]]:2, [[VAR_strides_2_2_:%.+]]:2 = "tts.get_structured_state"([[VAR_15_2_]]) <{resultSegmentSizes = array<i32: 1, 2, 2>}> : (tensor<2x2x!tt.ptr<f32>>) -> (tensor<2x2x!tt.ptr<f32>>, index, index, index, index)
-// CHECK-DAG:         [[VAR_18_2_:%.+]]:10 = scf.for [[VAR_arg4_:%.+]] = [[CST_0_2_]] to [[CST_2_2_]] step [[CST_1_2_]] iter_args([[VAR_arg5_:%.+]] = [[structuredPtr_]], [[VAR_arg6_:%.+]] = [[offsets_]]#0, [[VAR_arg7_:%.+]] = [[offsets_]]#1, [[VAR_arg8_2_:%.+]] = [[VAR_strides_2_]]#0, [[VAR_arg9_2_:%.+]] = [[VAR_strides_2_]]#1, [[VAR_arg10_2_:%.+]] = [[structuredPtr_0_]], [[VAR_arg11_2_:%.+]] = [[offsets_1_]]#0, [[VAR_arg12_2_:%.+]] = [[offsets_1_]]#1, [[VAR_arg13_2_:%.+]] = [[VAR_strides_2_2_]]#0, [[VAR_arg14_2_:%.+]] = [[VAR_strides_2_2_]]#1) -> (tensor<2x2x!tt.ptr<f32>>, index, index, index, index, tensor<2x2x!tt.ptr<f32>>, index, index, index, index)  : i32 {
-// CHECK-DAG:           [[VAR_19_1_:%.+]] = tt.load [[VAR_arg5_]] : tensor<2x2x!tt.ptr<f32>>
-// CHECK:               tt.store [[VAR_arg10_2_]], [[VAR_19_1_]] : tensor<2x2x!tt.ptr<f32>>
-// CHECK-DAG:           [[VAR_20_2_:%.+]] = tt.addptr [[VAR_arg5_]], [[VAR_17_2_]] : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
-// CHECK-DAG:           [[VAR_21_2_:%.+]] = tt.addptr [[VAR_arg10_2_]], [[VAR_17_2_]] : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
-// CHECK:               [[structuredPtr_3_:%.+]], [[offsets_4_:%.+]]:2, [[VAR_strides_5_2_:%.+]]:2 = "tts.get_structured_state"([[VAR_20_2_]]) <{resultSegmentSizes = array<i32: 1, 2, 2>}> : (tensor<2x2x!tt.ptr<f32>>) -> (tensor<2x2x!tt.ptr<f32>>, index, index, index, index)
-// CHECK:               [[structuredPtr_6_:%.+]], [[offsets_7_:%.+]]:2, [[VAR_strides_8_2_:%.+]]:2 = "tts.get_structured_state"([[VAR_21_2_]]) <{resultSegmentSizes = array<i32: 1, 2, 2>}> : (tensor<2x2x!tt.ptr<f32>>) -> (tensor<2x2x!tt.ptr<f32>>, index, index, index, index)
-// CHECK-DAG:           [[VAR_22_2_:%.+]]:10 = scf.for [[VAR_arg15_2_:%.+]] = [[CST_0_2_]] to [[CST_2_2_]] step [[CST_1_2_]] iter_args([[VAR_arg16_2_:%.+]] = [[structuredPtr_3_]], [[VAR_arg17_2_:%.+]] = [[offsets_4_]]#0, [[VAR_arg18_2_:%.+]] = [[offsets_4_]]#1, [[VAR_arg19_1_:%.+]] = [[VAR_strides_5_2_]]#0, [[VAR_arg20_1_:%.+]] = [[VAR_strides_5_2_]]#1, [[VAR_arg21_1_:%.+]] = [[structuredPtr_6_]], [[VAR_arg22_1_:%.+]] = [[offsets_7_]]#0, [[VAR_arg23_1_:%.+]] = [[offsets_7_]]#1, [[VAR_arg24_1_:%.+]] = [[VAR_strides_8_2_]]#0, [[VAR_arg25_1_:%.+]] = [[VAR_strides_8_2_]]#1) -> (tensor<2x2x!tt.ptr<f32>>, index, index, index, index, tensor<2x2x!tt.ptr<f32>>, index, index, index, index)  : i32 {
-// CHECK-DAG:             [[VAR_25_1_:%.+]] = tt.load [[VAR_arg16_2_]] : tensor<2x2x!tt.ptr<f32>>
-// CHECK:                 tt.store [[VAR_arg21_1_]], [[VAR_25_1_]] : tensor<2x2x!tt.ptr<f32>>
-// CHECK-DAG:             [[VAR_26_2_:%.+]] = tt.addptr [[VAR_arg16_2_]], [[VAR_17_2_]] : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
-// CHECK-DAG:             [[VAR_27_1_:%.+]] = tt.addptr [[VAR_arg21_1_]], [[VAR_17_2_]] : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
-// CHECK:                 [[structuredPtr_15_:%.+]], [[offsets_16_:%.+]]:2, [[VAR_strides_17_:%.+]]:2 = "tts.get_structured_state"([[VAR_26_2_]]) <{resultSegmentSizes = array<i32: 1, 2, 2>}> : (tensor<2x2x!tt.ptr<f32>>) -> (tensor<2x2x!tt.ptr<f32>>, index, index, index, index)
-// CHECK:                 [[structuredPtr_18_:%.+]], [[offsets_19_:%.+]]:2, [[VAR_strides_20_:%.+]]:2 = "tts.get_structured_state"([[VAR_27_1_]]) <{resultSegmentSizes = array<i32: 1, 2, 2>}> : (tensor<2x2x!tt.ptr<f32>>) -> (tensor<2x2x!tt.ptr<f32>>, index, index, index, index)
-// CHECK:                 scf.yield [[structuredPtr_15_]], [[offsets_16_]]#0, [[offsets_16_]]#1, [[VAR_strides_17_]]#0, [[VAR_strides_17_]]#1, [[structuredPtr_18_]], [[offsets_19_]]#0, [[offsets_19_]]#1, [[VAR_strides_20_]]#0, [[VAR_strides_20_]]#1 : tensor<2x2x!tt.ptr<f32>>, index, index, index, index, tensor<2x2x!tt.ptr<f32>>, index, index, index, index
-// CHECK:               }
-// CHECK-DAG:           [[VAR_23_2_:%.+]] = tt.addptr [[VAR_22_2_]]#0, [[VAR_17_2_]] : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
-// CHECK-DAG:           [[LOAD_VAR_arg9_MEM_1_:%.+]] = tt.addptr [[VAR_22_2_]]#5, [[VAR_17_2_]] : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
-// CHECK:               [[structuredPtr_9_:%.+]], [[offsets_10_:%.+]]:2, [[VAR_strides_11_1_:%.+]]:2 = "tts.get_structured_state"([[VAR_23_2_]]) <{resultSegmentSizes = array<i32: 1, 2, 2>}> : (tensor<2x2x!tt.ptr<f32>>) -> (tensor<2x2x!tt.ptr<f32>>, index, index, index, index)
-// CHECK:               [[structuredPtr_12_:%.+]], [[offsets_13_:%.+]]:2, [[VAR_strides_14_1_:%.+]]:2 = "tts.get_structured_state"([[LOAD_VAR_arg9_MEM_1_]]) <{resultSegmentSizes = array<i32: 1, 2, 2>}> : (tensor<2x2x!tt.ptr<f32>>) -> (tensor<2x2x!tt.ptr<f32>>, index, index, index, index)
-// CHECK:               scf.yield [[structuredPtr_9_]], [[offsets_10_]]#0, [[offsets_10_]]#1, [[VAR_strides_11_1_]]#0, [[VAR_strides_11_1_]]#1, [[structuredPtr_12_]], [[offsets_13_]]#0, [[offsets_13_]]#1, [[VAR_strides_14_1_]]#0, [[VAR_strides_14_1_]]#1 : tensor<2x2x!tt.ptr<f32>>, index, index, index, index, tensor<2x2x!tt.ptr<f32>>, index, index, index, index
-// CHECK:             }
-// CHECK:             tt.return
-// CHECK:           }
-
+// CHECK-COUNT-8: tts.get_structured_state
+// CHECK-NOT: tts.get_structured_state
 // ----
 
 module {
@@ -348,61 +195,5 @@ module {
   }
 }
 
-// CHECK:           tt.func public @nested3([[arg0_:.+]]: !tt.ptr<f32>, [[arg1_:.+]]: !tt.ptr<f32>, [[arg2_:.+]]: i32, [[arg3_:.+]]: i32) attributes {noinline = false} {
-// CHECK-DAG:         [[CST_1_3_:%.+]] = arith.constant 1 : i32
-// CHECK-DAG:         [[CST_0_3_:%.+]] = arith.constant 0 : i32
-// CHECK-DAG:         [[CST_2_3_:%.+]] = arith.constant 2 : i32
-// CHECK-DAG:         [[VAR_0_3_:%.+]] = tt.make_range {end = 2 : i32, start = 0 : i32} : tensor<2xi32>
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_1_3_:%.+]] = tt.expand_dims [[VAR_0_3_]] {axis = 1 : i32} : tensor<2xi32> -> tensor<2x1xi32>
-// CHECK-DAG:         [[VAR_2_3_:%.+]] = tt.splat [[arg2_]] : i32 -> tensor<2x1xi32>
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_3_3_:%.+]] = arith.muli [[VAR_1_3_]], [[VAR_2_3_]] : tensor<2x1xi32>
-// CHECK-DAG:         [[VAR_4_3_:%.+]] = tt.expand_dims [[VAR_0_3_]] {axis = 0 : i32} : tensor<2xi32> -> tensor<1x2xi32>
-// CHECK-DAG:         [[VAR_5_3_:%.+]] = tt.splat [[arg3_]] : i32 -> tensor<1x2xi32>
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_6_3_:%.+]] = arith.muli [[VAR_4_3_]], [[VAR_5_3_]] : tensor<1x2xi32>
-// CHECK-DAG:         [[VAR_7_3_:%.+]] = tt.broadcast [[VAR_3_3_]] : tensor<2x1xi32> -> tensor<2x2xi32>
-// CHECK:             [[VAR_8_3_:%.+]] = tt.broadcast [[VAR_6_3_]] : tensor<1x2xi32> -> tensor<2x2xi32>
-// CHECK-DAG:         [[VAR_9_3_:%.+]] = arith.addi [[VAR_7_3_]], [[VAR_8_3_]] : tensor<2x2xi32>
-// CHECK-DAG:         [[VAR_10_3_:%.+]] = tt.splat [[arg0_]] : !tt.ptr<f32> -> tensor<2x2x!tt.ptr<f32>>
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_11_3_:%.+]] = tt.addptr [[VAR_10_3_]], [[VAR_9_3_]] : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
-// CHECK-DAG:         [[VAR_12_3_:%.+]] = tt.splat [[arg1_]] : !tt.ptr<f32> -> tensor<2x1x!tt.ptr<f32>>
-// CHECK:             [[VAR_13_3_:%.+]] = tt.addptr [[VAR_12_3_]], [[VAR_3_3_]] : tensor<2x1x!tt.ptr<f32>>, tensor<2x1xi32>
-// CHECK:             [[VAR_14_3_:%.+]] = tt.broadcast [[VAR_13_3_]] : tensor<2x1x!tt.ptr<f32>> -> tensor<2x2x!tt.ptr<f32>>
-// CHECK-DAG:         [[VAR_15_3_:%.+]] = tt.addptr [[VAR_14_3_]], [[VAR_8_3_]] : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
-// CHECK-DAG:         [[VAR_16_3_:%.+]] = arith.muli [[arg3_]], [[CST_2_3_]] : i32
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_17_3_:%.+]] = tt.splat [[VAR_16_3_]] : i32 -> tensor<2x2xi32>
-// CHECK-DAG:         [[VAR_18_3_:%.+]] = arith.muli [[arg3_]], [[CST_2_3_]] : i32
-// CHECK:             [[VAR_19_2_:%.+]] = tt.splat [[VAR_18_3_]] : i32 -> tensor<2x2xi32>
-// CHECK:             [[structuredPtr_:%.+]], [[offsets_:%.+]]:2, [[VAR_strides_3_:%.+]]:2 = "tts.get_structured_state"([[VAR_11_3_]]) <{resultSegmentSizes = array<i32: 1, 2, 2>}> : (tensor<2x2x!tt.ptr<f32>>) -> (tensor<2x2x!tt.ptr<f32>>, index, index, index, index)
-// CHECK:             [[structuredPtr_0_:%.+]], [[offsets_1_:%.+]]:2, [[VAR_strides_2_3_:%.+]]:2 = "tts.get_structured_state"([[VAR_15_3_]]) <{resultSegmentSizes = array<i32: 1, 2, 2>}> : (tensor<2x2x!tt.ptr<f32>>) -> (tensor<2x2x!tt.ptr<f32>>, index, index, index, index)
-// CHECK-DAG:         [[VAR_20_3_:%.+]]:10 = scf.for [[VAR_arg4_1_:%.+]] = [[CST_0_3_]] to [[CST_2_3_]] step [[CST_1_3_]] iter_args([[VAR_arg5_1_:%.+]] = [[structuredPtr_]], [[VAR_arg6_1_:%.+]] = [[offsets_]]#0, [[VAR_arg7_1_:%.+]] = [[offsets_]]#1, [[VAR_arg8_3_:%.+]] = [[VAR_strides_3_]]#0, [[VAR_arg9_3_:%.+]] = [[VAR_strides_3_]]#1, [[VAR_arg10_3_:%.+]] = [[structuredPtr_0_]], [[VAR_arg11_3_:%.+]] = [[offsets_1_]]#0, [[VAR_arg12_3_:%.+]] = [[offsets_1_]]#1, [[VAR_arg13_3_:%.+]] = [[VAR_strides_2_3_]]#0, [[VAR_arg14_3_:%.+]] = [[VAR_strides_2_3_]]#1) -> (tensor<2x2x!tt.ptr<f32>>, index, index, index, index, tensor<2x2x!tt.ptr<f32>>, index, index, index, index)  : i32 {
-// CHECK-DAG:           [[VAR_21_2_:%.+]] = tt.load [[VAR_arg5_1_]] : tensor<2x2x!tt.ptr<f32>>
-// CHECK-DAG:           [[VAR_22_3_:%.+]]:10 = scf.for [[VAR_arg15_3_:%.+]] = [[CST_0_3_]] to [[CST_2_3_]] step [[CST_1_3_]] iter_args([[VAR_arg16_3_:%.+]] = [[VAR_arg5_1_]], [[VAR_arg17_3_:%.+]] = [[VAR_arg6_1_]], [[VAR_arg18_3_:%.+]] = [[VAR_arg7_1_]], [[VAR_arg19_2_:%.+]] = [[VAR_arg8_3_]], [[VAR_arg20_2_:%.+]] = [[VAR_arg9_3_]], [[VAR_arg21_2_:%.+]] = [[VAR_arg10_3_]], [[VAR_arg22_2_:%.+]] = [[VAR_arg11_3_]], [[VAR_arg23_2_:%.+]] = [[VAR_arg12_3_]], [[VAR_arg24_2_:%.+]] = [[VAR_arg13_3_]], [[VAR_arg25_2_:%.+]] = [[VAR_arg14_3_]]) -> (tensor<2x2x!tt.ptr<f32>>, index, index, index, index, tensor<2x2x!tt.ptr<f32>>, index, index, index, index)  : i32 {
-// CHECK-DAG:             [[LOAD_VAR_arg9_MEM_1_1_:%.+]] = tt.addptr [[VAR_arg16_3_]], [[VAR_17_3_]] : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
-// CHECK:                 [[VAR_25_1_1_:%.+]] = tt.load [[LOAD_VAR_arg9_MEM_1_1_]] : tensor<2x2x!tt.ptr<f32>>
-// CHECK:                 [[structuredPtr_6_:%.+]], [[offsets_7_:%.+]]:2, [[VAR_strides_8_3_:%.+]]:2 = "tts.get_structured_state"([[LOAD_VAR_arg9_MEM_1_1_]]) <{resultSegmentSizes = array<i32: 1, 2, 2>}> : (tensor<2x2x!tt.ptr<f32>>) -> (tensor<2x2x!tt.ptr<f32>>, index, index, index, index)
-// CHECK-DAG:             [[VAR_26_3_:%.+]]:10 = scf.for [[VAR_arg26_1_:%.+]] = [[CST_0_3_]] to [[CST_2_3_]] step [[CST_1_3_]] iter_args([[VAR_arg27_1_:%.+]] = [[structuredPtr_6_]], [[VAR_arg28_1_:%.+]] = [[offsets_7_]]#0, [[VAR_arg29_1_:%.+]] = [[offsets_7_]]#1, [[VAR_arg30_:%.+]] = [[VAR_strides_8_3_]]#0, [[VAR_arg31_:%.+]] = [[VAR_strides_8_3_]]#1, [[VAR_arg32_:%.+]] = [[VAR_arg21_2_]], [[VAR_arg33_:%.+]] = [[VAR_arg22_2_]], [[VAR_arg34_:%.+]] = [[VAR_arg23_2_]], [[VAR_arg35_:%.+]] = [[VAR_arg24_2_]], [[VAR_arg36_:%.+]] = [[VAR_arg25_2_]]) -> (tensor<2x2x!tt.ptr<f32>>, index, index, index, index, tensor<2x2x!tt.ptr<f32>>, index, index, index, index)  : i32 {
-// CHECK-DAG:               [[VAR_27_2_:%.+]] = tt.addptr [[VAR_arg27_1_]], [[VAR_17_3_]] : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
-// CHECK:                   [[LOAD_VAR_arg20_MEM_1_:%.+]] = tt.load [[VAR_27_2_]] : tensor<2x2x!tt.ptr<f32>>
-// CHECK:                   tt.store [[VAR_arg32_]], [[VAR_21_2_]] : tensor<2x2x!tt.ptr<f32>>
-// CHECK:                   [[VAR_29_1_:%.+]] = tt.addptr [[VAR_arg32_]], [[VAR_17_3_]] : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
-// CHECK:                   tt.store [[VAR_29_1_]], [[VAR_25_1_1_]] : tensor<2x2x!tt.ptr<f32>>
-// CHECK:                   [[VAR_30_1_:%.+]] = tt.addptr [[VAR_29_1_]], [[VAR_17_3_]] : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
-// CHECK:                   tt.store [[VAR_30_1_]], [[LOAD_VAR_arg20_MEM_1_]] : tensor<2x2x!tt.ptr<f32>>
-// CHECK:                   [[VAR_31_:%.+]] = tt.addptr [[VAR_30_1_]], [[VAR_17_3_]] : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
-// CHECK:                   [[structuredPtr_9_:%.+]], [[offsets_10_:%.+]]:2, [[VAR_strides_11_2_:%.+]]:2 = "tts.get_structured_state"([[VAR_27_2_]]) <{resultSegmentSizes = array<i32: 1, 2, 2>}> : (tensor<2x2x!tt.ptr<f32>>) -> (tensor<2x2x!tt.ptr<f32>>, index, index, index, index)
-// CHECK:                   [[structuredPtr_12_:%.+]], [[offsets_13_:%.+]]:2, [[VAR_strides_14_2_:%.+]]:2 = "tts.get_structured_state"([[VAR_31_]]) <{resultSegmentSizes = array<i32: 1, 2, 2>}> : (tensor<2x2x!tt.ptr<f32>>) -> (tensor<2x2x!tt.ptr<f32>>, index, index, index, index)
-// CHECK:                   scf.yield [[structuredPtr_9_]], [[offsets_10_]]#0, [[offsets_10_]]#1, [[VAR_strides_11_2_]]#0, [[VAR_strides_11_2_]]#1, [[structuredPtr_12_]], [[offsets_13_]]#0, [[offsets_13_]]#1, [[VAR_strides_14_2_]]#0, [[VAR_strides_14_2_]]#1 : tensor<2x2x!tt.ptr<f32>>, index, index, index, index, tensor<2x2x!tt.ptr<f32>>, index, index, index, index
-// CHECK:                 }
-// CHECK:                 scf.yield [[VAR_26_3_]]#0, [[VAR_26_3_]]#1, [[VAR_26_3_]]#2, [[VAR_26_3_]]#3, [[VAR_26_3_]]#4, [[VAR_26_3_]]#5, [[VAR_26_3_]]#6, [[VAR_26_3_]]#7, [[VAR_26_3_]]#8, [[VAR_26_3_]]#9 : tensor<2x2x!tt.ptr<f32>>, index, index, index, index, tensor<2x2x!tt.ptr<f32>>, index, index, index, index
-// CHECK:               }
-// CHECK:               [[VAR_23_3_:%.+]] = tt.addptr [[VAR_22_3_]]#0, [[VAR_19_2_]] : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
-// CHECK:               [[structuredPtr_3_:%.+]], [[offsets_4_:%.+]]:2, [[VAR_strides_5_3_:%.+]]:2 = "tts.get_structured_state"([[VAR_23_3_]]) <{resultSegmentSizes = array<i32: 1, 2, 2>}> : (tensor<2x2x!tt.ptr<f32>>) -> (tensor<2x2x!tt.ptr<f32>>, index, index, index, index)
-// CHECK:               scf.yield [[structuredPtr_3_]], [[offsets_4_]]#0, [[offsets_4_]]#1, [[VAR_strides_5_3_]]#0, [[VAR_strides_5_3_]]#1, [[VAR_22_3_]]#5, [[VAR_22_3_]]#6, [[VAR_22_3_]]#7, [[VAR_22_3_]]#8, [[VAR_22_3_]]#9 : tensor<2x2x!tt.ptr<f32>>, index, index, index, index, tensor<2x2x!tt.ptr<f32>>, index, index, index, index
-// CHECK:             }
-// CHECK:             tt.return
-// CHECK:           }
+// CHECK-COUNT-6: tts.get_structured_state
+// CHECK-NOT: tts.get_structured_state

--- a/tools/triton-shared-opt/CMakeLists.txt
+++ b/tools/triton-shared-opt/CMakeLists.txt
@@ -12,8 +12,6 @@ target_link_libraries(triton-shared-opt PRIVATE
   ${dialect_libs}
   ${conversion_libs}
   ${triton_libs}
-  # tests
-  # TritonTestAnalysis
   # MLIR core
   MLIROptLib
   MLIRPass

--- a/tools/triton-shared-opt/CMakeLists.txt
+++ b/tools/triton-shared-opt/CMakeLists.txt
@@ -1,5 +1,6 @@
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
+get_property(triton_libs GLOBAL PROPERTY TRITON_LIBS)
 
 add_llvm_executable(triton-shared-opt triton-shared-opt.cpp PARTIAL_SOURCES_INTENDED)
 
@@ -10,8 +11,9 @@ target_link_libraries(triton-shared-opt PRIVATE
   TritonSharedAnalysis
   ${dialect_libs}
   ${conversion_libs}
+  ${triton_libs}
   # tests
-  TritonTestAnalysis
+  # TritonTestAnalysis
   # MLIR core
   MLIROptLib
   MLIRPass

--- a/tools/triton-shared-opt/RegisterTritonSharedDialects.h
+++ b/tools/triton-shared-opt/RegisterTritonSharedDialects.h
@@ -6,9 +6,8 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Ptr/IR/PtrDialect.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
-#include "triton-shared/Conversion/StructuredToMemref/Passes.h"
-#include "triton/Dialect/Triton/IR/Dialect.h"
 
+#include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/Triton/Transforms/Passes.h"
 
 #include "triton-shared/Conversion/StructuredToMemref/Passes.h"
@@ -25,23 +24,10 @@
 
 #include "mlir/InitAllPasses.h"
 
-namespace mlir {
-namespace test {
-void registerTestAliasPass();
-void registerTestAlignmentPass();
-void registerTestAllocationPass();
-void registerTestMembarPass();
-} // namespace test
-} // namespace mlir
-
 inline void registerTritonSharedDialects(mlir::DialectRegistry &registry) {
   mlir::registerAllPasses();
-  mlir::registerTritonPasses();
   mlir::registerLinalgPasses();
-  mlir::test::registerTestAliasPass();
-  mlir::test::registerTestAlignmentPass();
-  mlir::test::registerTestAllocationPass();
-  mlir::test::registerTestMembarPass();
+  mlir::triton::registerTritonPasses();
   mlir::triton::registerTritonToLinalgPass();
   mlir::triton::registerTritonToLinalgExperimentalPass();
   mlir::triton::registerTritonToStructuredPass();


### PR DESCRIPTION
- Fixed linker issue where `triton_libs` is missing as a dependency in triton-shared-opt
- Fixed the signature for pointer dialect attribute
- Updated triton-to-structured pass to use the default conversion infra (one-to-N is deprecated and its features have been merged to the original conversion driver)
  - After this update, fixed a bug in the update iter-arg code to consider all loop init-args because a value could be used in the loop init-args multiple times. The new mlir conversion driver code exposed this bug because now the `tts.get_structured_state` is only created once for each unique value.