### PR TITLE
Use sha256 to satisfy weak hash query.

### DIFF
--- a/backend/compiler.py
+++ b/backend/compiler.py
@@ -200,7 +200,7 @@ class CPUOptions:
 
     def hash(self):
         key = '_'.join([f'{name}-{val}' for name, val in self.__dict__.items()])
-        return hashlib.md5(key.encode("utf-8")).hexdigest()
+        return hashlib.sha256(key.encode("utf-8")).hexdigest()
 
 
 class CPUBackend(BaseBackend):

--- a/backend/driver.py
+++ b/backend/driver.py
@@ -269,7 +269,7 @@ def compile_module(launcher_src, kernel_placeholder_name):
         kernel_name = kernel_metadata[6] # see pack_metadata in compiler.py
         src = launcher_src.replace(kernel_placeholder_name, kernel_name)
 
-        key = hashlib.md5(src.encode("utf-8") + kernel_obj).hexdigest()
+        key = hashlib.sha256(src.encode("utf-8") + kernel_obj).hexdigest()
         cache = get_cache_manager(key)
         name = "__triton_shared_ref_cpu_kernel_launcher"
 


### PR DESCRIPTION
CodeQL flags usage of md5 so switch to sha256 like used in the rest of Triton.