### PR TITLE
Add reduction support for arith.mulf and arith.ori

### DIFF
--- a/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
+++ b/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
@@ -1192,9 +1192,9 @@ private:
   }
 
   bool isReductionOpSupported(Operation *redOp) const {
-    return isa<arith::AddFOp, arith::AddIOp, arith::MaximumFOp, arith::MulFOp, arith::OrIOp
+    return isa<arith::AddFOp, arith::AddIOp, arith::MaximumFOp, arith::MulFOp,
                arith::MaxNumFOp, arith::MinimumFOp, arith::MinNumFOp,
-               arith::MinSIOp, arith::MinUIOp, arith::MaxSIOp, arith::MaxUIOp>(
+               arith::MinSIOp, arith::MinUIOp, arith::MaxSIOp, arith::MaxUIOp, arith::OrIOp>(
         redOp);
   }
 


### PR DESCRIPTION
Enable reductions for `tt.reduce` ops with a single operation body consisting of a `arith.andi`, `arith.mulf`, `arith.muli`, `arith.xori`, or `arith.ori`. 