### PR TITLE
Add device_assert support for tensors

### DIFF
--- a/backend/compiler.py
+++ b/backend/compiler.py
@@ -170,7 +170,7 @@ def _llir_to_bin(llir: str, metadata):
             subprocess.check_call(subprocess_args)
         else:
             llc_path = _get_llvm_bin_path("llc")
-            subprocess.check_call([llc_path, src_path, "-filetype=obj", "-o", dst_path])
+            subprocess.check_call([llc_path, src_path, "-filetype=obj", "-relocation-model=pic", "-o", dst_path])
         
         return Path(dst_path).read_bytes()
 

--- a/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
+++ b/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
@@ -790,25 +790,91 @@ struct AssertConverter : public OpConversionPattern<triton::AssertOp> {
                   ConversionPatternRewriter &rewriter) const override {
     Value condVal = op.getCondition();
 
-    if (isa<mlir::TensorType>(condVal.getType())) {
-      auto scalarVal = getScalarValue(op.getCondition(), op.getLoc(), rewriter);
-      condVal = scalarVal ? scalarVal : condVal;
-    }
-    assert(condVal && isa<mlir::IntegerType>(condVal.getType()) &&
-           "Only asserts on scalars are currently supported");
-
-    if (!condVal.getType().isInteger(1)) {
-      auto zero =
-          rewriter.create<mlir::arith::ConstantIntOp>(op.getLoc(), 0, 32);
-      auto newCond = rewriter.create<mlir::arith::CmpIOp>(
-          op.getLoc(), arith::CmpIPredicate::ne, condVal, zero);
-      condVal = newCond.getResult();
-    }
-
     auto assertMessage =
-        llvm::formatv("Assertion `{0}` failed", op.getMessage());
-    rewriter.create<mlir::cf::AssertOp>(op.getLoc(), condVal,
-                                        assertMessage.str());
+          llvm::formatv("Assertion `{0}` failed", op.getMessage());
+
+    if (isa<mlir::IntegerType>(condVal.getType())) {
+      // handle scalar case
+      if (!condVal.getType().isInteger(1)) {
+        auto zero =
+            rewriter.create<mlir::arith::ConstantIntOp>(op.getLoc(), 0, 32);
+        auto newCond = rewriter.create<mlir::arith::CmpIOp>(
+            op.getLoc(), arith::CmpIPredicate::ne, condVal, zero);
+        condVal = newCond.getResult();
+      }
+
+      rewriter.create<mlir::cf::AssertOp>(op.getLoc(), condVal,
+                                          assertMessage.str());
+    } else {
+      // handle tensor case
+      // dimensions
+      auto tensorType = dyn_cast<RankedTensorType>(condVal.getType()); // TODO: assertion?
+      int64_t rank = tensorType.getRank();
+
+      Value dim0, dim1, dim2;
+      if (rank == 1) {
+        dim0 = rewriter.create<arith::ConstantIndexOp>(op.getLoc(), 1);
+        dim1 = rewriter.create<tensor::DimOp>(op.getLoc(), condVal, 0);
+        dim2 = rewriter.create<arith::ConstantIndexOp>(op.getLoc(), 1);
+      } else if (rank == 2) {
+        dim0 = rewriter.create<tensor::DimOp>(op.getLoc(), condVal, 0);
+        dim1 = rewriter.create<tensor::DimOp>(op.getLoc(), condVal, 1);
+        dim2 = rewriter.create<arith::ConstantIndexOp>(op.getLoc(), 1);
+      } else if (rank == 3) {
+        dim0 = rewriter.create<tensor::DimOp>(op.getLoc(), condVal, 0);
+        dim1 = rewriter.create<tensor::DimOp>(op.getLoc(), condVal, 1);
+        dim2 = rewriter.create<tensor::DimOp>(op.getLoc(), condVal, 2);
+      }
+
+      // loop bounds
+      Value begin = rewriter.create<arith::ConstantIndexOp>(op.getLoc(), 0);
+      Value step = rewriter.create<arith::ConstantIndexOp>(op.getLoc(), 1);
+
+      rewriter.create<scf::ForOp>(
+        op.getLoc(), begin, dim0, step, ValueRange{}, 
+        [&](OpBuilder &b0, Location loc0, Value index0, ValueRange args0) {
+          b0.create<scf::ForOp>(
+            op.getLoc(), begin, dim1, step, ValueRange{},
+            [&](OpBuilder &b1, Location loc1, Value index1, ValueRange args1) {
+              b1.create<scf::ForOp>(
+                op.getLoc(), begin, dim2, step, ValueRange{},
+                [&](OpBuilder &b2, Location loc2, Value index2, ValueRange args2) {
+                  // make an extract op to load in the value from the tensor at current index
+                  Value element;
+                  
+                  if (rank == 1) {
+                    element = b2.create<tensor::ExtractOp>(op.getLoc(), condVal, ValueRange{index1});
+                  } else if (rank == 2) {
+                    element = b2.create<tensor::ExtractOp>(op.getLoc(), condVal, ValueRange{index0, index1});
+                  } else {
+                    element = b2.create<tensor::ExtractOp>(op.getLoc(), condVal, ValueRange{index0, index1, index2});
+                  }
+
+                  // convert to I1
+                  if (!element.getType().isInteger(1)) {
+                    auto zero =
+                        b2.create<mlir::arith::ConstantIntOp>(op.getLoc(), 0, 32);
+                    auto newCond = rewriter.create<mlir::arith::CmpIOp>(
+                        op.getLoc(), arith::CmpIPredicate::ne, element, zero);
+                    element = newCond.getResult();
+                  }
+                  
+                  // make a cf.assert for the current element
+                  b2.create<mlir::cf::AssertOp>(op.getLoc(), element, assertMessage.str());
+                  
+                  b2.create<scf::YieldOp>(op.getLoc());
+                }
+              );
+
+              b1.create<scf::YieldOp>(op.getLoc());
+            }
+          );
+
+          // yield
+          b0.create<scf::YieldOp>(op.getLoc());
+        }
+      );
+    }
 
     rewriter.eraseOp(op);
     return success();

--- a/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
+++ b/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
@@ -797,14 +797,6 @@ struct AssertConverter : public OpConversionPattern<triton::AssertOp> {
     // Tensors will always be RankedTensorType.
     if (isa<mlir::IntegerType>(condVal.getType())) {
       // handle scalar case
-      if (!condVal.getType().isInteger(1)) {
-        auto zero =
-            rewriter.create<mlir::arith::ConstantIntOp>(op.getLoc(), 0, 32);
-        auto newCond = rewriter.create<mlir::arith::CmpIOp>(
-            op.getLoc(), arith::CmpIPredicate::ne, condVal, zero);
-        condVal = newCond.getResult();
-      }
-
       rewriter.create<mlir::cf::AssertOp>(op.getLoc(), condVal,
                                           assertMessage.str());
     } else if (auto tensorType = dyn_cast<RankedTensorType>(condVal.getType())) {
@@ -827,15 +819,6 @@ struct AssertConverter : public OpConversionPattern<triton::AssertOp> {
         [&](OpBuilder &b, Location loc, ValueRange args) {
           // obtain the element in the tensor
           Value element = args[0];
-          
-          // convert to I1 if needed
-          if (!element.getType().isInteger(1)) {
-            auto zero =
-                b.create<mlir::arith::ConstantIntOp>(loc, 0, 32);
-            auto newCond = rewriter.create<mlir::arith::CmpIOp>(
-                loc, arith::CmpIPredicate::ne, element, zero);
-            element = newCond.getResult();
-          }
 
           // make a cf.assert for the current element
           b.create<mlir::cf::AssertOp>(loc, element, assertMessage.str());

--- a/test/Conversion/StructuredToMemref/triton_assert.mlir
+++ b/test/Conversion/StructuredToMemref/triton_assert.mlir
@@ -1,17 +1,50 @@
 // RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
-tt.func public @assert_lol(%arg0: i32) {
-  %c0_i32 = arith.constant 0 : i32
-  %0 = arith.cmpi sgt, %arg0, %c0_i32 : i32
-  %1 = tt.splat %0 : i1 -> tensor<1xi1>
-  tt.assert %1, "lol" : tensor<1xi1>
+
+// CHECK:           #map = affine_map<(d0) -> (d0)>
+// CHECK:           #map1 = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK:           #map2 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+
+tt.func public @assert_tensor_1d() {
+  %0 = tensor.empty() : tensor<4xi1>
+  tt.assert %0, "message" : tensor<4xi1>
   tt.return
 }
 
+// CHECK-LABEL:   func.func @assert_tensor_1d
+// CHECK-NOT:       tt.assert
+// CHECK:           linalg.generic {indexing_maps = [#map], iterator_types = ["parallel"]} ins(%0 : tensor<4xi1>) { 
+// CHECK:           ^bb0(%in: i1):
+// CHECK:             cf.assert %in, "Assertion `message` failed"
+// CHECK:             linalg.yield
+// CHECK:           }
+// CHECK-NOT:       tt.assert
 
-// CHECK-LABEL:  func.func @assert_lol
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: i32, [[PARAM_1_:%.+]]: i32, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32) {
-// CHECK:           [[CST_0_:%.+]] = arith.constant 0 : i32
-// CHECK:           [[VAR_0_:%.+]] = arith.cmpi sgt, [[PARAM_0_]], [[CST_0_]] : i32
-// CHECK:           cf.assert [[VAR_0_]], "Assertion `lol` failed"
-// CHECK:           return
-// CHECK:         }
+tt.func public @assert_tensor_2d() {
+  %0 = tensor.empty() : tensor<4x4xi1>
+  tt.assert %0, "message" : tensor<4x4xi1>
+  tt.return
+}
+
+// CHECK-LABEL:   func.func @assert_tensor_2d
+// CHECK-NOT:       tt.assert
+// CHECK:           linalg.generic {indexing_maps = [#map1], iterator_types = ["parallel", "parallel"]} ins(%0 : tensor<4x4xi1>) { 
+// CHECK:           ^bb0(%in: i1):
+// CHECK:             cf.assert %in, "Assertion `message` failed"
+// CHECK:             linalg.yield
+// CHECK:           }
+// CHECK-NOT:       tt.assert
+
+tt.func public @assert_tensor_3d() {
+  %0 = tensor.empty() : tensor<4x4x4xi1>
+  tt.assert %0, "message" : tensor<4x4x4xi1>
+  tt.return
+}
+
+// CHECK-LABEL:   func.func @assert_tensor_3d
+// CHECK-NOT:       tt.assert
+// CHECK:           linalg.generic {indexing_maps = [#map2], iterator_types = ["parallel", "parallel", "parallel"]} ins(%0 : tensor<4x4x4xi1>) { 
+// CHECK:           ^bb0(%in: i1):
+// CHECK:             cf.assert %in, "Assertion `message` failed"
+// CHECK:             linalg.yield
+// CHECK:           }
+// CHECK-NOT:       tt.assert

--- a/test/Conversion/TritonArithToLinalg/triton_assert.mlir
+++ b/test/Conversion/TritonArithToLinalg/triton_assert.mlir
@@ -1,55 +1,50 @@
 // RUN: triton-shared-opt --triton-arith-to-linalg %s | FileCheck %s
 
-tt.func public @assert_tensor_1d(%arg0: tensor<4xi1>) {
-  tt.assert %arg0, "message" : tensor<4xi1>
+// CHECK:           #map = affine_map<(d0) -> (d0)>
+// CHECK:           #map1 = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK:           #map2 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+
+tt.func public @assert_tensor_1d() {
+  %0 = tensor.empty() : tensor<4xi1>
+  tt.assert %0, "message" : tensor<4xi1>
   tt.return
 }
 
 // CHECK-LABEL:   func.func @assert_tensor_1d
-// CHECK:           %c1 = arith.constant 1 : index
-// CHECK:           %c0 = arith.constant 0 : index
-// CHECK:           %c4 = arith.constant 4 : index
-// CHECK:           scf.for %{{.*}} = %c0 to %c1 step %c1 {
-// CHECK:             scf.for [[INDEX:%.+]] = %c0 to %c4 step %c1 {
-// CHECK:               scf.for %{{.*}} = %c0 to %c1 step %c1 {
-// CHECK:                 %extracted = tensor.extract %arg0[[[INDEX]]] : tensor<4xi1>
-// CHECK:                 cf.assert %extracted, "Assertion `message` failed"
-// CHECK:               }
-// CHECK:             }
+// CHECK-NOT:       tt.assert
+// CHECK:           linalg.generic {indexing_maps = [#map], iterator_types = ["parallel"]} ins(%0 : tensor<4xi1>) { 
+// CHECK:           ^bb0(%in: i1):
+// CHECK:             cf.assert %in, "Assertion `message` failed"
+// CHECK:             linalg.yield
 // CHECK:           }
+// CHECK-NOT:       tt.assert
 
-tt.func public @assert_tensor_2d(%arg0: tensor<4x4xi1>) {
-  tt.assert %arg0, "message" : tensor<4x4xi1>
+tt.func public @assert_tensor_2d() {
+  %0 = tensor.empty() : tensor<4x4xi1>
+  tt.assert %0, "message" : tensor<4x4xi1>
   tt.return
 }
 
 // CHECK-LABEL:   func.func @assert_tensor_2d
-// CHECK:           %c1 = arith.constant 1 : index
-// CHECK:           %c0 = arith.constant 0 : index
-// CHECK:           %c4 = arith.constant 4 : index
-// CHECK:           scf.for [[INDEX0:%.+]] = %c0 to %c4 step %c1 {
-// CHECK:             scf.for [[INDEX1:%.+]] = %c0 to %c4 step %c1 {
-// CHECK:               scf.for %{{.*}} = %c0 to %c1 step %c1 {
-// CHECK:                 %extracted = tensor.extract %arg0[[[INDEX0]], [[INDEX1]]] : tensor<4x4xi1>
-// CHECK:                 cf.assert %extracted, "Assertion `message` failed"
-// CHECK:               }
-// CHECK:             }
+// CHECK-NOT:       tt.assert
+// CHECK:           linalg.generic {indexing_maps = [#map1], iterator_types = ["parallel", "parallel"]} ins(%0 : tensor<4x4xi1>) { 
+// CHECK:           ^bb0(%in: i1):
+// CHECK:             cf.assert %in, "Assertion `message` failed"
+// CHECK:             linalg.yield
 // CHECK:           }
+// CHECK-NOT:       tt.assert
 
-tt.func public @assert_tensor_3d(%arg0: tensor<4x4x4xi1>) {
-  tt.assert %arg0, "message" : tensor<4x4x4xi1>
+tt.func public @assert_tensor_3d() {
+  %0 = tensor.empty() : tensor<4x4x4xi1>
+  tt.assert %0, "message" : tensor<4x4x4xi1>
   tt.return
 }
 
 // CHECK-LABEL:   func.func @assert_tensor_3d
-// CHECK:           %c1 = arith.constant 1 : index
-// CHECK:           %c0 = arith.constant 0 : index
-// CHECK:           %c4 = arith.constant 4 : index
-// CHECK:           scf.for [[INDEX0:%.+]] = %c0 to %c4 step %c1 {
-// CHECK:             scf.for [[INDEX1:%.+]] = %c0 to %c4 step %c1 {
-// CHECK:               scf.for [[INDEX2:%.+]] = %c0 to %c4 step %c1 {
-// CHECK:                 %extracted = tensor.extract %arg0[[[INDEX0]], [[INDEX1]], [[INDEX2]]] : tensor<4x4x4xi1>
-// CHECK:                 cf.assert %extracted, "Assertion `message` failed"
-// CHECK:               }
-// CHECK:             }
+// CHECK-NOT:       tt.assert
+// CHECK:           linalg.generic {indexing_maps = [#map2], iterator_types = ["parallel", "parallel", "parallel"]} ins(%0 : tensor<4x4x4xi1>) { 
+// CHECK:           ^bb0(%in: i1):
+// CHECK:             cf.assert %in, "Assertion `message` failed"
+// CHECK:             linalg.yield
 // CHECK:           }
+// CHECK-NOT:       tt.assert

--- a/test/Conversion/TritonArithToLinalg/triton_assert.mlir
+++ b/test/Conversion/TritonArithToLinalg/triton_assert.mlir
@@ -1,16 +1,55 @@
 // RUN: triton-shared-opt --triton-arith-to-linalg %s | FileCheck %s
-tt.func public @assert_lol(%arg0: i32) {
-  %c0_i32 = arith.constant 0 : i32
-  %0 = arith.cmpi sgt, %arg0, %c0_i32 : i32
-  %1 = tt.splat %0 : i1 -> tensor<1xi1>
-  tt.assert %1, "lol" : tensor<1xi1>
+
+tt.func public @assert_tensor_1d(%arg0: tensor<4xi1>) {
+  tt.assert %arg0, "message" : tensor<4xi1>
   tt.return
 }
 
-// CHECK-LABEL:  func.func @assert_lol
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: i32, [[PARAM_1_:%.+]]: i32, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32) {
-// CHECK:           [[CST_0_:%.+]] = arith.constant 0 : i32
-// CHECK-DAG:       [[VAR_0_:%.+]] = arith.cmpi sgt, [[PARAM_0_]], [[CST_0_]] : i32
-// CHECK:           cf.assert [[VAR_0_]], "Assertion `lol` failed"
-// CHECK:           return
-// CHECK:         }
+// CHECK-LABEL:   func.func @assert_tensor_1d
+// CHECK:           %c1 = arith.constant 1 : index
+// CHECK:           %c0 = arith.constant 0 : index
+// CHECK:           %c4 = arith.constant 4 : index
+// CHECK:           scf.for %{{.*}} = %c0 to %c1 step %c1 {
+// CHECK:             scf.for [[INDEX:%.+]] = %c0 to %c4 step %c1 {
+// CHECK:               scf.for %{{.*}} = %c0 to %c1 step %c1 {
+// CHECK:                 %extracted = tensor.extract %arg0[[[INDEX]]] : tensor<4xi1>
+// CHECK:                 cf.assert %extracted, "Assertion `message` failed"
+// CHECK:               }
+// CHECK:             }
+// CHECK:           }
+
+tt.func public @assert_tensor_2d(%arg0: tensor<4x4xi1>) {
+  tt.assert %arg0, "message" : tensor<4x4xi1>
+  tt.return
+}
+
+// CHECK-LABEL:   func.func @assert_tensor_2d
+// CHECK:           %c1 = arith.constant 1 : index
+// CHECK:           %c0 = arith.constant 0 : index
+// CHECK:           %c4 = arith.constant 4 : index
+// CHECK:           scf.for [[INDEX0:%.+]] = %c0 to %c4 step %c1 {
+// CHECK:             scf.for [[INDEX1:%.+]] = %c0 to %c4 step %c1 {
+// CHECK:               scf.for %{{.*}} = %c0 to %c1 step %c1 {
+// CHECK:                 %extracted = tensor.extract %arg0[[[INDEX0]], [[INDEX1]]] : tensor<4x4xi1>
+// CHECK:                 cf.assert %extracted, "Assertion `message` failed"
+// CHECK:               }
+// CHECK:             }
+// CHECK:           }
+
+tt.func public @assert_tensor_3d(%arg0: tensor<4x4x4xi1>) {
+  tt.assert %arg0, "message" : tensor<4x4x4xi1>
+  tt.return
+}
+
+// CHECK-LABEL:   func.func @assert_tensor_3d
+// CHECK:           %c1 = arith.constant 1 : index
+// CHECK:           %c0 = arith.constant 0 : index
+// CHECK:           %c4 = arith.constant 4 : index
+// CHECK:           scf.for [[INDEX0:%.+]] = %c0 to %c4 step %c1 {
+// CHECK:             scf.for [[INDEX1:%.+]] = %c0 to %c4 step %c1 {
+// CHECK:               scf.for [[INDEX2:%.+]] = %c0 to %c4 step %c1 {
+// CHECK:                 %extracted = tensor.extract %arg0[[[INDEX0]], [[INDEX1]], [[INDEX2]]] : tensor<4x4x4xi1>
+// CHECK:                 cf.assert %extracted, "Assertion `message` failed"
+// CHECK:               }
+// CHECK:             }
+// CHECK:           }

--- a/test/Conversion/TritonToLinalg/triton_assert.mlir
+++ b/test/Conversion/TritonToLinalg/triton_assert.mlir
@@ -1,15 +1,50 @@
 // RUN: triton-shared-opt --triton-to-linalg %s | FileCheck %s
-tt.func public @assert_lol(%arg0: i32) {
-  %c0_i32 = arith.constant 0 : i32
-  %0 = arith.cmpi sgt, %arg0, %c0_i32 : i32
-  %1 = tt.splat %0 : i1 -> tensor<1xi1>
-  tt.assert %1, "lol": tensor<1xi1>
+
+// CHECK:           #map = affine_map<(d0) -> (d0)>
+// CHECK:           #map1 = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK:           #map2 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+
+tt.func public @assert_tensor_1d() {
+  %0 = tensor.empty() : tensor<4xi1>
+  tt.assert %0, "message" : tensor<4xi1>
   tt.return
 }
 
-// CHECK: func.func @assert_lol(%arg0: i32, %arg1: i32, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32, %arg6: i32) {
-// CHECK:   %c0_i32 = arith.constant 0 : i32
-// CHECK:   %0 = arith.cmpi sgt, %arg0, %c0_i32 : i32
-// CHECK:   cf.assert %0, "Assertion `lol` failed"
-// CHECK:   return
-// CHECK: }
+// CHECK-LABEL:   func.func @assert_tensor_1d
+// CHECK-NOT:       tt.assert
+// CHECK:           linalg.generic {indexing_maps = [#map], iterator_types = ["parallel"]} ins(%0 : tensor<4xi1>) { 
+// CHECK:           ^bb0(%in: i1):
+// CHECK:             cf.assert %in, "Assertion `message` failed"
+// CHECK:             linalg.yield
+// CHECK:           }
+// CHECK-NOT:       tt.assert
+
+tt.func public @assert_tensor_2d() {
+  %0 = tensor.empty() : tensor<4x4xi1>
+  tt.assert %0, "message" : tensor<4x4xi1>
+  tt.return
+}
+
+// CHECK-LABEL:   func.func @assert_tensor_2d
+// CHECK-NOT:       tt.assert
+// CHECK:           linalg.generic {indexing_maps = [#map1], iterator_types = ["parallel", "parallel"]} ins(%0 : tensor<4x4xi1>) { 
+// CHECK:           ^bb0(%in: i1):
+// CHECK:             cf.assert %in, "Assertion `message` failed"
+// CHECK:             linalg.yield
+// CHECK:           }
+// CHECK-NOT:       tt.assert
+
+tt.func public @assert_tensor_3d() {
+  %0 = tensor.empty() : tensor<4x4x4xi1>
+  tt.assert %0, "message" : tensor<4x4x4xi1>
+  tt.return
+}
+
+// CHECK-LABEL:   func.func @assert_tensor_3d
+// CHECK-NOT:       tt.assert
+// CHECK:           linalg.generic {indexing_maps = [#map2], iterator_types = ["parallel", "parallel", "parallel"]} ins(%0 : tensor<4x4x4xi1>) { 
+// CHECK:           ^bb0(%in: i1):
+// CHECK:             cf.assert %in, "Assertion `message` failed"
+// CHECK:             linalg.yield
+// CHECK:           }
+// CHECK-NOT:       tt.assert


### PR DESCRIPTION
Adds device_assert support for tensors in triton-shared
- Done by looping through every element of the tensor, extracting each element, and adding a `cf.assert` for each element
- To make asserts work in the triton-shared CPU backend: compiling asserts results in symbols that are incompatible with shared libraries - requires compilation with PIC enabled