### PR TITLE
Update triton to e44bd1c83c1c3e8deac7c4f02683cfb3cc395c8b

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "triton"]
-	path = triton
-	url = https://github.com/triton-lang/triton.git

--- a/backend/driver.py
+++ b/backend/driver.py
@@ -54,6 +54,10 @@ def _ty_to_cpp(ty):
         "u16": "uint16_t",
         "u32": "uint32_t",
         "u64": "uint64_t",
+        # Proper support for bfloat16 and float16 is not yet handled.
+        # https://github.com/microsoft/triton-shared/issues/348
+        # "fp16": "TODO",
+        # "bf16": "TODO",
         "fp32": "float",
         "f32": "float",
         "fp64": "double",

--- a/backend/driver.py
+++ b/backend/driver.py
@@ -54,8 +54,6 @@ def _ty_to_cpp(ty):
         "u16": "uint16_t",
         "u32": "uint32_t",
         "u64": "uint64_t",
-        "fp16": "float",
-        "bf16": "float",
         "fp32": "float",
         "f32": "float",
         "fp64": "double",

--- a/include/triton-shared/Dialect/TPtr/IR/TPtrDialect.td
+++ b/include/triton-shared/Dialect/TPtr/IR/TPtrDialect.td
@@ -109,9 +109,6 @@ def TPTR_TypeOffsetOp : TPTR_Op<"type_offset", [ConstantLike, Pure]> {
 
   let arguments = (ins TypeAttr:$baseType);
   let results = (outs AnySignlessIntegerOrIndex:$result);
-  let builders = [
-    OpBuilder<(ins "TypeAttr":$baseType, CArg<"Type", "nullptr">:$resultTy)>
-  ];
   let assemblyFormat = [{
      attr-dict $baseType custom<IntType>(type($result))
   }];

--- a/lib/Conversion/StructuredToMemref/StructuredToMemref.cpp
+++ b/lib/Conversion/StructuredToMemref/StructuredToMemref.cpp
@@ -577,21 +577,18 @@ public:
 
 struct MakeGatherScatterTensorPtrConverter
     : public OpConversionPattern<tts::MakeGatherScatterTensorPtrOp> {
-private:
-  using OpConversionPattern<tts::MakeGatherScatterTensorPtrOp>::OpConversionPattern;
-
-public:
-  MakeGatherScatterTensorPtrConverter(const TypeConverter &typeConverter,
-                         MLIRContext *context)
-      : OpConversionPattern<tts::MakeGatherScatterTensorPtrOp>(typeConverter, context) {}
+  using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
   matchAndRewrite(tts::MakeGatherScatterTensorPtrOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     // The gatherScatterPtr is rewritten as separate rows during load/store
     // operations. Therefore, no action is needed here except saving
-    // adaptor.getBase().
-    rewriter.replaceOp(op, adaptor.getBase());
+    // adaptor.getBase(). DialectConversion will ignore pure type conversion if
+    // we were to simply replace the op with adaptor.getBase(). To circumvent
+    // this we create an identity cast.
+    rewriter.replaceOpWithNewOp<UnrealizedConversionCastOp>(
+        op, adaptor.getBase().getType(), adaptor.getBase());
     return success();
   }
 };

--- a/lib/Conversion/TritonArithToLinalg/TritonArithToLinalg.cpp
+++ b/lib/Conversion/TritonArithToLinalg/TritonArithToLinalg.cpp
@@ -78,6 +78,7 @@ void mlir::triton::populateTritonArithToLinalgConversionPatterns(
   patterns.add<ClampConverter>(patterns.getContext());
   patterns.add<MatmulConverter>(patterns.getContext());
   patterns.add<SplatConverter>(patterns.getContext());
+  patterns.add<UnsplatConverter>(patterns.getContext());
   patterns.add<DenseConstantConverter>(patterns.getContext());
   patterns.add<CumSumConverter>(patterns.getContext());
   patterns.add<ReshapeConverter>(patterns.getContext());

--- a/lib/Conversion/TritonToLinalg/TritonToLinalg.cpp
+++ b/lib/Conversion/TritonToLinalg/TritonToLinalg.cpp
@@ -63,6 +63,7 @@ void mlir::triton::populateTritonToLinalgConversionPatterns(
   patterns.add<AssertConverter>(patterns.getContext());
   patterns.add<MatmulConverter>(patterns.getContext());
   patterns.add<SplatConverter>(patterns.getContext());
+  patterns.add<UnsplatConverter>(patterns.getContext());
   patterns.add<DenseConstantConverter>(patterns.getContext());
   patterns.add<UnrealizedCastConverter>(patterns.getContext());
   patterns.add<CumSumConverter>(patterns.getContext());

--- a/lib/Conversion/UnstructuredToMemref/UnstructuredToMemrefPass.cpp
+++ b/lib/Conversion/UnstructuredToMemref/UnstructuredToMemrefPass.cpp
@@ -104,7 +104,7 @@ struct ScalarLoadConverter : public OpConversionPattern<tts::GatherOp> {
     auto zeroMap = AffineMap::getConstantMap(0, rewriter.getContext());
 
     auto scalarLoadOp = rewriter.create<affine::AffineLoadOp>(
-        loc, memref, zeroMap, std::nullopt);
+        loc, memref, zeroMap, ValueRange{});
 
     rewriter.replaceOp(gatherOp, scalarLoadOp.getResult());
 
@@ -150,7 +150,7 @@ struct ScalarStoreConverter : public OpConversionPattern<tts::ScatterOp> {
     auto zeroMap = AffineMap::getConstantMap(0, rewriter.getContext());
 
     rewriter.create<affine::AffineStoreOp>(loc, storeVal, memref, zeroMap,
-                                           std::nullopt);
+                                           ValueRange{});
     rewriter.eraseOp(scatterOp);
 
     return success();

--- a/test/Conversion/TritonToLinalgExperimental/convert_unsplat.mlir
+++ b/test/Conversion/TritonToLinalgExperimental/convert_unsplat.mlir
@@ -6,10 +6,7 @@ module {
     %0 = tt.splat %arg0 : !tt.ptr<i32> -> tensor<1x!tt.ptr<i32>>
     %1 = tt.load %0 : tensor<1x!tt.ptr<i32>>
     %2 = arith.cmpi sgt, %1, %cst : tensor<1xi32>
-    %3 = "tt.reduce"(%2) <{axis = 0 : i32}> ({
-    ^bb0(%arg1: i1, %arg2: i1):
-      tt.reduce.return %arg1 : i1
-    }) : (tensor<1xi1>) -> i1
+    %3 = tt.unsplat %2 : tensor<1xi1>
     scf.if %3 {
       tt.store %arg0, %c42_i32 : !tt.ptr<i32>
     }

--- a/tools/triton-shared-opt/CMakeLists.txt
+++ b/tools/triton-shared-opt/CMakeLists.txt
@@ -15,6 +15,7 @@ target_link_libraries(triton-shared-opt PRIVATE
   # MLIR core
   MLIROptLib
   MLIRPass
+  MLIRRegisterAllPasses
   MLIRTransforms
 )
 

--- a/tools/triton-shared-opt/RegisterTritonSharedDialects.h
+++ b/tools/triton-shared-opt/RegisterTritonSharedDialects.h
@@ -45,7 +45,7 @@ inline void registerTritonSharedDialects(mlir::DialectRegistry &registry) {
       mlir::ttx::TritonTilingExtDialect, mlir::tts::TritonStructuredDialect,
       mlir::triton::TritonDialect, mlir::cf::ControlFlowDialect,
       mlir::math::MathDialect, mlir::arith::ArithDialect, mlir::scf::SCFDialect,
-      mlir::gpu::GPUDialect, mlir::linalg::LinalgDialect,
-      mlir::func::FuncDialect, mlir::tensor::TensorDialect,
-      mlir::memref::MemRefDialect, mlir::bufferization::BufferizationDialect>();
+      mlir::linalg::LinalgDialect, mlir::func::FuncDialect,
+      mlir::tensor::TensorDialect, mlir::memref::MemRefDialect,
+      mlir::bufferization::BufferizationDialect>();
 }

--- a/triton-hash.txt
+++ b/triton-hash.txt
@@ -1,1 +1,1 @@
-ec8cb09329cf25ac241a7dee1eea5a5d94daef8a
+e44bd1c83c1c3e8deac7c4f02683cfb3cc395c8b


### PR DESCRIPTION
This updates to latest Triton main which should resolve the nightly build issues.

Primary changes:
* Change conversion of tts::MakeGatherScatterTensorPtrOp to insert identity cast so that DialectConversion does not ignore the type converted operand of the associated tts::LoadOp when supplying the op adaptor to the pattern.
* Move support of unsplat to the new dedicated operation since they do not do reduction anymore
* Add missing test figure to conftest
* Disable float annotation tests since bfloat16 and float16 are not supported in CPU backend
* Add missing link library to registering of passes
* Update construction of ValueRange{} which was causing compilation errors.
* Remove unused builder in TPtrOps since it caused linker errors.
* Remove bfloat16 and float16 from CPU backend since not testing is present. Better to crash during compilation than get runtime errors.
* Remove GPUDialect that is no longer present upstream
