### PR TITLE
Skip i1 tensor in structured state tuple conversion

### DIFF
--- a/lib/Conversion/TritonToStructured/TritonToStructuredPass.cpp
+++ b/lib/Conversion/TritonToStructured/TritonToStructuredPass.cpp
@@ -93,31 +93,31 @@ public:
       auto elementType = tensorType.getElementType();
       if (isa<triton::PointerType>(elementType) ||
           (elementType.isIntOrIndex() && !elementType.isInteger(1))) {
-        // There's a subtle difference between returning failure() and
-        // std::nullopt. From the documentation:
-        //
-        // If std::nullopt is returned, the converter is allowed to try another
-        // conversion function to perform the conversion.
-        //
-        // Say we have type tensor<4x256xbf16> which is a RankedTensorType. Even
-        // though this RankedTensorType matches the converter that handles the
-        // tuple conversion, we want to keep this type as is because the inner
-        // type isn't a pointer.
-        //
-        // By returning failure(), the TypeConverters will stop trying the
-        // remaining converters. In our case, the last type converter which
-        // simply returns the same type is skipped. And because the conversion
-        // for this type has failed, the whole conversion process is also
-        // skipped.
-        //
-        // Relevant links to the implementation:
-        //
-        // https://github.com/llvm/llvm-project/blob/cb5dc1faa8b3702e0d03426ee5dfc5e1b903ec47/mlir/lib/Transforms/Utils/DialectConversion.cpp#L2958
-        // https://github.com/llvm/llvm-project/blob/cb5dc1faa8b3702e0d03426ee5dfc5e1b903ec47/mlir/lib/Transforms/Utils/DialectConversion.cpp#L3033
         types =
             SmallVector<Type>{getStructuredStateTupleType(context, tensorType)};
         return success();
       }
+      // There's a subtle difference between returning failure() and
+      // std::nullopt. From the documentation:
+      //
+      // If std::nullopt is returned, the converter is allowed to try another
+      // conversion function to perform the conversion.
+      //
+      // Say we have type tensor<4x256xbf16> which is a RankedTensorType. Even
+      // though this RankedTensorType matches the converter that handles the
+      // tuple conversion, we want to keep this type as is because the inner
+      // type isn't a pointer.
+      //
+      // By returning failure(), the TypeConverters will stop trying the
+      // remaining converters. In our case, the last type converter which
+      // simply returns the same type is skipped. And because the conversion
+      // for this type has failed, the whole conversion process is also
+      // skipped.
+      //
+      // Relevant links to the implementation:
+      //
+      // https://github.com/llvm/llvm-project/blob/cb5dc1faa8b3702e0d03426ee5dfc5e1b903ec47/mlir/lib/Transforms/Utils/DialectConversion.cpp#L2958
+      // https://github.com/llvm/llvm-project/blob/cb5dc1faa8b3702e0d03426ee5dfc5e1b903ec47/mlir/lib/Transforms/Utils/DialectConversion.cpp#L3033
       return std::nullopt;
     });
 


### PR DESCRIPTION
Skip tensor of i1 element type in `convertToPointerTupleWithOffsetsAndStrides` in the prepass of `TritonToStructured`, this solves pass failure in `test_accuracy_all_dims[dtype0-normal-True-1-shape0]` test case of [FlagGems all op](https://github.com/FlagOpen/FlagGems/blob/master/src/flag_gems/ops/all.py).

