### PR TITLE
Setup clang-format action and format the whole codebase.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+BasedOnStyle: LLVM

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,27 @@
+name: clang-format
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  clang-format:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12"]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install clang-format==20.1.8 ripgrep
+    - name: Running clang-format
+      run: |
+        rg . --type cpp --type c --files-with-matches \
+            | xargs clang-format --dry-run --Werror

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -8,19 +8,15 @@ on:
 jobs:
   clang-format:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.12"]
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python 3.12
       uses: actions/setup-python@v2
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: "3.12"
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install clang-format==20.1.8 ripgrep
+        pip install clang-format==20.1.8 ripgrep==14.1.0
     - name: Running clang-format
       run: |
         rg . --type cpp --type c --files-with-matches \

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,5 @@
 compile_commands.json
 build/*
 .vscode/*
-/.clang-format
-test_core.py
-test_annotations.py
+/python/examples/test_core.py
+/python/examples/test_annotations.py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,15 +27,12 @@ if (TRITON_SHARED_BUILD_CPU_BACKEND)
     target_link_libraries(TritonShared PRIVATE Python3::Module pybind11::headers)
 endif()
 
-# Add symlinks to selected pytest files and the clang-format setting in triton. The tests are imported into triton-shared’s test folder to 
-# run under triton-shared's conftest configuration, and the clang-format link ensures consistent code style enforcement across both repositories.
+# Add symlinks to selected pytest files in triton. The tests are imported into triton-shared’s test folder to
+# run under triton-shared's conftest configuration.
 cmake_path(APPEND CMAKE_CURRENT_SOURCE_DIR "python" "examples" "test_core.py" OUTPUT_VARIABLE TRITON_SHARED_TEST_CORE)
 cmake_path(APPEND CMAKE_CURRENT_SOURCE_DIR "python" "examples" "test_annotations.py" OUTPUT_VARIABLE TRITON_SHARED_TEST_ANNOTATIONS)
-cmake_path(APPEND CMAKE_CURRENT_SOURCE_DIR ".clang-format" OUTPUT_VARIABLE TRITON_SHARED_CLANG_FORMAT_SETTING)
 cmake_path(APPEND CMAKE_SOURCE_DIR "python" "test" "unit" "language" "test_core.py" OUTPUT_VARIABLE TRITON_TEST_CORE)
 cmake_path(APPEND CMAKE_SOURCE_DIR "python" "test" "unit" "language" "test_annotations.py" OUTPUT_VARIABLE TRITON_TEST_ANNOTATIONS)
-cmake_path(APPEND CMAKE_SOURCE_DIR ".clang-format" OUTPUT_VARIABLE TRITON_CLANG_FORMAT_SETTING)
 
 add_symlink(${TRITON_TEST_CORE} ${TRITON_SHARED_TEST_CORE})
 add_symlink(${TRITON_TEST_ANNOTATIONS} ${TRITON_SHARED_TEST_ANNOTATIONS})
-add_symlink(${TRITON_CLANG_FORMAT_SETTING} ${TRITON_SHARED_CLANG_FORMAT_SETTING})

--- a/backend/include/ExecutionEngine/CRunnerUtils.cpp
+++ b/backend/include/ExecutionEngine/CRunnerUtils.cpp
@@ -16,7 +16,7 @@
 #include "Msan.h"
 
 #ifndef _WIN32
-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || \
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) ||     \
     defined(__DragonFly__)
 #include <cstdlib>
 #else
@@ -37,10 +37,7 @@
 #ifdef MLIR_CRUNNERUTILS_DEFINE_FUNCTIONS
 
 namespace {
-template <typename V>
-void stdSort(uint64_t n, V *p) {
-  std::sort(p, p + n);
-}
+template <typename V> void stdSort(uint64_t n, V *p) { std::sort(p, p + n); }
 
 } // namespace
 

--- a/backend/include/ExecutionEngine/CRunnerUtils.h
+++ b/backend/include/ExecutionEngine/CRunnerUtils.h
@@ -50,11 +50,9 @@ constexpr unsigned nextPowerOf2(int n) {
   return (n <= 1) ? 1 : (isPowerOf2(n) ? n : (2 * nextPowerOf2((n + 1) / 2)));
 }
 
-template <typename T, int Dim, bool IsPowerOf2>
-struct Vector1D;
+template <typename T, int Dim, bool IsPowerOf2> struct Vector1D;
 
-template <typename T, int Dim>
-struct Vector1D<T, Dim, /*IsPowerOf2=*/true> {
+template <typename T, int Dim> struct Vector1D<T, Dim, /*IsPowerOf2=*/true> {
   Vector1D() {
     static_assert(detail::nextPowerOf2(sizeof(T[Dim])) == sizeof(T[Dim]),
                   "size error");
@@ -68,8 +66,7 @@ private:
 
 // 1-D vector, padded to the next power of 2 allocation.
 // Specialization occurs to avoid zero size arrays (which fail in -Werror).
-template <typename T, int Dim>
-struct Vector1D<T, Dim, /*IsPowerOf2=*/false> {
+template <typename T, int Dim> struct Vector1D<T, Dim, /*IsPowerOf2=*/false> {
   Vector1D() {
     static_assert(nextPowerOf2(sizeof(T[Dim])) > sizeof(T[Dim]), "size error");
     static_assert(nextPowerOf2(sizeof(T[Dim])) < 2 * sizeof(T[Dim]),
@@ -86,8 +83,7 @@ private:
 } // namespace mlir
 
 // N-D vectors recurse down to 1-D.
-template <typename T, int Dim, int... Dims>
-struct Vector {
+template <typename T, int Dim, int... Dims> struct Vector {
   inline Vector<T, Dims...> &operator[](unsigned i) { return vector[i]; }
   inline const Vector<T, Dims...> &operator[](unsigned i) const {
     return vector[i];
@@ -105,17 +101,14 @@ struct Vector<T, Dim>
                                     mlir::detail::isPowerOf2(sizeof(T[Dim]))> {
 };
 
-template <int D1, typename T>
-using Vector1D = Vector<T, D1>;
-template <int D1, int D2, typename T>
-using Vector2D = Vector<T, D1, D2>;
+template <int D1, typename T> using Vector1D = Vector<T, D1>;
+template <int D1, int D2, typename T> using Vector2D = Vector<T, D1, D2>;
 template <int D1, int D2, int D3, typename T>
 using Vector3D = Vector<T, D1, D2, D3>;
 template <int D1, int D2, int D3, int D4, typename T>
 using Vector4D = Vector<T, D1, D2, D3, D4>;
 
-template <int N>
-void dropFront(int64_t arr[N], int64_t *res) {
+template <int N> void dropFront(int64_t arr[N], int64_t *res) {
   for (unsigned i = 1; i < N; ++i)
     *(res + i - 1) = arr[i];
 }
@@ -123,12 +116,10 @@ void dropFront(int64_t arr[N], int64_t *res) {
 //===----------------------------------------------------------------------===//
 // Codegen-compatible structures for StridedMemRef type.
 //===----------------------------------------------------------------------===//
-template <typename T, int Rank>
-class StridedMemrefIterator;
+template <typename T, int Rank> class StridedMemrefIterator;
 
 /// StridedMemRef descriptor type with static rank.
-template <typename T, int N>
-struct StridedMemRefType {
+template <typename T, int N> struct StridedMemRefType {
   T *basePtr;
   T *data;
   int64_t offset;
@@ -165,8 +156,7 @@ struct StridedMemRefType {
 };
 
 /// StridedMemRef descriptor type specialized for rank 1.
-template <typename T>
-struct StridedMemRefType<T, 1> {
+template <typename T> struct StridedMemRefType<T, 1> {
   T *basePtr;
   T *data;
   int64_t offset;
@@ -188,8 +178,7 @@ struct StridedMemRefType<T, 1> {
 };
 
 /// StridedMemRef descriptor type specialized for rank 0.
-template <typename T>
-struct StridedMemRefType<T, 0> {
+template <typename T> struct StridedMemRefType<T, 0> {
   T *basePtr;
   T *data;
   int64_t offset;
@@ -207,8 +196,7 @@ struct StridedMemRefType<T, 0> {
 };
 
 /// Iterate over all elements in a strided memref.
-template <typename T, int Rank>
-class StridedMemrefIterator {
+template <typename T, int Rank> class StridedMemrefIterator {
 public:
   using iterator_category = std::forward_iterator_tag;
   using value_type = T;
@@ -261,8 +249,7 @@ private:
 };
 
 /// Iterate over all elements in a 0-ranked strided memref.
-template <typename T>
-class StridedMemrefIterator<T, 0> {
+template <typename T> class StridedMemrefIterator<T, 0> {
 public:
   using iterator_category = std::forward_iterator_tag;
   using value_type = T;
@@ -307,8 +294,7 @@ private:
 // Codegen-compatible structure for UnrankedMemRef type.
 //===----------------------------------------------------------------------===//
 // Unranked MemRef
-template <typename T>
-struct UnrankedMemRefType {
+template <typename T> struct UnrankedMemRefType {
   int64_t rank;
   void *descriptor;
 };
@@ -316,12 +302,10 @@ struct UnrankedMemRefType {
 //===----------------------------------------------------------------------===//
 // DynamicMemRefType type.
 //===----------------------------------------------------------------------===//
-template <typename T>
-class DynamicMemRefIterator;
+template <typename T> class DynamicMemRefIterator;
 
 // A reference to one of the StridedMemRef types.
-template <typename T>
-class DynamicMemRefType {
+template <typename T> class DynamicMemRefType {
 public:
   int64_t rank;
   T *basePtr;
@@ -388,8 +372,7 @@ public:
 };
 
 /// Iterate over all elements in a dynamic memref.
-template <typename T>
-class DynamicMemRefIterator {
+template <typename T> class DynamicMemRefIterator {
 public:
   using iterator_category = std::forward_iterator_tag;
   using value_type = T;

--- a/include/triton-shared/Analysis/MaskAnalysis.h
+++ b/include/triton-shared/Analysis/MaskAnalysis.h
@@ -90,8 +90,9 @@ private:
   LogicalResult addStates(const MaskState &lhsState, const MaskState &rhsState,
                           Location loc, OpBuilder &builder);
 
-  LogicalResult minStateScalar(const MaskState &lhsState, const MaskState &rhsState,
-                          Location loc, OpBuilder &builder);
+  LogicalResult minStateScalar(const MaskState &lhsState,
+                               const MaskState &rhsState, Location loc,
+                               OpBuilder &builder);
 
   LogicalResult minStates(const MaskState &lhsState, const MaskState &rhsState,
                           Location loc, OpBuilder &builder);

--- a/include/triton-shared/AnalysisStructured/PtrAnalysis.h
+++ b/include/triton-shared/AnalysisStructured/PtrAnalysis.h
@@ -46,9 +46,9 @@ const extern std::string ptrAnalysisAttr;
 // address, it will be collapsed to 1D. To support gather/scatter access, treat
 // the unstructured offset as a whole offset instead of decoding the pointer
 // arithmetic on it except scalar mul.
-// The stride is set to 1 when there's no scalar mul so it still matches the offset *
-// stride formula. When there're scalar muls, the stride is set to the multiplication
-// of all the scalar strides.
+// The stride is set to 1 when there's no scalar mul so it still matches the
+// offset * stride formula. When there're scalar muls, the stride is set to the
+// multiplication of all the scalar strides.
 struct PtrState {
   SmallVector<OpFoldResult> offsets;
   SmallVector<OpFoldResult> sizes;
@@ -321,14 +321,16 @@ public:
   // Operand is the result of tt.int_to_ptr.
   // Expected result:
   //  Directly grab op result
-  LogicalResult visitOperandIntToPtr(triton::IntToPtrOp intToPtrOp, PtrState &state,
-                                     const Location loc, OpBuilder &builder);
+  LogicalResult visitOperandIntToPtr(triton::IntToPtrOp intToPtrOp,
+                                     PtrState &state, const Location loc,
+                                     OpBuilder &builder);
 
   // Operand is the result of tt.bitcast.
   // Expected result:
   //  Directly grab op result
-  LogicalResult visitOperandBitcast(triton::BitcastOp bitcastOp, PtrState &state,
-                                    const Location loc, OpBuilder &builder);
+  LogicalResult visitOperandBitcast(triton::BitcastOp bitcastOp,
+                                    PtrState &state, const Location loc,
+                                    OpBuilder &builder);
 
   // Get the computed PtrState for the forOp's init-arg at the provided index.
   FailureOr<PtrState> getLoopInitArgPtrState(scf::ForOp forOp, size_t index);

--- a/include/triton-shared/Conversion/TritonArithToLinalg/ConversionTools.h
+++ b/include/triton-shared/Conversion/TritonArithToLinalg/ConversionTools.h
@@ -6,7 +6,8 @@
 namespace mlir {
 namespace triton {
 
-static inline SmallVector<utils::IteratorType> getNParallelLoopsAttrs(unsigned n) {
+static inline SmallVector<utils::IteratorType>
+getNParallelLoopsAttrs(unsigned n) {
   return SmallVector<utils::IteratorType>(n, utils::IteratorType::parallel);
 }
 

--- a/include/triton-shared/Conversion/TritonToLinalgExperimental/Passes.h
+++ b/include/triton-shared/Conversion/TritonToLinalgExperimental/Passes.h
@@ -8,10 +8,10 @@
 #ifndef TRITON_TO_LINALG_EXPERIMENTAL_CONVERSION_PASSES_H
 #define TRITON_TO_LINALG_EXPERIMENTAL_CONVERSION_PASSES_H
 
-#include "triton-shared/Conversion/TritonToLinalgExperimental/TritonToLinalgExperimental.h"
-#include "triton-shared/Conversion/TritonToLinalgExperimental/ReconcilePtrCasts.h"
-#include "triton-shared/Conversion/TritonToLinalgExperimental/TritonToPtr.h"
 #include "triton-shared/Conversion/TritonToLinalgExperimental/CollapseShape.h"
+#include "triton-shared/Conversion/TritonToLinalgExperimental/ReconcilePtrCasts.h"
+#include "triton-shared/Conversion/TritonToLinalgExperimental/TritonToLinalgExperimental.h"
+#include "triton-shared/Conversion/TritonToLinalgExperimental/TritonToPtr.h"
 
 namespace mlir {
 namespace triton {

--- a/include/triton-shared/Transform/AddLLVMDebugInfo/AddLLVMDebugInfo.h
+++ b/include/triton-shared/Transform/AddLLVMDebugInfo/AddLLVMDebugInfo.h
@@ -20,7 +20,6 @@ namespace triton {
 
 std::unique_ptr<OperationPass<ModuleOp>> createAddLLVMDebugInfoPass();
 
-
 } // namespace triton
 } // namespace mlir
 

--- a/include/triton-shared/Utils/Utils.h
+++ b/include/triton-shared/Utils/Utils.h
@@ -5,7 +5,8 @@
 
 namespace mlir {
 namespace triton {
-// Return true if the input type is a triton pointer or a tensor of triton pointers
+// Return true if the input type is a triton pointer or a tensor of triton
+// pointers
 bool isPtrTypeLike(Type t);
 } // namespace triton
 

--- a/lib/Analysis/OpFoldResultUtils.cpp
+++ b/lib/Analysis/OpFoldResultUtils.cpp
@@ -355,7 +355,8 @@ OpFoldResult selectOFRs(const OpFoldResult condOFR, const OpFoldResult trueOFR,
   auto trueValue = ofrToIndexValue(trueOFR, loc, b);
   auto falseValue = ofrToIndexValue(falseOFR, loc, b);
   auto condValue = ofrToValue(condOFR, loc, b);
-  assert(condValue.getType().isInteger(1) && "Condition for selectOp must be a bool type");
+  assert(condValue.getType().isInteger(1) &&
+         "Condition for selectOp must be a bool type");
 
   auto selectOp =
       b.create<arith::SelectOp>(loc, condValue, trueValue, falseValue);

--- a/lib/AnalysisStructured/PtrAnalysis.cpp
+++ b/lib/AnalysisStructured/PtrAnalysis.cpp
@@ -284,13 +284,13 @@ LogicalResult PtrState::addState(const PtrState &lhsState,
           }
 
           if (lhsStride == rhsStride) {
-            // For case like lhs_offset * stride + rhs_offset * stride, it is same as
-            // (lhs_offset + rhs_offset) * stride.
-            // We can just
-            // add the offsets and reuse the stride like this:
+            // For case like lhs_offset * stride + rhs_offset * stride, it is
+            // same as (lhs_offset + rhs_offset) * stride. We can just add the
+            // offsets and reuse the stride like this:
             //   offsets[i] = lhsOffset + rhsOffset
             //   strides[i] = lhsStride
-            // Expand structured offset since unstructured offset has tensor type.
+            // Expand structured offset since unstructured offset has tensor
+            // type.
             if (!lhsState.dimIsStructured(i)) {
               rhsOffset = expandOFRIndex(rhsOffset, lhsOffset, loc, builder);
             } else {
@@ -306,10 +306,9 @@ LogicalResult PtrState::addState(const PtrState &lhsState,
             // equal to 1 earlier for case both offsets and strides not equal.
             assert(lhsOffset == rhsOffset &&
                    "If strides are not equal, offsets must be equal");
-            // For case like offset * lhs_stride + offset * rhs_stride, it is same as
-            // offset * (lhs_stride + rhs_stride).
-            // We can just
-            // add the strides and reuse the offset like this:
+            // For case like offset * lhs_stride + offset * rhs_stride, it is
+            // same as offset * (lhs_stride + rhs_stride). We can just add the
+            // strides and reuse the offset like this:
             //   offsets[i] = lhsOffset
             //   strides[i] = lhsStride + rhsStride
 

--- a/lib/Conversion/StructuredToMemref/StructuredToMemrefPass.cpp
+++ b/lib/Conversion/StructuredToMemref/StructuredToMemrefPass.cpp
@@ -50,15 +50,13 @@ public:
     });
     addTargetMaterialization([&](OpBuilder &builder,
                                  UnrankedMemRefType resultType,
-                                 ValueRange inputs,
-                                 Location loc) -> Value {
+                                 ValueRange inputs, Location loc) -> Value {
       return builder.create<UnrealizedConversionCastOp>(loc, resultType, inputs)
           .getResult(0);
     });
 
     addSourceMaterialization([&](OpBuilder &builder, Type resultType,
-                                 ValueRange inputs,
-                                 Location loc) -> Value {
+                                 ValueRange inputs, Location loc) -> Value {
       return builder.create<UnrealizedConversionCastOp>(loc, resultType, inputs)
           .getResult(0);
     });

--- a/lib/Conversion/TritonPtrToMemref/TritonPtrToMemrefPass.cpp
+++ b/lib/Conversion/TritonPtrToMemref/TritonPtrToMemrefPass.cpp
@@ -60,8 +60,7 @@ public:
     });
 
     auto createUnrealizedCast = [&](OpBuilder &builder, Type resultType,
-                                    ValueRange inputs,
-                                    Location loc) -> Value {
+                                    ValueRange inputs, Location loc) -> Value {
       return builder.create<UnrealizedConversionCastOp>(loc, resultType, inputs)
           .getResult(0);
     };

--- a/lib/Conversion/TritonToLinalgExperimental/TritonToLinalgExperimentalPass.cpp
+++ b/lib/Conversion/TritonToLinalgExperimental/TritonToLinalgExperimentalPass.cpp
@@ -53,8 +53,7 @@ public:
     auto moduleOp = getOperation();
     PassManager pm(&getContext(), moduleOp.getOperationName());
 
-    pm.addPass(createTritonToStructuredPass(
-        enableMakeGatherScatterTensorPtr));
+    pm.addPass(createTritonToStructuredPass(enableMakeGatherScatterTensorPtr));
 
     // Erase dead code and fold constants created during lowering
     pm.addPass(createCSEPass());

--- a/lib/Dialect/TPtr/IR/TPtrOps.cpp
+++ b/lib/Dialect/TPtr/IR/TPtrOps.cpp
@@ -1,14 +1,14 @@
-#include "mlir/Interfaces/SideEffectInterfaces.h" // Required for IR/TPtrOps.h.inc
 #include "mlir/Bytecode/BytecodeOpInterface.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h" // Required for IR/TPtrOps.h.inc
 
-#include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
-#include "mlir/IR/MLIRContext.h"
-#include "mlir/IR/OperationSupport.h"
-#include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/Dialect.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/OpImplementation.h"
+#include "mlir/IR/OperationSupport.h"
 
 #include "mlir/Dialect/Ptr/IR/PtrDialect.h"
 #include "mlir/Dialect/Ptr/IR/PtrTypes.h"

--- a/lib/Dialect/TritonStructured/IR/TritonStructuredOps.cpp
+++ b/lib/Dialect/TritonStructured/IR/TritonStructuredOps.cpp
@@ -132,10 +132,11 @@ void MakeTensorPtrOp::build(OpBuilder &b, OperationState &state, Value base,
 }
 
 void MakeGatherScatterTensorPtrOp::build(OpBuilder &b, OperationState &state,
-                                    Value base, Value gatherScatterOffset,
-                                    int gatherScatterDim, ArrayRef<int64_t> sizes,
-                                    ArrayRef<OpFoldResult> strides,
-                                    ArrayRef<OpFoldResult> offsets) {
+                                         Value base, Value gatherScatterOffset,
+                                         int gatherScatterDim,
+                                         ArrayRef<int64_t> sizes,
+                                         ArrayRef<OpFoldResult> strides,
+                                         ArrayRef<OpFoldResult> offsets) {
   SmallVector<int64_t> staticStrides, staticOffsets;
   SmallVector<Value> dynamicStrides, dynamicOffsets;
   for (auto [i, offset] : llvm::enumerate(offsets)) {

--- a/lib/Dialect/TritonTilingExt/IR/BufferizableOpInterfaceImpl.cpp
+++ b/lib/Dialect/TritonTilingExt/IR/BufferizableOpInterfaceImpl.cpp
@@ -36,8 +36,7 @@ namespace {
 /// Generic conversion for any DestinationStyleOpInterface on tensors.
 static LogicalResult bufferizeTritonTilingExtDestinationStyleOpInterface(
     RewriterBase &rewriter, DestinationStyleOpInterface op,
-    const BufferizationOptions &options,
-    BufferizationState &state) {
+    const BufferizationOptions &options, BufferizationState &state) {
   // Take a guard before anything else.
   OpBuilder::InsertionGuard g(rewriter);
   rewriter.setInsertionPoint(op);
@@ -59,7 +58,8 @@ static LogicalResult bufferizeTritonTilingExtDestinationStyleOpInterface(
       newInputBuffers.push_back(opOperand->get());
       continue;
     }
-    FailureOr<Value> buffer = getBuffer(rewriter, opOperand->get(), options, state);
+    FailureOr<Value> buffer =
+        getBuffer(rewriter, opOperand->get(), options, state);
     if (failed(buffer))
       return failure();
     newInputBuffers.push_back(*buffer);

--- a/lib/Sanitizer/SanitizerAttributes/SanitizerAttributes.cpp
+++ b/lib/Sanitizer/SanitizerAttributes/SanitizerAttributes.cpp
@@ -1,20 +1,20 @@
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Passes/PassPlugin.h"
-#include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/raw_ostream.h"
 
 using namespace llvm;
 
 namespace opts {
 
 // command line option for the type of sanitizer
-static cl::opt<std::string> SanitizerType(
-  "sanitizer-type", 
-  cl::desc("Type of sanitizer being used: AddressSanitizer = asan, ThreadSanitizer = tsan"),
-  cl::value_desc("string")
-);
+static cl::opt<std::string>
+    SanitizerType("sanitizer-type",
+                  cl::desc("Type of sanitizer being used: AddressSanitizer = "
+                           "asan, ThreadSanitizer = tsan"),
+                  cl::value_desc("string"));
 
-}
+} // namespace opts
 
 namespace {
 
@@ -26,7 +26,7 @@ struct SanitizerAttributes : PassInfoMixin<SanitizerAttributes> {
     } else if (opts::SanitizerType == "tsan") {
       F.addFnAttr(Attribute::SanitizeThread);
     }
-    
+
     // this pass modifies all function attributes
     return PreservedAnalyses::none();
   }

--- a/tools/triton-shared-opt/triton-shared-opt.cpp
+++ b/tools/triton-shared-opt/triton-shared-opt.cpp
@@ -13,6 +13,6 @@ int main(int argc, char **argv) {
   mlir::DialectRegistry registry;
   registerTritonSharedDialects(registry);
 
-  return mlir::asMainReturnCode(mlir::MlirOptMain(
-      argc, argv, "Triton-Shared test driver\n", registry));
+  return mlir::asMainReturnCode(
+      mlir::MlirOptMain(argc, argv, "Triton-Shared test driver\n", registry));
 }


### PR DESCRIPTION
This PR does the following:

* Clang-Formats all C and C++ files within our repository using the LLVM style.
* Creates a github workflow that will verify code formatting on PRs.
* Removes symlink of clang-format in favor of a permanent copy. We do not care to keep it up to date with Triton. The likelihood of Triton updating their clang format file is low enough for this to not be a problem. Even if it were updated, it is not essential for us to fully match their style. It is more important to have a permanent copy that keeps the workflows simple.