### PR TITLE
Handle mix of structured and unstructured accesses in loops

### DIFF
--- a/lib/Conversion/TritonToLinalgExperimental/TritonToLinalgExperimentalPass.cpp
+++ b/lib/Conversion/TritonToLinalgExperimental/TritonToLinalgExperimentalPass.cpp
@@ -67,7 +67,7 @@ public:
     pm.addPass(createReconcileUnrealizedCastsPass());
     pm.addPass(createReconcilePtrCastsPass());
 
-    // Now that remove-dead-values fully work with linalg ops, clean up the IR
+    // Now that remove-dead-values fully works with linalg ops, clean up the IR
     // again, particularly unused loop iter-args that were created
     // during triton-to-structured.
     pm.addPass(createRemoveDeadValuesPass());

--- a/lib/Conversion/TritonToLinalgExperimental/TritonToLinalgExperimentalPass.cpp
+++ b/lib/Conversion/TritonToLinalgExperimental/TritonToLinalgExperimentalPass.cpp
@@ -60,15 +60,6 @@ public:
     pm.addPass(createTritonToUnstructuredPass());
     pm.addPass(createTritonArithToLinalgPass(/*tensorPtrToLinalg=*/true));
 
-    // TODO: structured-to-memref converts the loop iter-args to memref, while
-    // triton-to-ptr converts the loop iter-args to ptr. These two passes might
-    // end up conflicting with each other in cases where we have a mixed of
-    // structured and unstructured accesses. Fortunately, the structured ops do
-    // not need to use the loop iter-args at all (see code in PtrAnalysis.cpp),
-    // so if we run remove-dead-values after structured-to-memref, the memref
-    // iter-args that are used in structured loads and stores should be removed.
-    // Running this now may be too invasive and cause many IR changes, so
-    // leave as a TODO for now.
     pm.addPass(createStructuredToMemrefPass());
     pm.addPass(createUnstructuredToMemrefPass());
     pm.addPass(createTritonPtrToMemrefPass());
@@ -76,6 +67,9 @@ public:
     pm.addPass(createReconcileUnrealizedCastsPass());
     pm.addPass(createReconcilePtrCastsPass());
 
+    // Now that remove-dead-values fully work with linalg ops, clean up the IR
+    // again, particularly unused loop iter-args that were created
+    // during triton-to-structured.
     pm.addPass(createRemoveDeadValuesPass());
     pm.addPass(createCSEPass());
     pm.addPass(createCanonicalizerPass());

--- a/lib/Conversion/TritonToLinalgExperimental/TritonToLinalgExperimentalPass.cpp
+++ b/lib/Conversion/TritonToLinalgExperimental/TritonToLinalgExperimentalPass.cpp
@@ -76,6 +76,7 @@ public:
     pm.addPass(createReconcileUnrealizedCastsPass());
     pm.addPass(createReconcilePtrCastsPass());
 
+    pm.addPass(createRemoveDeadValuesPass());
     pm.addPass(createCSEPass());
     pm.addPass(createCanonicalizerPass());
 

