### PR TITLE
Set default other = 0 for masked load

### DIFF
--- a/lib/Conversion/StructuredToMemref/StructuredToMemref.cpp
+++ b/lib/Conversion/StructuredToMemref/StructuredToMemref.cpp
@@ -784,10 +784,13 @@ private:
     SmallVector<OpFoldResult> mixedDims = op.getMixedMaskDims();
 
     // Fill load destination with other value
-    if (Value other = op.getOther()) {
-      fillWithValue(loc, alloc, other, tensorType.getShape(),
-                    op.getMixedMaskDims(), op.getStaticMaskDims(), rewriter);
+    Value other = op.getOther();
+    if (!other) {
+      other = rewriter.create<arith::ConstantOp>(
+          loc, rewriter.getZeroAttr(elemType));
     }
+    fillWithValue(loc, alloc, other, tensorType.getShape(),
+                  op.getMixedMaskDims(), op.getStaticMaskDims(), rewriter);
 
     auto ptrDefiningOp = ptr.getDefiningOp();
     if (ptrDefiningOp->hasAttr(WRAP_SIDE_BY_SIDE) ||


### PR DESCRIPTION
For masked loads where other is not specified, the Triton CUDA backend fills the masked elements with 0 by default. This change ensures that the behavior matches the Triton CUDA backend results.

A reference test case named `basic_load` in Triton can be found here: [test/Conversion/tritongpu_to_llvm.mlir](https://github.com/triton-lang/triton/blob/05a0439087648793213accfe5459400bd1c79bc8/test/Conversion/tritongpu_to_llvm.mlir#L15-L26)
This test case specifies an other value. Its generated LLVM IR includes:

```
(module attributes {...}
  llvm.func @basic_load(...) {
    ...
    %10 = llvm.inline_asm has_side_effects ... "mov.u32 $0, $1;\0A\09@$3 ld.global.b32 { $0 }, [ $2 + 0 ];", ...
    ...
  }
)
```

Another test case `vecadd_masked_vec1` without an other value generates LLVM IR like:
```
(module attributes {...}
  llvm.func @vecadd_masked_vec1(...) {
    ...
    %72 = llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "mov.u32 $0, 0x0;\0A\09@$2 ld.global.b32 { $0 }, [ $1 + 0 ];", "=r,l,b" %70, %71 : (!llvm.ptr<1>, i1) -> i32
    ...
  }
)
```

In this case, the masked elements are always filled with 0x0 when other is not specified.