### PR TITLE
[MaskAnalysis] Fix implement of scalar conjunction in mask analysis.

### DIFF
--- a/include/triton-shared/Analysis/OpFoldResultUtils.h
+++ b/include/triton-shared/Analysis/OpFoldResultUtils.h
@@ -8,9 +8,9 @@
 #ifndef TRITON_ANALYSIS_OPFOLDRESULT_UTILS_H
 #define TRITON_ANALYSIS_OPFOLDRESULT_UTILS_H
 
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/IR/Location.h"
 #include "mlir/IR/OpDefinition.h"
-#include "mlir/Dialect/Arith/IR/Arith.h"
 
 #include <optional>
 
@@ -55,7 +55,7 @@ OpFoldResult subOFRs(const OpFoldResult lhs, const OpFoldResult rhs,
 // result is an Integer Attribtue. Otherwise, insert the arith.muli
 // instruction if needed and use its result Value.
 OpFoldResult mulOFRs(const OpFoldResult lhs, const OpFoldResult rhs,
-                         const Location loc, OpBuilder &b);
+                     const Location loc, OpBuilder &b);
 
 OpFoldResult minOFRs(const OpFoldResult lhs, const OpFoldResult rhs,
                      const Location loc, OpBuilder &b);
@@ -63,9 +63,15 @@ OpFoldResult minOFRs(const OpFoldResult lhs, const OpFoldResult rhs,
 OpFoldResult maxOFRs(const OpFoldResult lhs, const OpFoldResult rhs,
                      const Location loc, OpBuilder &b);
 
+OpFoldResult selectOFRs(const OpFoldResult cond, const OpFoldResult trueOFR,
+                        const OpFoldResult falseOFR, const Location loc,
+                        OpBuilder &b);
+
 OpFoldResult compareOFRs(const OpFoldResult lhs, const OpFoldResult rhs,
-                    const arith::CmpIPredicate pred, const OpFoldResult trueVal,
-                    const OpFoldResult falseVal, const Location loc, OpBuilder &b);
+                         const arith::CmpIPredicate pred,
+                         const OpFoldResult trueVal,
+                         const OpFoldResult falseVal, const Location loc,
+                         OpBuilder &b);
 } // namespace mlir
 
 #endif