--- a/test/Conversion/StructuredToMemref/addptr_scalar_for.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_scalar_for.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
+// RUN: triton-shared-opt --triton-to-linalg-experimental %s | FileCheck %s
 module {
   tt.func @kernel (%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: i32, %arg3: i32, %arg4: i32) {
     %0 = tt.get_program_id x : i32
@@ -47,7 +47,7 @@ module {
 // CHECK-DAG:       [[VAR_1_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[VAR_0_]] : tensor<1024xf32>) -> tensor<1024xf32>
 // CHECK-DAG:       [[VAR_2_:%.+]] = arith.muli [[PARAM_8_]], [[PARAM_2_]] : i32
 // CHECK:           [[VAR_3_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
-// CHECK-DAG:       [[VAR_4_:%.+]]:3 = scf.for [[VAR_arg11_:%.+]] = [[CST_0_]] to [[CST_12_]] step [[CST_3_]] iter_args([[VAR_arg12_:%.+]] = [[VAR_2_]], [[VAR_arg13_:%.+]] = [[VAR_3_]], [[VAR_arg14_:%.+]] = [[VAR_1_]]) -> (i32, index, tensor<1024xf32>) {
+// CHECK-DAG:       [[VAR_4_:%.+]]:2 = scf.for [[VAR_arg11_:%.+]] = [[CST_0_]] to [[CST_12_]] step [[CST_3_]] iter_args([[VAR_arg13_:%.+]] = [[VAR_3_]], [[VAR_arg14_:%.+]] = [[VAR_1_]]) -> (index, tensor<1024xf32>) {
 // CHECK-DAG:         [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_arg13_]]{{.}}, sizes: [1024], strides: [1] : memref<*xf32> to memref<1024xf32, strided<[1], offset: ?>>
 // CHECK-DAG:         [[RES_:%.+]] = memref.alloc() : memref<1024xf32>
 // CHECK:             memref.copy [[VAR_reinterpret_cast_0_]], [[RES_]] : memref<1024xf32, strided<[1], offset: ?>> to memref<1024xf32>
@@ -62,14 +62,12 @@ module {
 // CHECK:               [[VAR_13_1_:%.+]] = arith.addf [[IN_2_]], [[IN_3_]] : f32
 // CHECK:               linalg.yield [[VAR_13_1_]] : f32
 // CHECK:             } -> tensor<1024xf32>
-// CHECK-DAG:         [[VAR_10_:%.+]] = arith.index_cast [[VAR_arg11_]] : index to i32
 // CHECK-DAG:         [[VAR_11_:%.+]] = arith.addi [[VAR_arg13_]], [[VAR_arg11_]] : index
-// CHECK:             [[VAR_12_:%.+]] = arith.addi [[VAR_arg12_]], [[VAR_10_]] : i32
-// CHECK:             scf.yield [[VAR_12_]], [[VAR_11_]], [[VAR_9_]] : i32, index, tensor<1024xf32>
+// CHECK:             scf.yield [[VAR_11_]], [[VAR_9_]] : index, tensor<1024xf32>
 // CHECK:           }
 // CHECK:           [[VAR_5_:%.+]] = arith.muli [[PARAM_8_]], [[PARAM_3_]] : i32
 // CHECK:           [[VAR_6_:%.+]] = arith.index_cast [[VAR_5_]] : i32 to index
 // CHECK:           [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_6_]]{{.}}, sizes: [1024], strides: [1] : memref<*xf32> to memref<1024xf32, strided<[1], offset: ?>>
-// CHECK:           bufferization.materialize_in_destination [[VAR_4_]]#2 in writable [[VAR_reinterpret_cast_]] : (tensor<1024xf32>, memref<1024xf32, strided<[1], offset: ?>>) -> ()
+// CHECK:           bufferization.materialize_in_destination [[VAR_4_]]#1 in writable [[VAR_reinterpret_cast_]] : (tensor<1024xf32>, memref<1024xf32, strided<[1], offset: ?>>) -> ()
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/StructuredToMemref/addptr_scalar_for_2d.mlir
+++ b/test/Conversion/StructuredToMemref/addptr_scalar_for_2d.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
+// RUN: triton-shared-opt --triton-to-linalg-experimental %s | FileCheck %s
 module {
   tt.func @kernel (%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: i32, %arg3: i32, %arg4: i32) {
     %0 = tt.get_program_id x : i32
@@ -67,7 +67,7 @@ module {
 // CHECK-DAG:       [[VAR_1_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[VAR_0_]] : tensor<128x128xf32>) -> tensor<128x128xf32>
 // CHECK-DAG:       [[VAR_2_:%.+]] = arith.muli [[PARAM_8_]], [[PARAM_2_]] : i32
 // CHECK:           [[VAR_3_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
-// CHECK-DAG:       [[VAR_4_:%.+]]:3 = scf.for [[VAR_arg11_:%.+]] = [[CST_0_]] to [[CST_12_]] step [[CST_3_]] iter_args([[VAR_arg12_:%.+]] = [[VAR_1_]], [[VAR_arg13_:%.+]] = [[VAR_2_]], [[VAR_arg14_:%.+]] = [[VAR_3_]]) -> (tensor<128x128xf32>, i32, index) {
+// CHECK-DAG:       [[VAR_4_:%.+]]:2 = scf.for [[VAR_arg11_:%.+]] = [[CST_0_]] to [[CST_12_]] step [[CST_3_]] iter_args([[VAR_arg12_:%.+]] = [[VAR_1_]], [[VAR_arg14_:%.+]] = [[VAR_3_]]) -> (tensor<128x128xf32>, index) {
 // CHECK-DAG:         [[VAR_8_:%.+]] = arith.addi [[VAR_arg14_]], [[CST_128_]] : index
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:         [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_8_]]{{.}}, sizes: [128, 128], strides: [1, 1] : memref<*xf32> to memref<128x128xf32, strided<[1, 1], offset: ?>>
@@ -84,10 +84,8 @@ module {
 // CHECK:               [[VAR_15_1_:%.+]] = arith.addf [[IN_2_]], [[IN_3_]] : f32
 // CHECK:               linalg.yield [[VAR_15_1_]] : f32
 // CHECK:             } -> tensor<128x128xf32>
-// CHECK-DAG:         [[VAR_12_:%.+]] = arith.index_cast [[VAR_arg11_]] : index to i32
 // CHECK-DAG:         [[VAR_13_:%.+]] = arith.addi [[VAR_arg14_]], [[VAR_arg11_]] : index
-// CHECK:             [[VAR_14_:%.+]] = arith.addi [[VAR_arg13_]], [[VAR_12_]] : i32
-// CHECK:             scf.yield [[VAR_11_]], [[VAR_14_]], [[VAR_13_]] : tensor<128x128xf32>, i32, index
+// CHECK:             scf.yield [[VAR_11_]], [[VAR_13_]] : tensor<128x128xf32>, index
 // CHECK:           }
 // CHECK:           [[VAR_5_:%.+]] = arith.muli [[PARAM_8_]], [[PARAM_3_]] : i32
 // CHECK:           [[VAR_6_:%.+]] = arith.index_cast [[VAR_5_]] : i32 to index

--- a/test/Conversion/StructuredToMemref/nested_loops.mlir
+++ b/test/Conversion/StructuredToMemref/nested_loops.mlir
@@ -182,6 +182,4 @@ module {
 // CHECK-NOT: tt.addptr
 // CHECK-NOT: tt.load
 // CHECK-NOT: tt.store
-
-// CHECK-COUNT-20: memref.reinterpret_cast %arg{{[0-9]+}}
-// CHECK-NOT: memref.reinterpret_cast %arg{{[0-9]+}}
+// CHECK-NOT: unrealized_conversion_cast

--- a/test/Conversion/StructuredToMemref/ridiculously_nested_loops.mlir
+++ b/test/Conversion/StructuredToMemref/ridiculously_nested_loops.mlir
@@ -159,6 +159,4 @@ module {
 // CHECK-NOT: tt.addptr
 // CHECK-NOT: tt.load
 // CHECK-NOT: tt.store
-
-// CHECK-COUNT-43: memref.reinterpret_cast %arg{{[0-9]+}}
-// CHECK-NOT: memref.reinterpret_cast %arg{{[0-9]+}}
+// CHECK-NOT: unrealized_conversion_cast

--- a/test/Conversion/StructuredToMemref/scalar_store_loop_iterargs.mlir
+++ b/test/Conversion/StructuredToMemref/scalar_store_loop_iterargs.mlir
@@ -25,18 +25,14 @@ module {
 // CHECK-DAG:       [[CST_5_:%.+]] = arith.constant 5 : i32
 // CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : i32
 // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : i32
-// CHECK-DAG:       [[VAR_0_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
 // CHECK-DAG:       [[VAR_1_:%.+]] = arith.sitofp [[PARAM_7_]] : i32 to f32
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_2_:%.+]]:3 = scf.for [[VAR_arg16_:%.+]] = [[CST_0_]] to [[CST_5_]] step [[CST_1_]] iter_args([[VAR_arg17_:%.+]] = [[PARAM_7_]], [[VAR_arg18_:%.+]] = [[VAR_0_]], [[VAR_arg19_:%.+]] = [[VAR_0_]]) -> (i32, index, index)  : i32 {
+// CHECK-DAG:       [[VAR_2_:%.+]] = scf.for [[VAR_arg16_:%.+]] = [[CST_0_]] to [[CST_5_]] step [[CST_1_]] iter_args([[VAR_arg17_:%.+]] = [[PARAM_7_]]) -> (i32)  : i32 {
 // CHECK-DAG:         [[VAR_3_:%.+]] = arith.index_cast [[VAR_arg17_]] : i32 to index
 // CHECK:             [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_3_]]{{.}}, sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
 // CHECK:             memref.store [[VAR_1_]], [[VAR_reinterpret_cast_]][%[[C0]]] : memref<1xf32, strided<[1], offset: ?>>
-// CHECK:             [[VAR_4_:%.+]] = arith.index_cast [[VAR_arg16_]] : i32 to index
-// CHECK-DAG:         [[VAR_5_:%.+]] = arith.addi [[VAR_arg18_]], [[VAR_4_]] : index
 // CHECK-DAG:         [[VAR_6_:%.+]] = arith.addi [[VAR_arg17_]], [[VAR_arg16_]] : i32
-// CHECK-DAG:         [[VAR_7_:%.+]] = arith.addi [[VAR_arg19_]], [[VAR_4_]] : index
-// CHECK:             scf.yield [[VAR_6_]], [[VAR_5_]], [[VAR_7_]] : i32, index, index
+// CHECK:             scf.yield [[VAR_6_]] : i32
 // CHECK:           }
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/StructuredToMemref/scalar_store_nested_loop.mlir
+++ b/test/Conversion/StructuredToMemref/scalar_store_nested_loop.mlir
@@ -24,26 +24,22 @@ module {
 // CHECK-LABEL:  func.func @reduce_kernel_2d_0d
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32> {tt.divisibility = 16 : i32}, [[PARAM_1_:%.+]]: i32, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32, [[PARAM_10_:%.+]]: i32, [[PARAM_11_:%.+]]: i32, [[PARAM_12_:%.+]]: i32) {
 // CHECK-DAG:      %[[C0:.*]] = arith.constant 0 : index
-// CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : index
 // CHECK-DAG:       [[CST_1_1_:%.+]] = arith.constant 1 : i32
 // CHECK-DAG:       [[CST_8_:%.+]] = arith.constant 8 : i32
 // CHECK-DAG:       [[CST_2_:%.+]] = arith.constant 2 : i32
 // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : i32
-// CHECK-DAG:       [[VAR_0_:%.+]] = arith.index_cast [[PARAM_4_]] : i32 to index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_1_:%.+]]:2 = scf.for [[VAR_arg13_:%.+]] = [[CST_0_]] to [[CST_8_]] step [[CST_1_1_]] iter_args([[VAR_arg14_:%.+]] = [[PARAM_4_]], [[VAR_arg15_:%.+]] = [[VAR_0_]]) -> (i32, index)  : i32 {
-// CHECK-DAG:         [[VAR_2_:%.+]]:2 = scf.for [[VAR_arg16_:%.+]] = [[CST_0_]] to [[CST_2_]] step [[CST_1_1_]] iter_args([[VAR_arg17_:%.+]] = [[VAR_arg14_]], [[VAR_arg18_:%.+]] = [[VAR_arg15_]]) -> (i32, index)  : i32 {
+// CHECK-DAG:       [[VAR_1_:%.+]] = scf.for [[VAR_arg13_:%.+]] = [[CST_0_]] to [[CST_8_]] step [[CST_1_1_]] iter_args([[VAR_arg14_:%.+]] = [[PARAM_4_]]) -> (i32)  : i32 {
+// CHECK-DAG:         [[VAR_2_:%.+]] = scf.for [[VAR_arg16_:%.+]] = [[CST_0_]] to [[CST_2_]] step [[CST_1_1_]] iter_args([[VAR_arg17_:%.+]] = [[VAR_arg14_]]) -> (i32)  : i32 {
 // CHECK-DAG:           [[VAR_3_:%.+]] = arith.muli [[VAR_arg13_]], [[VAR_arg16_]] : i32
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:           [[VAR_4_:%.+]] = arith.sitofp [[VAR_3_]] : i32 to f32
 // CHECK-DAG:           [[VAR_5_:%.+]] = arith.index_cast [[VAR_arg17_]] : i32 to index
 // CHECK:               [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_5_]]{{.}}, sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
 // CHECK:               memref.store [[VAR_4_]], [[VAR_reinterpret_cast_]][%[[C0]]] : memref<1xf32, strided<[1], offset: ?>>
-// CHECK-DAG:           [[VAR_6_:%.+]] = arith.addi [[VAR_arg18_]], [[CST_1_]] : index
-// CHECK-DAG:           [[VAR_7_:%.+]] = arith.addi [[VAR_arg17_]], [[CST_1_1_]] : i32
-// CHECK:               scf.yield [[VAR_7_]], [[VAR_6_]] : i32, index
+// CHECK:              [[VAR_7_:%.+]] = arith.addi [[VAR_arg17_]], [[CST_1_1_]] : i32
+// CHECK:               scf.yield [[VAR_7_]] : i32
 // CHECK:             }
-// CHECK:             scf.yield [[VAR_2_]]#0, [[VAR_2_]]#1 : i32, index
+// CHECK:             scf.yield [[VAR_2_]] : i32
 // CHECK:           }
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/StructuredToMemref/tensor_indices_loop_iterargs_nested.mlir
+++ b/test/Conversion/StructuredToMemref/tensor_indices_loop_iterargs_nested.mlir
@@ -39,86 +39,43 @@ module {
   }
 }
 
-// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
 // CHECK-LABEL:  func.func @tensor_indices_nested
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32) {
-// CHECK-DAG:       [[CST_4_:%.+]] = arith.constant 4 : i32
 // CHECK-DAG:       [[CST_3_:%.+]] = arith.constant 3 : i32
 // CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : i32
 // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
-// CHECK-DAG:       [[CST_4_1_:%.+]] = arith.constant 4 : index
+// CHECK-DAG:       [[CST_4_:%.+]] = arith.constant 4 : index
 // CHECK-DAG:       [[CST_0_1_:%.+]] = arith.constant 0 : i32
 // CHECK-DAG:       [[CST_2_:%.+]] = arith.constant 2 : i32
-// CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<4xi32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_1_:%.+]] = linalg.fill ins([[CST_4_]] : i32) outs([[VAR_0_]] : tensor<4xi32>) -> tensor<4xi32>
-// CHECK-DAG:       [[VAR_2_:%.+]] = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel"]} outs([[VAR_0_]] : tensor<4xi32>) {
-// CHECK:           ^bb0([[IN_0_:%.+]]: i32):
-// CHECK:             [[VAR_4_:%.+]] = linalg.index 0 : index
-// CHECK:             [[VAR_5_:%.+]] = arith.index_cast [[VAR_4_]] : index to i32
-// CHECK:             linalg.yield [[VAR_5_]] : i32
-// CHECK:           } -> tensor<4xi32>
-// CHECK-DAG:       [[VAR_3_:%.+]]:4 = scf.for [[VAR_arg8_:%.+]] = [[CST_0_1_]] to [[CST_2_]] step [[CST_1_]] iter_args([[VAR_arg9_:%.+]] = [[VAR_2_]], [[VAR_arg10_:%.+]] = [[CST_0_]], [[VAR_arg11_:%.+]] = [[VAR_2_]], [[VAR_arg12_:%.+]] = [[CST_0_]]) -> (tensor<4xi32>, index, tensor<4xi32>, index)  : i32 {
-// CHECK-DAG:         [[VAR_4_1_:%.+]] = arith.muli [[VAR_arg8_]], [[CST_2_]] : i32
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_5_1_:%.+]] = arith.index_cast [[VAR_4_1_]] : i32 to index
-// CHECK-DAG:         [[VAR_6_:%.+]] = linalg.fill ins([[VAR_4_1_]] : i32) outs([[VAR_0_]] : tensor<4xi32>) -> tensor<4xi32>
-// CHECK:             [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_arg9_]], [[VAR_6_]] : tensor<4xi32>, tensor<4xi32>) outs([[VAR_arg9_]] : tensor<4xi32>) {
-// CHECK:             ^bb0([[IN_1_:%.+]]: i32, [[IN_2_:%.+]]: i32, [[IN_3_:%.+]]: i32):
-// CHECK:               [[VAR_15_:%.+]] = arith.addi [[IN_1_]], [[IN_2_]] : i32
-// CHECK:               linalg.yield [[VAR_15_]] : i32
-// CHECK:             } -> tensor<4xi32>
-// CHECK:             [[VAR_8_:%.+]] = arith.addi [[VAR_arg10_]], [[VAR_5_1_]] : index
-// CHECK-DAG:         [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_8_]]{{.}}, sizes: [4], strides: [1] : memref<*xf32> to memref<4xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_0_:%.+]]:2 = scf.for [[VAR_arg8_:%.+]] = [[CST_0_1_]] to [[CST_2_]] step [[CST_1_]] iter_args([[VAR_arg9_:%.+]] = [[CST_0_]], [[VAR_arg10_:%.+]] = [[CST_0_]]) -> (index, index)  : i32 {
+// CHECK-DAG:         [[VAR_1_:%.+]] = arith.muli [[VAR_arg8_]], [[CST_2_]] : i32
+// CHECK:             [[VAR_2_:%.+]] = arith.index_cast [[VAR_1_]] : i32 to index
+// CHECK:             [[VAR_3_:%.+]] = arith.addi [[VAR_arg9_]], [[VAR_2_]] : index
+// CHECK-DAG:         [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_3_]]{{.}}, sizes: [4], strides: [1] : memref<*xf32> to memref<4xf32, strided<[1], offset: ?>>
 // CHECK-DAG:         [[RES_:%.+]] = memref.alloc() : memref<4xf32>
 // CHECK:             memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<4xf32, strided<[1], offset: ?>> to memref<4xf32>
-// CHECK-DAG:         [[VAR_9_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<4xf32> to tensor<4xf32>
-// CHECK-DAG:         [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_arg12_]]{{.}}, sizes: [4], strides: [1] : memref<*xf32> to memref<4xf32, strided<[1], offset: ?>>
-// CHECK:             bufferization.materialize_in_destination [[VAR_9_]] in writable [[VAR_reinterpret_cast_0_]] : (tensor<4xf32>, memref<4xf32, strided<[1], offset: ?>>) -> ()
-// CHECK:             [[VAR_10_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_7_]], [[VAR_1_]] : tensor<4xi32>, tensor<4xi32>) outs([[VAR_7_]] : tensor<4xi32>) {
-// CHECK:             ^bb0([[IN_4_:%.+]]: i32, [[IN_5_:%.+]]: i32, [[IN_6_:%.+]]: i32):
-// CHECK:               [[VAR_15_1_:%.+]] = arith.addi [[IN_4_]], [[IN_5_]] : i32
-// CHECK:               linalg.yield [[VAR_15_1_]] : i32
-// CHECK:             } -> tensor<4xi32>
-// CHECK-DAG:         [[VAR_11_:%.+]] = arith.addi [[VAR_8_]], [[CST_4_1_]] : index
-// CHECK-DAG:         [[VAR_12_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_arg11_]], [[VAR_1_]] : tensor<4xi32>, tensor<4xi32>) outs([[VAR_arg11_]] : tensor<4xi32>) {
-// CHECK:             ^bb0([[IN_7_:%.+]]: i32, [[IN_8_:%.+]]: i32, [[IN_9_:%.+]]: i32):
-// CHECK:               [[VAR_15_2_:%.+]] = arith.addi [[IN_7_]], [[IN_8_]] : i32
-// CHECK:               linalg.yield [[VAR_15_2_]] : i32
-// CHECK:             } -> tensor<4xi32>
-// CHECK:             [[VAR_13_:%.+]] = arith.addi [[VAR_arg12_]], [[CST_4_1_]] : index
-// CHECK-DAG:         [[VAR_14_:%.+]]:4 = scf.for [[VAR_arg13_:%.+]] = [[CST_0_1_]] to [[CST_3_]] step [[CST_1_]] iter_args([[VAR_arg14_:%.+]] = [[VAR_10_]], [[VAR_arg15_:%.+]] = [[VAR_11_]], [[VAR_arg16_:%.+]] = [[VAR_12_]], [[VAR_arg17_:%.+]] = [[VAR_13_]]) -> (tensor<4xi32>, index, tensor<4xi32>, index)  : i32 {
-// CHECK-DAG:           [[VAR_15_3_:%.+]] = arith.muli [[VAR_arg13_]], [[CST_3_]] : i32
+// CHECK-DAG:         [[VAR_4_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<4xf32> to tensor<4xf32>
+// CHECK-DAG:         [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_arg10_]]{{.}}, sizes: [4], strides: [1] : memref<*xf32> to memref<4xf32, strided<[1], offset: ?>>
+// CHECK:             bufferization.materialize_in_destination [[VAR_4_]] in writable [[VAR_reinterpret_cast_0_]] : (tensor<4xf32>, memref<4xf32, strided<[1], offset: ?>>) -> ()
+// CHECK-DAG:         [[VAR_5_:%.+]] = arith.addi [[VAR_3_]], [[CST_4_]] : index
+// CHECK-DAG:         [[VAR_6_:%.+]] = arith.addi [[VAR_arg10_]], [[CST_4_]] : index
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:           [[VAR_16_:%.+]] = arith.index_cast [[VAR_15_3_]] : i32 to index
-// CHECK-DAG:           [[VAR_17_:%.+]] = linalg.fill ins([[VAR_15_3_]] : i32) outs([[VAR_0_]] : tensor<4xi32>) -> tensor<4xi32>
-// CHECK:               [[VAR_18_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_arg14_]], [[VAR_17_]] : tensor<4xi32>, tensor<4xi32>) outs([[VAR_arg14_]] : tensor<4xi32>) {
-// CHECK:               ^bb0([[IN_10_:%.+]]: i32, [[IN_11_:%.+]]: i32, [[IN_12_:%.+]]: i32):
-// CHECK:                 [[VAR_25_:%.+]] = arith.addi [[IN_10_]], [[IN_11_]] : i32
-// CHECK:                 linalg.yield [[VAR_25_]] : i32
-// CHECK:               } -> tensor<4xi32>
-// CHECK:               [[VAR_19_:%.+]] = arith.addi [[VAR_arg15_]], [[VAR_16_]] : index
-// CHECK-DAG:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_19_]]{{.}}, sizes: [4], strides: [1] : memref<*xf32> to memref<4xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_7_:%.+]]:2 = scf.for [[VAR_arg11_:%.+]] = [[CST_0_1_]] to [[CST_3_]] step [[CST_1_]] iter_args([[VAR_arg12_:%.+]] = [[VAR_5_]], [[VAR_arg13_:%.+]] = [[VAR_6_]]) -> (index, index)  : i32 {
+// CHECK-DAG:           [[VAR_8_:%.+]] = arith.muli [[VAR_arg11_]], [[CST_3_]] : i32
+// CHECK:               [[VAR_9_:%.+]] = arith.index_cast [[VAR_8_]] : i32 to index
+// CHECK:               [[VAR_10_:%.+]] = arith.addi [[VAR_arg12_]], [[VAR_9_]] : index
+// CHECK-DAG:           [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_10_]]{{.}}, sizes: [4], strides: [1] : memref<*xf32> to memref<4xf32, strided<[1], offset: ?>>
 // CHECK-DAG:           [[RES_1_:%.+]] = memref.alloc() : memref<4xf32>
 // CHECK:               memref.copy [[VAR_reinterpret_cast_1_]], [[RES_1_]] : memref<4xf32, strided<[1], offset: ?>> to memref<4xf32>
-// CHECK-DAG:           [[VAR_20_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<4xf32> to tensor<4xf32>
-// CHECK-DAG:           [[VAR_reinterpret_cast_3_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_arg17_]]{{.}}, sizes: [4], strides: [1] : memref<*xf32> to memref<4xf32, strided<[1], offset: ?>>
-// CHECK:               bufferization.materialize_in_destination [[VAR_20_]] in writable [[VAR_reinterpret_cast_3_]] : (tensor<4xf32>, memref<4xf32, strided<[1], offset: ?>>) -> ()
-// CHECK:               [[VAR_21_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_18_]], [[VAR_1_]] : tensor<4xi32>, tensor<4xi32>) outs([[VAR_18_]] : tensor<4xi32>) {
-// CHECK:               ^bb0([[IN_13_:%.+]]: i32, [[IN_14_:%.+]]: i32, [[IN_15_:%.+]]: i32):
-// CHECK:                 [[VAR_25_1_:%.+]] = arith.addi [[IN_13_]], [[IN_14_]] : i32
-// CHECK:                 linalg.yield [[VAR_25_1_]] : i32
-// CHECK:               } -> tensor<4xi32>
-// CHECK-DAG:           [[VAR_22_:%.+]] = arith.addi [[VAR_19_]], [[CST_4_1_]] : index
-// CHECK-DAG:           [[VAR_23_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_arg16_]], [[VAR_1_]] : tensor<4xi32>, tensor<4xi32>) outs([[VAR_arg16_]] : tensor<4xi32>) {
-// CHECK:               ^bb0([[IN_16_:%.+]]: i32, [[IN_17_:%.+]]: i32, [[IN_18_:%.+]]: i32):
-// CHECK:                 [[VAR_25_2_:%.+]] = arith.addi [[IN_16_]], [[IN_17_]] : i32
-// CHECK:                 linalg.yield [[VAR_25_2_]] : i32
-// CHECK:               } -> tensor<4xi32>
-// CHECK:               [[VAR_24_:%.+]] = arith.addi [[VAR_arg17_]], [[CST_4_1_]] : index
-// CHECK:               scf.yield [[VAR_21_]], [[VAR_22_]], [[VAR_23_]], [[VAR_24_]] : tensor<4xi32>, index, tensor<4xi32>, index
+// CHECK-DAG:           [[VAR_11_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<4xf32> to tensor<4xf32>
+// CHECK-DAG:           [[VAR_reinterpret_cast_3_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_arg13_]]{{.}}, sizes: [4], strides: [1] : memref<*xf32> to memref<4xf32, strided<[1], offset: ?>>
+// CHECK:               bufferization.materialize_in_destination [[VAR_11_]] in writable [[VAR_reinterpret_cast_3_]] : (tensor<4xf32>, memref<4xf32, strided<[1], offset: ?>>) -> ()
+// CHECK-DAG:           [[VAR_12_:%.+]] = arith.addi [[VAR_10_]], [[CST_4_]] : index
+// CHECK-DAG:           [[VAR_13_:%.+]] = arith.addi [[VAR_arg13_]], [[CST_4_]] : index
+// CHECK:               scf.yield [[VAR_12_]], [[VAR_13_]] : index, index
 // CHECK:             }
-// CHECK:             scf.yield [[VAR_14_]]#0, [[VAR_14_]]#1, [[VAR_14_]]#2, [[VAR_14_]]#3 : tensor<4xi32>, index, tensor<4xi32>, index
+// CHECK:             scf.yield [[VAR_7_]]#0, [[VAR_7_]]#1 : index, index
 // CHECK:           }
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/TritonToLinalgExperimental/conditional_ptr_as_src_for_yield_input.mlir
+++ b/test/Conversion/TritonToLinalgExperimental/conditional_ptr_as_src_for_yield_input.mlir
@@ -1,7 +1,7 @@
 // RUN: triton-shared-opt --triton-to-linalg-experimental %s | FileCheck %s
 
 module attributes {} {
-  tt.func public @gather_kernel(%arg0: !tt.ptr<i64> { tt.divisibility = 16 : i32}, %arg1: !tt.ptr<i64> { tt.divisibility = 16 : i32}, %arg2: !tt.ptr<i64> { tt.divisibility = 16 : i32}, %arg3: i32 {tt.divisibility = 16 : i32}, %arg4: i32 {tt.divisibility = 16 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}, %arg6: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+  tt.func public @gather_kernel(%arg0: !tt.ptr<i64>, %arg1: !tt.ptr<i64>, %arg2: !tt.ptr<i64>, %arg3: i32 , %arg4: i32 , %arg5: i32 , %arg6: i32) {
     %c0_i32 = arith.constant 0 : i32
     %0 = tt.get_program_id x : i32
     %1 = tt.make_range {end = 512 : i32, start = 0 : i32} : tensor<512xi32>
@@ -37,111 +37,5 @@ module attributes {} {
   }
 }
 
-// CHECK: #[[$ATTR_0:.+]] = affine_map<(d0) -> (d0)>
-// CHECK-LABEL:   func.func @gather_kernel(
-// CHECK-SAME:                             %[[VAL_0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<*xi64> {tt.divisibility = 16 : i32},
-// CHECK-SAME:                             %[[VAL_1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<*xi64> {tt.divisibility = 16 : i32},
-// CHECK-SAME:                             %[[VAL_2:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<*xi64> {tt.divisibility = 16 : i32},
-// CHECK-SAME:                             %[[VAL_3:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32 {tt.divisibility = 16 : i32},
-// CHECK-SAME:                             %[[VAL_4:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32 {tt.divisibility = 16 : i32},
-// CHECK-SAME:                             %[[VAL_5:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32 {tt.divisibility = 16 : i32},
-// CHECK-SAME:                             %[[VAL_6:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32 {tt.divisibility = 16 : i32},
-// CHECK-SAME:                             %[[VAL_7:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
-// CHECK-SAME:                             %[[VAL_8:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
-// CHECK-SAME:                             %[[VAL_9:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
-// CHECK-SAME:                             %[[VAL_10:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
-// CHECK-SAME:                             %[[VAL_11:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
-// CHECK-SAME:                             %[[VAL_12:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32) {
-// CHECK:           %[[VAL_13:.*]] = arith.constant 0 : i64
-// CHECK:           %[[VAL_14:.*]] = tptr.type_offset i64  : i32
-// CHECK:           %[[VAL_15:.*]] = tptr.type_offset i64  : i64
-// CHECK:           %[[VAL_16:.*]] = arith.constant 512 : index
-// CHECK:           %[[VAL_17:.*]] = arith.constant 0 : index
-// CHECK:           %[[VAL_18:.*]] = arith.constant 0 : i32
-// CHECK:           %[[VAL_19:.*]] = memref.cast %[[VAL_0]] : memref<*xi64> to memref<1xi64>
-// CHECK:           %[[VAL_20:.*]] = tptr.from_memref %[[VAL_19]] : memref<1xi64> to <#{{.*}}>
-// CHECK:           %[[VAL_21:.*]] = tensor.empty() : tensor<512xi32>
-// CHECK:           %[[VAL_22:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]]], iterator_types = ["parallel"]} outs(%[[VAL_21]] : tensor<512xi32>) {
-// CHECK:           ^bb0(%[[VAL_23:.*]]: i32):
-// CHECK:             %[[VAL_24:.*]] = linalg.index 0 : index
-// CHECK:             %[[VAL_25:.*]] = arith.index_cast %[[VAL_24]] : index to i32
-// CHECK:             linalg.yield %[[VAL_25]] : i32
-// CHECK:           } -> tensor<512xi32>
-// CHECK:           %[[VAL_26:.*]] = arith.muli %[[VAL_10]], %[[VAL_6]] : i32
-// CHECK:           %[[VAL_27:.*]] = arith.index_cast %[[VAL_26]] : i32 to index
-// CHECK:           %[[VAL_28:.*]] = memref.reinterpret_cast %[[VAL_1]] to offset: {{\[}}%[[VAL_27]]], sizes: [512], strides: [1] : memref<*xi64> to memref<512xi64, strided<[1], offset: ?>>
-// CHECK:           %[[VAL_29:.*]] = linalg.fill ins(%[[VAL_3]] : i32) outs(%[[VAL_21]] : tensor<512xi32>) -> tensor<512xi32>
-// CHECK:           %[[VAL_30:.*]] = tensor.empty() : tensor<512xi1>
-// CHECK:           %[[VAL_31:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_0]], #[[$ATTR_0]]], iterator_types = ["parallel"]} ins(%[[VAL_22]], %[[VAL_29]] : tensor<512xi32>, tensor<512xi32>) outs(%[[VAL_30]] : tensor<512xi1>) {
-// CHECK:           ^bb0(%[[VAL_32:.*]]: i32, %[[VAL_33:.*]]: i32, %[[VAL_34:.*]]: i1):
-// CHECK:             %[[VAL_35:.*]] = arith.cmpi slt, %[[VAL_32]], %[[VAL_33]] : i32
-// CHECK:             linalg.yield %[[VAL_35]] : i1
-// CHECK:           } -> tensor<512xi1>
-// CHECK:           %[[VAL_36:.*]] = arith.index_cast %[[VAL_3]] : i32 to index
-// CHECK:           %[[VAL_37:.*]] = arith.minsi %[[VAL_36]], %[[VAL_16]] : index
-// CHECK:           %[[VAL_38:.*]] = arith.maxsi %[[VAL_37]], %[[VAL_17]] : index
-// CHECK:           %[[VAL_39:.*]] = memref.alloc() : memref<512xi64>
-// CHECK:           %[[VAL_40:.*]] = memref.subview %[[VAL_28]][0] {{\[}}%[[VAL_38]]] [1] : memref<512xi64, strided<[1], offset: ?>> to memref<?xi64, strided<[1], offset: ?>>
-// CHECK:           %[[VAL_41:.*]] = memref.subview %[[VAL_39]][0] {{\[}}%[[VAL_38]]] [1] : memref<512xi64> to memref<?xi64, strided<[1]>>
-// CHECK:           memref.copy %[[VAL_40]], %[[VAL_41]] : memref<?xi64, strided<[1], offset: ?>> to memref<?xi64, strided<[1]>>
-// CHECK:           %[[VAL_42:.*]] = bufferization.to_tensor %[[VAL_39]] restrict writable : memref<512xi64> to tensor<512xi64>
-// CHECK:           %[[VAL_43:.*]] = arith.cmpi eq, %[[VAL_4]], %[[VAL_18]] : i32
-// CHECK:           %[[VAL_44:.*]] = scf.if %[[VAL_43]] -> (memref<512xi64, strided<[?], offset: ?>>) {
-// CHECK:             %[[VAL_45:.*]] = arith.extsi %[[VAL_5]] : i32 to i64
-// CHECK:             %[[VAL_46:.*]] = tensor.empty() : tensor<512xi64>
-// CHECK:             %[[VAL_47:.*]] = linalg.fill ins(%[[VAL_45]] : i64) outs(%[[VAL_46]] : tensor<512xi64>) -> tensor<512xi64>
-// CHECK:             %[[VAL_48:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_0]], #[[$ATTR_0]]], iterator_types = ["parallel"]} ins(%[[VAL_42]], %[[VAL_47]] : tensor<512xi64>, tensor<512xi64>) outs(%[[VAL_42]] : tensor<512xi64>) {
-// CHECK:             ^bb0(%[[VAL_49:.*]]: i64, %[[VAL_50:.*]]: i64, %[[VAL_51:.*]]: i64):
-// CHECK:               %[[VAL_52:.*]] = arith.muli %[[VAL_49]], %[[VAL_50]] : i64
-// CHECK:               linalg.yield %[[VAL_52]] : i64
-// CHECK:             } -> tensor<512xi64>
-// CHECK:             %[[VAL_53:.*]] = tensor.empty() : tensor<512x!ptr.ptr<#{{.*}}>>
-// CHECK:             %[[VAL_54:.*]] = linalg.fill ins(%[[VAL_20]] : !ptr.ptr<#{{.*}}>) outs(%[[VAL_53]] : tensor<512x!ptr.ptr<#{{.*}}>>) -> tensor<512x!ptr.ptr<#{{.*}}>>
-// CHECK:             %[[VAL_55:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_0]], #[[$ATTR_0]]], iterator_types = ["parallel"]} ins(%[[VAL_54]], %[[VAL_48]] : tensor<512x!ptr.ptr<#{{.*}}>>, tensor<512xi64>) outs(%[[VAL_54]] : tensor<512x!ptr.ptr<#{{.*}}>>) {
-// CHECK:             ^bb0(%[[VAL_56:.*]]: !ptr.ptr<#{{.*}}>, %[[VAL_57:.*]]: i64, %[[VAL_58:.*]]: !ptr.ptr<#{{.*}}>):
-// CHECK:               %[[VAL_59:.*]] = arith.muli %[[VAL_57]], %[[VAL_15]] : i64
-// CHECK:               %[[VAL_60:.*]] = tptr.ptradd %[[VAL_56]] %[[VAL_59]] : <#{{.*}}>, i64 to <#{{.*}}>
-// CHECK:               linalg.yield %[[VAL_60]] : !ptr.ptr<#{{.*}}>
-// CHECK:             } -> tensor<512x!ptr.ptr<#{{.*}}>>
-// CHECK:             %[[VAL_61:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_0]], #[[$ATTR_0]]], iterator_types = ["parallel"]} ins(%[[VAL_55]], %[[VAL_22]] : tensor<512x!ptr.ptr<#{{.*}}>>, tensor<512xi32>) outs(%[[VAL_55]] : tensor<512x!ptr.ptr<#{{.*}}>>) {
-// CHECK:             ^bb0(%[[VAL_62:.*]]: !ptr.ptr<#{{.*}}>, %[[VAL_63:.*]]: i32, %[[VAL_64:.*]]: !ptr.ptr<#{{.*}}>):
-// CHECK:               %[[VAL_65:.*]] = arith.muli %[[VAL_63]], %[[VAL_14]] : i32
-// CHECK:               %[[VAL_66:.*]] = tptr.ptradd %[[VAL_62]] %[[VAL_65]] : <#{{.*}}>, i32 to <#{{.*}}>
-// CHECK:               linalg.yield %[[VAL_66]] : !ptr.ptr<#{{.*}}>
-// CHECK:             } -> tensor<512x!ptr.ptr<#{{.*}}>>
-// CHECK:             %[[VAL_67:.*]] = builtin.unrealized_conversion_cast %[[VAL_61]] : tensor<512x!ptr.ptr<#{{.*}}>> to memref<512xi64, strided<[?], offset: ?>>
-// CHECK:             scf.yield %[[VAL_67]] : memref<512xi64, strided<[?], offset: ?>>
-// CHECK:           } else {
-// CHECK:             %[[VAL_68:.*]] = arith.muli %[[VAL_10]], %[[VAL_5]] : i32
-// CHECK:             %[[VAL_69:.*]] = arith.muli %[[VAL_68]], %[[VAL_14]] : i32
-// CHECK:             %[[VAL_70:.*]] = tptr.ptradd %[[VAL_20]] %[[VAL_69]] : <#{{.*}}>, i32 to <#{{.*}}>
-// CHECK:             %[[VAL_71:.*]] = tensor.empty() : tensor<512x!ptr.ptr<#{{.*}}>>
-// CHECK:             %[[VAL_72:.*]] = linalg.fill ins(%[[VAL_70]] : !ptr.ptr<#{{.*}}>) outs(%[[VAL_71]] : tensor<512x!ptr.ptr<#{{.*}}>>) -> tensor<512x!ptr.ptr<#{{.*}}>>
-// CHECK:             %[[VAL_73:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_0]], #[[$ATTR_0]]], iterator_types = ["parallel"]} ins(%[[VAL_72]], %[[VAL_42]] : tensor<512x!ptr.ptr<#{{.*}}>>, tensor<512xi64>) outs(%[[VAL_72]] : tensor<512x!ptr.ptr<#{{.*}}>>) {
-// CHECK:             ^bb0(%[[VAL_74:.*]]: !ptr.ptr<#{{.*}}>, %[[VAL_75:.*]]: i64, %[[VAL_76:.*]]: !ptr.ptr<#{{.*}}>):
-// CHECK:               %[[VAL_77:.*]] = arith.muli %[[VAL_75]], %[[VAL_15]] : i64
-// CHECK:               %[[VAL_78:.*]] = tptr.ptradd %[[VAL_74]] %[[VAL_77]] : <#{{.*}}>, i64 to <#{{.*}}>
-// CHECK:               linalg.yield %[[VAL_78]] : !ptr.ptr<#{{.*}}>
-// CHECK:             } -> tensor<512x!ptr.ptr<#{{.*}}>>
-// CHECK:             %[[VAL_79:.*]] = builtin.unrealized_conversion_cast %[[VAL_73]] : tensor<512x!ptr.ptr<#{{.*}}>> to memref<512xi64, strided<[?], offset: ?>>
-// CHECK:             scf.yield %[[VAL_79]] : memref<512xi64, strided<[?], offset: ?>>
-// CHECK:           }
-// CHECK:           %[[VAL_80:.*]] = builtin.unrealized_conversion_cast %[[VAL_44]] : memref<512xi64, strided<[?], offset: ?>> to tensor<512x!ptr.ptr<#{{.*}}>>
-// CHECK:           %[[VAL_81:.*]] = tensor.empty() : tensor<512xi64>
-// CHECK:           %[[VAL_82:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_0]], #[[$ATTR_0]]], iterator_types = ["parallel"]} ins(%[[VAL_80]], %[[VAL_31]] : tensor<512x!ptr.ptr<#{{.*}}>>, tensor<512xi1>) outs(%[[VAL_81]] : tensor<512xi64>) {
-// CHECK:           ^bb0(%[[VAL_83:.*]]: !ptr.ptr<#{{.*}}>, %[[VAL_84:.*]]: i1, %[[VAL_85:.*]]: i64):
-// CHECK:             %[[VAL_86:.*]] = tptr.to_memref %[[VAL_83]] : <#{{.*}}> to memref<1xi64>
-// CHECK:             %[[VAL_87:.*]] = scf.if %[[VAL_84]] -> (i64) {
-// CHECK:               %[[VAL_88:.*]] = memref.load %[[VAL_86]]{{\[}}%[[VAL_17]]] : memref<1xi64>
-// CHECK:               scf.yield %[[VAL_88]] : i64
-// CHECK:             } else {
-// CHECK:               scf.yield %[[VAL_13]] : i64
-// CHECK:             }
-// CHECK:             linalg.yield %[[VAL_87]] : i64
-// CHECK:           } -> tensor<512xi64>
-// CHECK:           %[[VAL_89:.*]] = memref.reinterpret_cast %[[VAL_2]] to offset: {{\[}}%[[VAL_27]]], sizes: [512], strides: [1] : memref<*xi64> to memref<512xi64, strided<[1], offset: ?>>
-// CHECK:           %[[VAL_90:.*]] = tensor.extract_slice %[[VAL_82]][0] {{\[}}%[[VAL_38]]] [1] : tensor<512xi64> to tensor<?xi64>
-// CHECK:           %[[VAL_91:.*]] = memref.subview %[[VAL_89]][0] {{\[}}%[[VAL_38]]] [1] : memref<512xi64, strided<[1], offset: ?>> to memref<?xi64, strided<[1], offset: ?>>
-// CHECK:           bufferization.materialize_in_destination %[[VAL_90]] in writable %[[VAL_91]] : (tensor<?xi64>, memref<?xi64, strided<[1], offset: ?>>) -> ()
-// CHECK:           return
-// CHECK:         }
+// CHECK-NOT: unrealized_conversion_cast
+// CHECK-NOT: tt.

--- a/test/Conversion/TritonToLinalgExperimental/mixed_structured_unstructured.mlir
+++ b/test/Conversion/TritonToLinalgExperimental/mixed_structured_unstructured.mlir
@@ -1,0 +1,180 @@
+// RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
+//
+// This test verifies that we correctly handle the IR when there is a mix of
+// structured and unstructured accesses in loops.
+// Generated from the following dummy triton program:
+//
+// @triton.jit
+// def test_mixed(in_ptr_1, in_ptr_2, out_ptr, stride_m, stride_n):
+//     offs_am = tl.arange(0, 2)
+//     offs_an = tl.arange(0, 2)
+//     structured_ptrs = in_ptr_1 + (offs_am[:, None] * stride_m +
+//                         offs_an[None, :] * stride_n)
+//     unstructured_offset_ptrs = in_ptr_1 + ((offs_am[:, None] // 4) * stride_m +
+//                         (offs_an[None, :] % 3 + 2) * stride_n)
+//     if stride_m == 10:
+//         base_ptr = in_ptr_1
+//     else:
+//         base_ptr = in_ptr_2
+//     unstructured_raw_ptrs = base_ptr + ((offs_am[:, None] // 4) * stride_m +
+//                         (offs_an[None, :] % 3 + 2) * stride_n)
+//     offs_cm = tl.arange(0, 2)
+//     offs_cn = tl.arange(0, 2)
+//     c_ptrs = out_ptr + stride_m * offs_cm[:, None] + stride_n * offs_cn[
+//         None, :]
+//     for i in range(0, 2):
+//         structured_ptrs += stride_n
+//         unstructured_offset_ptrs += stride_n
+//         unstructured_raw_ptrs += stride_n
+//         for j in range(0, 2):
+//             t1 = tl.load(structured_ptrs)
+//             t2 = tl.load(unstructured_offset_ptrs)
+//             t3 = tl.load(unstructured_raw_ptrs)
+//             tl.store(c_ptrs, t1)
+//             c_ptrs += stride_n
+//             tl.store(c_ptrs, t2)
+//             c_ptrs += stride_n
+//             tl.store(c_ptrs, t3)
+//             structured_ptrs += stride_n
+//             unstructured_offset_ptrs += stride_n
+//             unstructured_raw_ptrs += stride_n
+//         structured_ptrs += stride_n
+//         unstructured_offset_ptrs += stride_n
+//         unstructured_raw_ptrs += stride_n
+// def test():
+//     src = triton.compiler.ASTSource(
+//         fn=test_mixed,
+//         signature={"in_ptr_1": "*fp32", "in_ptr_2": "*fp32", "out_ptr": "*fp32", "stride_m": "i32", "stride_n": "i32"},
+//     )
+//     ret = triton.compile(
+//         src,
+//     )
+//     print(ret.asm["ttir"])
+//     print('Pass')
+
+module {
+  tt.func public @test_mixed(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: i32, %arg3: i32) attributes {noinline = false} {
+    %c1_i32 = arith.constant 1 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %cst = arith.constant dense<2> : tensor<1x2xi32>
+    %cst_0 = arith.constant dense<3> : tensor<1x2xi32>
+    %cst_1 = arith.constant dense<4> : tensor<2x1xi32>
+    %0 = tt.make_range {end = 2 : i32, start = 0 : i32} : tensor<2xi32>
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<2xi32> -> tensor<2x1xi32>
+    %2 = tt.splat %arg2 : i32 -> tensor<2x1xi32>
+    %3 = arith.muli %1, %2 : tensor<2x1xi32>
+    %4 = tt.expand_dims %0 {axis = 0 : i32} : tensor<2xi32> -> tensor<1x2xi32>
+    %5 = tt.splat %arg3 : i32 -> tensor<1x2xi32>
+    %6 = arith.muli %4, %5 : tensor<1x2xi32>
+    %7 = tt.broadcast %3 : tensor<2x1xi32> -> tensor<2x2xi32>
+    %8 = tt.broadcast %6 : tensor<1x2xi32> -> tensor<2x2xi32>
+    %9 = arith.addi %7, %8 : tensor<2x2xi32>
+    %10 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<2x2x!tt.ptr<f32>>
+    %11 = tt.addptr %10, %9 : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
+    %12 = arith.divsi %1, %cst_1 : tensor<2x1xi32>
+    %13 = arith.muli %12, %2 : tensor<2x1xi32>
+    %14 = arith.remsi %4, %cst_0 : tensor<1x2xi32>
+    %15 = arith.addi %14, %cst : tensor<1x2xi32>
+    %16 = arith.muli %15, %5 : tensor<1x2xi32>
+    %17 = tt.broadcast %13 : tensor<2x1xi32> -> tensor<2x2xi32>
+    %18 = tt.broadcast %16 : tensor<1x2xi32> -> tensor<2x2xi32>
+    %19 = arith.addi %17, %18 : tensor<2x2xi32>
+    %20 = tt.addptr %10, %19 : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
+    %21 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<2x1x!tt.ptr<f32>>
+    %22 = tt.addptr %21, %3 : tensor<2x1x!tt.ptr<f32>>, tensor<2x1xi32>
+    %23 = tt.broadcast %22 : tensor<2x1x!tt.ptr<f32>> -> tensor<2x2x!tt.ptr<f32>>
+    %24 = tt.addptr %23, %8 : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
+    %25:3 = scf.for %arg4 = %c0_i32 to %c2_i32 step %c1_i32 iter_args(%arg5 = %11, %arg6 = %20, %arg7 = %24) -> (tensor<2x2x!tt.ptr<f32>>, tensor<2x2x!tt.ptr<f32>>, tensor<2x2x!tt.ptr<f32>>)  : i32 {
+      %26 = tt.splat %arg3 : i32 -> tensor<2x2xi32>
+      %27 = tt.addptr %arg5, %26 : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
+      %28 = tt.addptr %arg6, %26 : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
+      %29:3 = scf.for %arg8 = %c0_i32 to %c2_i32 step %c1_i32 iter_args(%arg9 = %arg7, %arg10 = %27, %arg11 = %28) -> (tensor<2x2x!tt.ptr<f32>>, tensor<2x2x!tt.ptr<f32>>, tensor<2x2x!tt.ptr<f32>>)  : i32 {
+        %32 = tt.load %arg10 : tensor<2x2x!tt.ptr<f32>>
+        %33 = tt.load %arg11 : tensor<2x2x!tt.ptr<f32>>
+        tt.store %arg9, %32 : tensor<2x2x!tt.ptr<f32>>
+        %34 = tt.addptr %arg9, %26 : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
+        tt.store %34, %33 : tensor<2x2x!tt.ptr<f32>>
+        %35 = tt.addptr %arg10, %26 : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
+        %36 = tt.addptr %arg11, %26 : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
+        scf.yield %34, %35, %36 : tensor<2x2x!tt.ptr<f32>>, tensor<2x2x!tt.ptr<f32>>, tensor<2x2x!tt.ptr<f32>>
+      }
+      %30 = tt.addptr %29#1, %26 : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
+      %31 = tt.addptr %29#2, %26 : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
+      scf.yield %30, %31, %29#0 : tensor<2x2x!tt.ptr<f32>>, tensor<2x2x!tt.ptr<f32>>, tensor<2x2x!tt.ptr<f32>>
+    }
+    tt.return
+  }
+}
+
+// CHECK-NOT: unrealized_conversion_cast
+
+// ---
+
+module {
+  tt.func public @test_mixed(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: !tt.ptr<f32>, %arg3: i32, %arg4: i32) attributes {noinline = false} {
+    %c1_i32 = arith.constant 1 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c10_i32 = arith.constant 10 : i32
+    %cst = arith.constant dense<2> : tensor<1x2xi32>
+    %cst_0 = arith.constant dense<3> : tensor<1x2xi32>
+    %cst_1 = arith.constant dense<4> : tensor<2x1xi32>
+    %0 = tt.make_range {end = 2 : i32, start = 0 : i32} : tensor<2xi32>
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<2xi32> -> tensor<2x1xi32>
+    %2 = tt.splat %arg3 : i32 -> tensor<2x1xi32>
+    %3 = arith.muli %1, %2 : tensor<2x1xi32>
+    %4 = tt.expand_dims %0 {axis = 0 : i32} : tensor<2xi32> -> tensor<1x2xi32>
+    %5 = tt.splat %arg4 : i32 -> tensor<1x2xi32>
+    %6 = arith.muli %4, %5 : tensor<1x2xi32>
+    %7 = tt.broadcast %3 : tensor<2x1xi32> -> tensor<2x2xi32>
+    %8 = tt.broadcast %6 : tensor<1x2xi32> -> tensor<2x2xi32>
+    %9 = arith.addi %7, %8 : tensor<2x2xi32>
+    %10 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<2x2x!tt.ptr<f32>>
+    %11 = tt.addptr %10, %9 : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
+    %12 = arith.divsi %1, %cst_1 : tensor<2x1xi32>
+    %13 = arith.muli %12, %2 : tensor<2x1xi32>
+    %14 = arith.remsi %4, %cst_0 : tensor<1x2xi32>
+    %15 = arith.addi %14, %cst : tensor<1x2xi32>
+    %16 = arith.muli %15, %5 : tensor<1x2xi32>
+    %17 = tt.broadcast %13 : tensor<2x1xi32> -> tensor<2x2xi32>
+    %18 = tt.broadcast %16 : tensor<1x2xi32> -> tensor<2x2xi32>
+    %19 = arith.addi %17, %18 : tensor<2x2xi32>
+    %20 = tt.addptr %10, %19 : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
+    %21 = arith.cmpi eq, %arg3, %c10_i32 : i32
+    %22 = arith.select %21, %arg0, %arg1 : !tt.ptr<f32>
+    %23 = tt.splat %22 : !tt.ptr<f32> -> tensor<2x2x!tt.ptr<f32>>
+    %24 = tt.addptr %23, %19 : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
+    %25 = tt.splat %arg2 : !tt.ptr<f32> -> tensor<2x1x!tt.ptr<f32>>
+    %26 = tt.addptr %25, %3 : tensor<2x1x!tt.ptr<f32>>, tensor<2x1xi32>
+    %27 = tt.broadcast %26 : tensor<2x1x!tt.ptr<f32>> -> tensor<2x2x!tt.ptr<f32>>
+    %28 = tt.addptr %27, %8 : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
+    %29:4 = scf.for %arg5 = %c0_i32 to %c2_i32 step %c1_i32 iter_args(%arg6 = %11, %arg7 = %20, %arg8 = %24, %arg9 = %28) -> (tensor<2x2x!tt.ptr<f32>>, tensor<2x2x!tt.ptr<f32>>, tensor<2x2x!tt.ptr<f32>>, tensor<2x2x!tt.ptr<f32>>)  : i32 {
+      %30 = tt.splat %arg4 : i32 -> tensor<2x2xi32>
+      %31 = tt.addptr %arg6, %30 : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
+      %32 = tt.addptr %arg7, %30 : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
+      %33 = tt.addptr %arg8, %30 : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
+      %34:4 = scf.for %arg10 = %c0_i32 to %c2_i32 step %c1_i32 iter_args(%arg11 = %arg9, %arg12 = %31, %arg13 = %32, %arg14 = %33) -> (tensor<2x2x!tt.ptr<f32>>, tensor<2x2x!tt.ptr<f32>>, tensor<2x2x!tt.ptr<f32>>, tensor<2x2x!tt.ptr<f32>>)  : i32 {
+        %38 = tt.load %arg12 : tensor<2x2x!tt.ptr<f32>>
+        %39 = tt.load %arg13 : tensor<2x2x!tt.ptr<f32>>
+        %40 = tt.load %arg14 : tensor<2x2x!tt.ptr<f32>>
+        tt.store %arg11, %38 : tensor<2x2x!tt.ptr<f32>>
+        %41 = tt.addptr %arg11, %30 : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
+        tt.store %41, %39 : tensor<2x2x!tt.ptr<f32>>
+        %42 = tt.addptr %41, %30 : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
+        tt.store %42, %40 : tensor<2x2x!tt.ptr<f32>>
+        %43 = tt.addptr %arg12, %30 : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
+        %44 = tt.addptr %arg13, %30 : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
+        %45 = tt.addptr %arg14, %30 : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
+        scf.yield %42, %43, %44, %45 : tensor<2x2x!tt.ptr<f32>>, tensor<2x2x!tt.ptr<f32>>, tensor<2x2x!tt.ptr<f32>>, tensor<2x2x!tt.ptr<f32>>
+      }
+      %35 = tt.addptr %34#1, %30 : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
+      %36 = tt.addptr %34#2, %30 : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
+      %37 = tt.addptr %34#3, %30 : tensor<2x2x!tt.ptr<f32>>, tensor<2x2xi32>
+      scf.yield %35, %36, %37, %34#0 : tensor<2x2x!tt.ptr<f32>>, tensor<2x2x!tt.ptr<f32>>, tensor<2x2x!tt.ptr<f32>>, tensor<2x2x!tt.ptr<f32>>
+    }
+    tt.return
+  }
+}
+
+// CHECK-NOT: unrealized_conversion_cast


### PR DESCRIPTION
Previously, before the conversion to the PtrDialect for fallback, the structured-to-memref pass has to convert loop's iter-args with triton pointer to unranked memref. This conversion ensures all types coming out of triton-shared are mlir built-in types and therefore allows the CPU backend to correctly lower the IR to llvm. However, in reality, structured ops do not need to use the loop iter-args since ptr-analysis generates load/store ops that directly use the kernel arguments as source; this means the conversion is mostly unnecessary.

With the introduction of the fallback using the PtrDialect (triton-to-ptr), we also convert the loop iter-args of triton pointer type to PtrDialect's ptr type. This conversion, along with the conversion to unranked memref above, means we will end up with `unrealized_conversion_cast` ops that convert back and forth between these two types when handling triton programs that have mixed uses of structured and unstructured accesses in loops.

To solve this issue, we:

- remove the conversion of loop-iter of triton ptr type to unranked memref since it is unnecessary as described as above
- run remove-dead-values to remove unused loop-iter args; this pass previously could not run in presence of ops with arbitrary regions but has now been fixed in this PR: https://github.com/llvm/llvm-project/pull/140793. Running remove-dead-values gives two benefits:
   - ability to remove all unused loop iter-arg that isn't used after ptr-analysis
   - make our codegen more efficient in general
