### PR TITLE
Adds flag for old transpose behavior on reduction conversion.

### DIFF
--- a/include/triton-shared/Conversion/TritonArithToLinalg/Passes.td
+++ b/include/triton-shared/Conversion/TritonArithToLinalg/Passes.td
@@ -16,6 +16,10 @@ def TritonArithToLinalg : Pass<"triton-arith-to-linalg", "mlir::ModuleOp"> {
              "Convert tt.assert to cf.assert">,
       Option<"tensorPtrToLinalg", "tensor-ptr-to-linalg", "bool", /*default*/"false",
              "Convert triton ops on tensor of pointers to linalg.generic">,
+      Option<"transposeReduceToRank0", "transpose-reduce-to-rank0", "bool", /*default*/"true",
+             "Transpose reductions to rank 0 which collapses remaining dimensions. Otherwise "
+             "transpose any rank - 1 reduction to rank - 2 as the old behavior. These transposes "
+             "are planned for removal as Triton Shared should not be responsible for this.">,
   ];
 }
 

--- a/include/triton-shared/Conversion/TritonArithToLinalg/TritonArithToLinalg.h
+++ b/include/triton-shared/Conversion/TritonArithToLinalg/TritonArithToLinalg.h
@@ -18,13 +18,15 @@ void populateTritonArithToLinalgCanonicalizationPatterns(
 void populateTritonArithToLinalgConversionPatterns(bool pidsToFuncArgs,
                                                    bool addptrToLinalg,
                                                    bool assertToCf,
+                                                   bool transposeReduceToRank0,
                                                    RewritePatternSet &patterns);
 
 // Expand the triton pointer ops operating on pointers to linalg
 void populateTritonTensorPtrConversionPatterns(RewritePatternSet &patterns);
 
 std::unique_ptr<OperationPass<ModuleOp>>
-createTritonArithToLinalgPass(bool tensorPtrToLinalg = false);
+createTritonArithToLinalgPass(bool tensorPtrToLinalg = false,
+                              bool transposeReduceToRank0 = true);
 
 } // namespace triton
 } // namespace mlir

--- a/lib/Conversion/TritonArithToLinalg/TritonArithToLinalg.cpp
+++ b/lib/Conversion/TritonArithToLinalg/TritonArithToLinalg.cpp
@@ -50,7 +50,7 @@ void mlir::triton::populateTritonTensorPtrConversionPatterns(
 
 void mlir::triton::populateTritonArithToLinalgConversionPatterns(
     bool pidsToFuncArgs, bool addptrToLinalg, bool assertToCf,
-    RewritePatternSet &patterns) {
+    bool transposeReduceToRank0, RewritePatternSet &patterns) {
 
   if (pidsToFuncArgs) {
     patterns.add<GetProgramIDConverter, GetNumProgramsConverter>(
@@ -96,7 +96,7 @@ void mlir::triton::populateTritonArithToLinalgConversionPatterns(
   // aren't always multiple of 2s, which are sub-optimal for certain hardwares.
   patterns.add<ArgMinConverter>(patterns.getContext());
   patterns.add<ArgMaxConverter>(patterns.getContext());
-  patterns.add<ReduceConverter>(patterns.getContext());
+  patterns.add<ReduceConverter>(patterns.getContext(), transposeReduceToRank0);
 
   // Note: the ordering here matters!
   // These patterns are added last to they will be tried last.

--- a/lib/Conversion/TritonArithToLinalg/TritonArithToLinalgPass.cpp
+++ b/lib/Conversion/TritonArithToLinalg/TritonArithToLinalgPass.cpp
@@ -186,7 +186,8 @@ public:
     }
 
     triton::populateTritonArithToLinalgConversionPatterns(
-        pidsToFuncArgs, addptrToLinalg, assertToCf, patterns);
+        pidsToFuncArgs, addptrToLinalg, assertToCf, transposeReduceToRank0,
+        patterns);
 
     if (pidsToFuncArgs) {
       for (auto func : getOperation().getOps<triton::FuncOp>()) {
@@ -244,8 +245,10 @@ public:
 } // namespace
 
 std::unique_ptr<OperationPass<ModuleOp>>
-triton::createTritonArithToLinalgPass(bool tensorPtrToLinalg) {
+triton::createTritonArithToLinalgPass(bool tensorPtrToLinalg,
+                                      bool transposeReduceToRank0) {
   TritonArithToLinalgOptions options;
   options.tensorPtrToLinalg = tensorPtrToLinalg;
+  options.transposeReduceToRank0 = transposeReduceToRank0;
   return std::make_unique<TritonArithToLinalgPass>(options);
 }


### PR DESCRIPTION
Preferably Triton Shared should not be doing any transposes for optimizations because we lack the wider analysis to understand if these transformations are going to be helpful or not. That will be a part of future work.

For now, we need the old transpose behavior on the Reduce Conversion where it just transposes rank - 1 reductions to rank - 2. This is added with a flag that is default off.