--- a/lib/Analysis/MaskAnalysis.cpp
+++ b/lib/Analysis/MaskAnalysis.cpp
@@ -239,6 +239,14 @@ LogicalResult MaskState::minStateScalar(const MaskState &lhsState,
   // are either going to take the mask dimension or take nothing at all. To do
   // that we use a select on the scalar value with the mask dimension in the
   // true case and zero in the false case.
+  //
+  // Example:
+  // def kernel(..., index: i32, ...):
+  //   ...
+  //   offs = tl.arange(0, 8)
+  //   mask = offs < 4
+  //   scalar = index < 4
+  //   ... = tl.load(some_ptr, mask=scalar & mask, other=0)
   auto &scalarState = lhsState.scalar ? lhsState : rhsState;
   auto &nonScalarState = lhsState.scalar ? rhsState : lhsState;
   for (uint32_t i = 0; i < nonScalarState.getRank(); i++) {

--- a/lib/Analysis/OpFoldResultUtils.cpp
+++ b/lib/Analysis/OpFoldResultUtils.cpp
@@ -346,6 +346,10 @@ OpFoldResult selectOFRs(const OpFoldResult condOFR, const OpFoldResult trueOFR,
   auto falseValue = ofrToIndexValue(falseOFR, loc, b);
   auto condValue = ofrToIndexValue(condOFR, loc, b);
 
+  // Ideally we should not be passing around everything as index type since mask
+  // analysis can come across i1 values, but that improvement is being left for
+  // future work. For now we just unwrap an index back into it's i1 value if
+  // necessary.
   if (!condValue.getType().isInteger(1)) {
     assert(condValue.getDefiningOp<arith::IndexCastOp>());
     condValue = condValue.getDefiningOp<arith::IndexCastOp>().getOperand();

--- a/python/examples/test_mask.py
+++ b/python/examples/test_mask.py
@@ -37,3 +37,29 @@ def test_mask(device):
     print(input)
     print(output)
     torch.testing.assert_close(output, torch.tensor([-1, -1, -1, -1, -2, -2, -2, -2], device=device, dtype=torch.int32))
+
+
+def test_mask_with_scalar_in_conjunction(device):
+    if device == 'cpu':
+        triton.runtime.driver.set_active(CPUDriver())
+
+    @triton.jit
+    def kernel(in0, out0, mask, value):
+        offs = tl.arange(0, 8)
+        out_offs = tl.arange(0, 8)
+        a = tl.load(in0 + offs, mask=(value < 5) & (offs < mask), other=-1)
+        tl.store(out0 + out_offs, a)
+
+    # Test scalar mask evaluate to True
+    SIZE = 8
+    input = torch.arange(0, SIZE, device=device, dtype=torch.int32)
+    output = torch.full((SIZE,), -2, device=device, dtype=torch.int32)
+    kernel[(1,)](input, output, 4, 3)
+    torch.testing.assert_close(output, torch.tensor([0, 1, 2, 3, -1, -1, -1, -1], device=device, dtype=torch.int32))
+
+    # Test scalar mask evaluate to False
+    SIZE = 8
+    input = torch.arange(0, SIZE, device=device, dtype=torch.int32)
+    output = torch.full((SIZE,), -2, device=device, dtype=torch.int32)
+    kernel[(1,)](input, output, 4, 8)
+    torch.testing.assert_close(output, torch.tensor([-1, -1, -1, -1, -1, -1, -1, -1], device=device, dtype=torch.int32))

--- a/test/Conversion/TritonToStructured/mask_ld_st_scalar_dim.mlir
+++ b/test/Conversion/TritonToStructured/mask_ld_st_scalar_dim.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --triton-to-structured --remove-dead-values --canonicalize %s | FileCheck %s
+// RUN: triton-shared-opt --triton-to-structured --remove-dead-values --canonicalize --cse %s | FileCheck %s
 
 module {
   tt.func @mask_ld_st_scalar(
@@ -38,10 +38,11 @@ module {
   }
 }
 
-// CHECK:   %{{.*}} = "tts.load"(%{{.*}}, %{{.*}}) <{operandSegmentSizes = array<i32: 1, 1, 0>, static_mask_dims = array<i64: -9223372036854775808, 1>}> : (tensor<2x1x!tt.ptr<f32>>, index) -> tensor<2x1xf32>
-// CHECK:   %{{.*}} = "tts.load"(%{{.*}}, %{{.*}}) <{operandSegmentSizes = array<i32: 1, 1, 0>, static_mask_dims = array<i64: -9223372036854775808, 1>}> : (tensor<2x1x!tt.ptr<f32>>, index) -> tensor<2x1xf32>
-// CHECK:   "tts.store"(%{{.*}}, %{{.*}}, %{{.*}}) <{static_mask_dims = array<i64: -9223372036854775808, 1>}> : (tensor<2x1x!tt.ptr<f32>>, tensor<2x1xf32>, index) -> ()
-// CHECK:   "tts.store"(%{{.*}}, %{{.*}}, %{{.*}}) <{static_mask_dims = array<i64: -9223372036854775808, 1>}> : (tensor<2x1x!tt.ptr<f32>>, tensor<2x1xf32>, index) -> ()
+// CHECK:   %{{.*}} = "tts.load"(%{{.*}}, %{{.*}}, %{{.*}}) <{operandSegmentSizes = array<i32: 1, 2, 0>, static_mask_dims = array<i64: -9223372036854775808, -9223372036854775808>}> : (tensor<2x1x!tt.ptr<f32>>, index, index) -> tensor<2x1xf32>
+// CHECK:   %{{.*}} = "tts.load"(%{{.*}}, %{{.*}}, %{{.*}}) <{operandSegmentSizes = array<i32: 1, 2, 0>, static_mask_dims = array<i64: -9223372036854775808, -9223372036854775808>}> : (tensor<2x1x!tt.ptr<f32>>, index, index) -> tensor<2x1xf32>
+// CHECK:   "tts.store"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) <{static_mask_dims = array<i64: -9223372036854775808, -9223372036854775808>}> : (tensor<2x1x!tt.ptr<f32>>, tensor<2x1xf32>, index, index) -> ()
+// CHECK:   "tts.store"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) <{static_mask_dims = array<i64: -9223372036854775808, -9223372036854775808>}> : (tensor<2x1x!tt.ptr<f32>>, tensor<2x1xf32>, index, index) -> ()
+
 
 // Original Triton Function:
 // def test_masked_ld_st(


### PR DESCRIPTION
The original implementation of conjunction with scalar mistakenly assumed that the scalar argument would use it's dimension as the mask point. This does not work because scalar arguments should be a binary and not a pivot point. To support scalar arguments, we must either use the mask argument of the conjunction or completely zero out the mask. This PR changes the code generation so that select statements embedded this pattern.