### PR TITLE
fix: remove spurious link to `libpython`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,5 +16,5 @@ add_subdirectory(tools/triton-shared-opt)
 
 if (TRITON_SHARED_BUILD_CPU_BACKEND)
     add_triton_plugin(TritonShared ${CMAKE_CURRENT_SOURCE_DIR}/triton_shared.cc LINK_LIBS TritonSharedAnalysis TritonToLinalg TritonTilingExtIR)
-    target_link_libraries(TritonShared PRIVATE Python3::Module pybind11::headers ${Python3_LIBRARIES})
+    target_link_libraries(TritonShared PRIVATE Python3::Module pybind11::headers)
 endif()


### PR DESCRIPTION
`libpython` is intended for host applications which wish to embed an interpreter w/o static linking a specific python version. Binary modules should *not* link to `libpython` for symbols, and should instead bind to symbols provided by the host environment.

See the section on `libpython` in PEP 513 for more details.