### PR TITLE
Fix lit subfolder tests failing when run via ninja check-triton-lit-tests-<folder>

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,7 +7,7 @@ configure_lit_site_cfg(
   ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
   ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py
   MAIN_CONFIG
-  ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py
+  ${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg.py
 )
 
 set(TRITON_SHARED_TEST_DEPENDS


### PR DESCRIPTION
### Summary

This PR fixes an issue where running a specific lit test folder
(e.g., `Conversion`) using `ninja check-triton-lit-tests-<folder>` fails with the error:
```
(triton) zzl@zzl-ubuntu:~/Project/triton-project/triton-shared/triton/build/cmake.linux-x86_64-cpython-3.10$ ninja check-triton-shared-lit-tests-conversion -v
[0/1] cd /home/zzl/Project/triton-project/triton-shared/triton/build/cmake.linux-x86_64-cpython-3.10/third_party/triton_shared/test && /usr/bin/python3 /home/zzl/.local/bin/lit -sv /home/zzl/Project/triton-project/triton-shared/test/Conversion
lit: /home/zzl/.local/lib/python3.10/site-packages/lit/TestingConfig.py:152: fatal: unable to parse config file '/home/zzl/Project/triton-project/triton-shared/test/lit.cfg.py', traceback: Traceback (most recent call last):
  File "/home/zzl/.local/lib/python3.10/site-packages/lit/TestingConfig.py", line 140, in load_from_path
    exec(compile(data, path, "exec"), cfg_globals, None)
  File "/home/zzl/Project/triton-project/triton-shared/test/lit.cfg.py", line 19, in <module>
    config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
AttributeError: 'NoneType' object has no attribute 'use_lit_shell'

FAILED: third_party/triton_shared/test/CMakeFiles/check-triton-shared-lit-tests-conversion /home/zzl/Project/triton-project/triton-shared/triton/build/cmake.linux-x86_64-cpython-3.10/third_party/triton_shared/test/CMakeFiles/check-triton-shared-lit-tests-conversion 
cd /home/zzl/Project/triton-project/triton-shared/triton/build/cmake.linux-x86_64-cpython-3.10/third_party/triton_shared/test && /usr/bin/python3 /home/zzl/.local/bin/lit -sv /home/zzl/Project/triton-project/triton-shared/test/Conversion
ninja: build stopped: subcommand failed.
```

The issue is that llvm_config ends up being NoneType, because ninja check is executed in ${CMAKE_CURRENT_SOURCE_DIR} instead of ${CMAKE_CURRENT_BINARY_DIR}.
As a result, lit.site.cfg.py is not invoked, which is supposed to call lit.llvm.initialize and properly initialize llvm_config.

### Changes
	•	Run tests from the binary directory in TRITON-LIT-TESTS.
	•	Explicitly set MAIN_CONFIG to lit.site.cfg.py so that llvm_config is initialized correctly.