### PR TITLE
Fix MaskAnalysis bool type workaround

### DIFF
--- a/include/triton-shared/Analysis/OpFoldResultUtils.h
+++ b/include/triton-shared/Analysis/OpFoldResultUtils.h
@@ -27,6 +27,9 @@ std::optional<int64_t> getIntAttr(const OpFoldResult ofr);
 // attribute or a constant value.
 bool hasConstZero(const OpFoldResult ofr);
 
+// Cast OpFoldResult to Value.
+Value ofrToValue(const OpFoldResult ofr, const Location loc, OpBuilder &b);
+
 // Create a value of index type if necessary from an OpFoldResult.
 Value ofrToIndexValue(const OpFoldResult ofr, const Location loc, OpBuilder &b);
 

--- a/lib/Analysis/MaskAnalysis.cpp
+++ b/lib/Analysis/MaskAnalysis.cpp
@@ -302,9 +302,13 @@ LogicalResult MaskState::parseConstant(arith::ConstantOp constOp,
 LogicalResult MaskState::parseIntScalar(Value scalar, const Location loc,
                                         OpBuilder &builder) {
   assert(this->isEmpty());
-  auto castOp =
-      builder.create<arith::IndexCastOp>(loc, builder.getIndexType(), scalar);
-  this->scalar = castOp.getResult();
+  if (scalar.getType().isInteger(1)) {
+    this->scalar = scalar;
+  } else {
+    auto castOp =
+        builder.create<arith::IndexCastOp>(loc, builder.getIndexType(), scalar);
+    this->scalar = castOp.getResult();
+  }
   return success();
 }
 


### PR DESCRIPTION
In MaskAnalysis, a Boolean type shouldn't be passed around as Index.
This replaces the workaround added in PR https://github.com/microsoft/triton-shared/pull/318. 
We use the following two tests as baseline, they needed the workaround to pass before and now passing with our fix.
```
test/Conversion/TritonToStructured/mask_ld_st_scalar_dim.mlir
python/examples/test_mask.py
```