### PR TITLE
Canonicalize triton::ReduceOp select(cmpf) patterns to min/max operations

### DIFF
--- a/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
+++ b/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
@@ -1862,31 +1862,31 @@ struct MinMaxConverter : public OpRewritePattern<CmpOp> {
 
   MinMaxConverter(MLIRContext *context)
       : OpRewritePattern<CmpOp>(context, /*benefit=*/10) {}
-  
+
   /// Helper that maps a floating-point compare predicate to the
   /// corresponding min/max operation. THis is parametrized by
   /// whether we want NaN-aware operations (MaximumFOp/MinimumFOp) or
   /// numeric operations (MaxNumFOp/MinNumFOp).
-  LogicalResult foldCmpToMinMax(PatternRewriter &rewriter, Location loc,
-                                Value lhs, Value rhs, arith::CmpFPredicate pred,
-                                bool useNaNOps, Value &result) const {
+  FailureOr<Value> foldCmpToMinMax(PatternRewriter &rewriter, Location loc,
+                                   Value lhs, Value rhs,
+                                   arith::CmpFPredicate pred,
+                                   bool useNaNOps) const {
     switch (pred) {
     case arith::CmpFPredicate::OGT:
     case arith::CmpFPredicate::OGE:
       if (useNaNOps) {
-        result = rewriter.create<arith::MaximumFOp>(loc, lhs, rhs).getResult();
+        return rewriter.create<arith::MaximumFOp>(loc, lhs, rhs).getResult();
       } else {
-        result = rewriter.create<arith::MaxNumFOp>(loc, lhs, rhs).getResult();
+        return rewriter.create<arith::MaxNumFOp>(loc, lhs, rhs).getResult();
       }
       return success();
     case arith::CmpFPredicate::OLT:
     case arith::CmpFPredicate::OLE:
       if (useNaNOps) {
-        result = rewriter.create<arith::MinimumFOp>(loc, lhs, rhs).getResult();
+        return rewriter.create<arith::MinimumFOp>(loc, lhs, rhs).getResult();
       } else {
-        result = rewriter.create<arith::MinNumFOp>(loc, lhs, rhs).getResult();
+        return rewriter.create<arith::MinNumFOp>(loc, lhs, rhs).getResult();
       }
-      return success();
     default:
       return failure();
     }
@@ -1970,12 +1970,13 @@ struct MinMaxConverter : public OpRewritePattern<CmpOp> {
             pred == arith::CmpFPredicate::OLT) {
           rewriter.setInsertionPoint(sel);
           Value foldedResult;
-          if (failed(foldCmpToMinMax(rewriter, sel.getLoc(), trueVal, falseVal,
-                                     pred, /*useNaNOps=*/false,
-                                     foldedResult))) {
+          FailureOr<Value> foldResult =
+              foldCmpToMinMax(rewriter, sel.getLoc(), trueVal, falseVal, pred,
+                              /*useNaNOps=*/false);
+          if (failed(foldResult)) {
             return failure();
           }
-          rewriter.replaceOp(sel, foldedResult);
+          rewriter.replaceOp(sel, *foldResult);
           return success();
         }
       }
@@ -2006,26 +2007,28 @@ struct MinMaxConverter : public OpRewritePattern<CmpOp> {
       // Match: select ((ogt(a, b) || une(a, a)), a, b) -> arith.maximumf(a, b).
       if ((isOGT(cmp1) && isNaN(cmp2)) || (isOGT(cmp2) && isNaN(cmp1))) {
         rewriter.setInsertionPoint(sel);
-        Value foldedResult;
-        if (failed(foldCmpToMinMax(rewriter, sel.getLoc(), trueVal, falseVal,
-                                   arith::CmpFPredicate::OGT,
-                                   /*useNaNOps=*/true, foldedResult))) {
+        FailureOr<Value> foldResult =
+            foldCmpToMinMax(rewriter, sel.getLoc(), trueVal, falseVal,
+                            arith::CmpFPredicate::OGT,
+                            /*useNaNOps=*/true);
+        if (failed(foldResult)) {
           return failure();
         }
-        rewriter.replaceOp(sel, foldedResult);
+        rewriter.replaceOp(sel, *foldResult);
         return success();
       }
 
       // Match: select ((olt(a, b) || une(a, a)), a, b) -> arith.minimumf(a, b).
       if ((isOLT(cmp1) && isNaN(cmp2)) || (isOLT(cmp2) && isNaN(cmp1))) {
         rewriter.setInsertionPoint(sel);
-        Value foldedResult;
-        if (failed(foldCmpToMinMax(rewriter, sel.getLoc(), trueVal, falseVal,
-                                   arith::CmpFPredicate::OLT,
-                                   /*useNaNOps=*/true, foldedResult))) {
+        FailureOr<Value> foldResult =
+            foldCmpToMinMax(rewriter, sel.getLoc(), trueVal, falseVal,
+                            arith::CmpFPredicate::OLT,
+                            /*useNaNOps=*/true);
+        if (failed(foldResult)) {
           return failure();
         }
-        rewriter.replaceOp(sel, foldedResult);
+        rewriter.replaceOp(sel, *foldResult);
         return success();
       }
     }
@@ -2035,17 +2038,13 @@ struct MinMaxConverter : public OpRewritePattern<CmpOp> {
   void rewriteOpWithMinMax(PatternRewriter &rewriter, arith::CmpFOp cmpOp,
                            arith::SelectOp selectOp,
                            arith::CmpFPredicate pred) const {
-    Value foldedResult;
-    // For the generic cmp+select pattern, we use the NaN-aware ops
-    // (arith::MaximumFOp/arith::MinimumFOp) to preserve semantics in the
-    // presence of NaN values.
-    if (succeeded(foldCmpToMinMax(rewriter, selectOp.getLoc(), cmpOp.getLhs(),
-                                  cmpOp.getRhs(), pred, /*useNaNOps=*/true,
-                                  foldedResult))) {
-      rewriter.replaceOp(selectOp, foldedResult);
-    } else {
+    FailureOr<Value> foldedResult =
+        foldCmpToMinMax(rewriter, selectOp.getLoc(), cmpOp.getLhs(),
+                        cmpOp.getRhs(), pred, /*useNaNOps=*/true);
+    if (failed(foldedResult)) {
       llvm_unreachable("Unhandled predicate");
     }
+    rewriter.replaceOp(selectOp, *foldedResult);
   }
 
   void rewriteOpWithMinMax(PatternRewriter &rewriter, arith::CmpIOp cmpOp,

--- a/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
+++ b/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
@@ -1928,13 +1928,9 @@ struct MinMaxConverter : public OpRewritePattern<CmpOp> {
   /// 'arith.select' operations based on a floating-point comparison
   /// and rewrites them into equivalent numeric min/max operations.
   ///
-  /// This pattern handles the following cases:
+  /// This pattern handles the following case:
   ///
-  /// 1. ** Simple Min/Max Reduction **
-  ///    - select (cmpf ogt a, b), a, b --> arith.maxnumf(a, b)
-  ///    - select (cmpf olt a, b), a, b --> arith.minnumf(a, b)
-  ///
-  /// 2. ** NaN-Aware Min/Max Reduction **
+  /// ** NaN-Aware Min/Max Reduction **
   ///    - select (cmpf ogt a, b) || cmpf une a, a), a, b --> arith.maximumf(a,
   ///    b)
   ///    - select (cmpf olt a, b) || cmpf une a, a), a, b --> arith.minimumf(a,
@@ -1960,80 +1956,56 @@ struct MinMaxConverter : public OpRewritePattern<CmpOp> {
     Value trueVal = sel.getTrueValue();
     Value falseVal = sel.getFalseValue();
 
-    // Case 1: Simple Min/Max Reduction (numeric min/max).
-    if (auto cmp = dyn_cast<arith::CmpFOp>(condOp)) {
+    // NaN-Aware Min/Max Reduction.
+    auto ori = dyn_cast<arith::OrIOp>(condOp);
+    if (!ori)
+      return failure();
+    // Extract both sides of the OR condition.
+    auto cmp1 = ori.getLhs().getDefiningOp<arith::CmpFOp>();
+    auto cmp2 = ori.getRhs().getDefiningOp<arith::CmpFOp>();
+    if (!cmp1 || !cmp2)
+      return failure();
 
-      if (cmp.getLhs() == trueVal && cmp.getRhs() == falseVal) {
-        auto pred = cmp.getPredicate();
-        // Only fold OGT/OLT predicates.
-        if (pred == arith::CmpFPredicate::OGT ||
-            pred == arith::CmpFPredicate::OLT) {
-          PatternRewriter::InsertionGuard guard(rewriter);
-          rewriter.setInsertionPoint(sel);
-          Value foldedResult;
-          FailureOr<Value> foldResult =
-              foldCmpToMinMax(rewriter, sel.getLoc(), trueVal, falseVal, pred,
-                              /*useNaNOps=*/false);
-          if (failed(foldResult)) {
-            return failure();
-          }
-          rewriter.replaceOp(sel, *foldResult);
-          return success();
-        }
+    // Helper lambdas to identify comparison patterns.
+    auto isOGT = [&](arith::CmpFOp cmp) {
+      return cmp.getPredicate() == arith::CmpFPredicate::OGT &&
+             trueVal == cmp.getLhs() && falseVal == cmp.getRhs();
+    };
+    auto isOLT = [&](arith::CmpFOp cmp) {
+      return cmp.getPredicate() == arith::CmpFPredicate::OLT &&
+             trueVal == cmp.getLhs() && falseVal == cmp.getRhs();
+    };
+    auto isNaN = [&](arith::CmpFOp cmp) {
+      return cmp.getPredicate() == arith::CmpFPredicate::UNE &&
+             trueVal == cmp.getLhs() && trueVal == cmp.getRhs();
+    };
+
+    // Match: select ((ogt(a, b) || une(a, a)), a, b) -> arith.maximumf(a, b).
+    if ((isOGT(cmp1) && isNaN(cmp2)) || (isOGT(cmp2) && isNaN(cmp1))) {
+      PatternRewriter::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPoint(sel);
+      FailureOr<Value> foldResult = foldCmpToMinMax(
+          rewriter, sel.getLoc(), trueVal, falseVal, arith::CmpFPredicate::OGT,
+          /*useNaNOps=*/true);
+      if (failed(foldResult)) {
+        return failure();
       }
+      rewriter.replaceOp(sel, *foldResult);
+      return success();
     }
 
-    // Case 2: NaN-Aware Min/Max Reduction.
-    if (auto ori = dyn_cast<arith::OrIOp>(condOp)) {
-      // Extract both sides of the OR condition.
-      auto cmp1 = ori.getLhs().getDefiningOp<arith::CmpFOp>();
-      auto cmp2 = ori.getRhs().getDefiningOp<arith::CmpFOp>();
-      if (!cmp1 || !cmp2)
+    // Match: select ((olt(a, b) || une(a, a)), a, b) -> arith.minimumf(a, b).
+    if ((isOLT(cmp1) && isNaN(cmp2)) || (isOLT(cmp2) && isNaN(cmp1))) {
+      PatternRewriter::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPoint(sel);
+      FailureOr<Value> foldResult = foldCmpToMinMax(
+          rewriter, sel.getLoc(), trueVal, falseVal, arith::CmpFPredicate::OLT,
+          /*useNaNOps=*/true);
+      if (failed(foldResult)) {
         return failure();
-
-      // Helper lambdas to identify comparison patterns.
-      auto isOGT = [&](arith::CmpFOp cmp) {
-        return cmp.getPredicate() == arith::CmpFPredicate::OGT &&
-               trueVal == cmp.getLhs() && falseVal == cmp.getRhs();
-      };
-      auto isOLT = [&](arith::CmpFOp cmp) {
-        return cmp.getPredicate() == arith::CmpFPredicate::OLT &&
-               trueVal == cmp.getLhs() && falseVal == cmp.getRhs();
-      };
-      auto isNaN = [&](arith::CmpFOp cmp) {
-        return cmp.getPredicate() == arith::CmpFPredicate::UNE &&
-               trueVal == cmp.getLhs() && trueVal == cmp.getRhs();
-      };
-
-      // Match: select ((ogt(a, b) || une(a, a)), a, b) -> arith.maximumf(a, b).
-      if ((isOGT(cmp1) && isNaN(cmp2)) || (isOGT(cmp2) && isNaN(cmp1))) {
-        PatternRewriter::InsertionGuard guard(rewriter);
-        rewriter.setInsertionPoint(sel);
-        FailureOr<Value> foldResult =
-            foldCmpToMinMax(rewriter, sel.getLoc(), trueVal, falseVal,
-                            arith::CmpFPredicate::OGT,
-                            /*useNaNOps=*/true);
-        if (failed(foldResult)) {
-          return failure();
-        }
-        rewriter.replaceOp(sel, *foldResult);
-        return success();
       }
-
-      // Match: select ((olt(a, b) || une(a, a)), a, b) -> arith.minimumf(a, b).
-      if ((isOLT(cmp1) && isNaN(cmp2)) || (isOLT(cmp2) && isNaN(cmp1))) {
-        PatternRewriter::InsertionGuard guard(rewriter);
-        rewriter.setInsertionPoint(sel);
-        FailureOr<Value> foldResult =
-            foldCmpToMinMax(rewriter, sel.getLoc(), trueVal, falseVal,
-                            arith::CmpFPredicate::OLT,
-                            /*useNaNOps=*/true);
-        if (failed(foldResult)) {
-          return failure();
-        }
-        rewriter.replaceOp(sel, *foldResult);
-        return success();
-      }
+      rewriter.replaceOp(sel, *foldResult);
+      return success();
     }
     return failure();
   }

--- a/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
+++ b/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
@@ -1968,6 +1968,7 @@ struct MinMaxConverter : public OpRewritePattern<CmpOp> {
         // Only fold OGT/OLT predicates.
         if (pred == arith::CmpFPredicate::OGT ||
             pred == arith::CmpFPredicate::OLT) {
+          PatternRewriter::InsertionGuard guard(rewriter);
           rewriter.setInsertionPoint(sel);
           Value foldedResult;
           FailureOr<Value> foldResult =
@@ -2006,6 +2007,7 @@ struct MinMaxConverter : public OpRewritePattern<CmpOp> {
 
       // Match: select ((ogt(a, b) || une(a, a)), a, b) -> arith.maximumf(a, b).
       if ((isOGT(cmp1) && isNaN(cmp2)) || (isOGT(cmp2) && isNaN(cmp1))) {
+        PatternRewriter::InsertionGuard guard(rewriter);
         rewriter.setInsertionPoint(sel);
         FailureOr<Value> foldResult =
             foldCmpToMinMax(rewriter, sel.getLoc(), trueVal, falseVal,
@@ -2020,6 +2022,7 @@ struct MinMaxConverter : public OpRewritePattern<CmpOp> {
 
       // Match: select ((olt(a, b) || une(a, a)), a, b) -> arith.minimumf(a, b).
       if ((isOLT(cmp1) && isNaN(cmp2)) || (isOLT(cmp2) && isNaN(cmp1))) {
+        PatternRewriter::InsertionGuard guard(rewriter);
         rewriter.setInsertionPoint(sel);
         FailureOr<Value> foldResult =
             foldCmpToMinMax(rewriter, sel.getLoc(), trueVal, falseVal,

--- a/test/Conversion/TritonToLinalg/convert_minmax_reduce.mlir
+++ b/test/Conversion/TritonToLinalg/convert_minmax_reduce.mlir
@@ -124,3 +124,35 @@ module {
 // CHECK:    affine.store %[[VAL_12]], %[[VAL_13]][0] : memref<1xi32, strided<[1]>>
 // CHECK:    return
 // CHECK:  }
+
+// -----
+
+module {
+  tt.func public @nan_aware_max(%arg0: tensor<1024xf32>, %arg_out: !tt.ptr<f32>) {
+    %res = "tt.reduce"(%arg0) <{axis = 0 : i32}> ({
+    ^bb0(%lhs: f32, %rhs: f32):
+      %cmp_gt = arith.cmpf ogt, %lhs, %rhs : f32
+      %lhs_nan = arith.cmpf une, %lhs, %lhs : f32
+      %pred = arith.ori %cmp_gt, %lhs_nan : i1
+      %sel = arith.select %pred, %lhs, %rhs : f32
+      tt.reduce.return %sel : f32
+    }) : (tensor<1024xf32>) -> f32
+    tt.store %arg_out, %res : !tt.ptr<f32>
+    tt.return 
+}
+}
+
+// CHECK-LABEL:  func.func @nan_aware_max
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1024xf32>, [[PARAM_1_:%.+]]: !tt.ptr<f32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_nan_:%.+]] = arith.constant 0xFF800000 : f32
+// CHECK-DAG:       [[VAR_0_:%.+]] = bufferization.alloc_tensor() : tensor<f32>
+// CHECK:           [[VAR_inserted_:%.+]] = tensor.insert [[CST_nan_]] into [[VAR_0_]][] : tensor<f32>
+// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[PARAM_0_]] : tensor<1024xf32>) outs([[VAR_inserted_]] : tensor<f32>) dimensions = [0]
+// CHECK:             ([[in_:%.+]]: f32, [[in_]]it: f32) {
+// CHECK:               [[CMP_gt_:%.+]] = arith.maximumf [[in_]], [[in_]]it : f32
+// CHECK:               linalg.yield [[CMP_gt_]] : f32
+// CHECK:             }
+// CHECK:           [[VAR_extracted_:%.+]] = tensor.extract [[VAR_reduced_]][] : tensor<f32>
+// CHECK:           tt.store [[PARAM_1_]], [[VAR_extracted_]] : !tt.ptr<f32>
+// CHECK:           return
+// CHECK:         }


### PR DESCRIPTION
This PR introduces a pattern rewrite that simplifies `triton::ReduceOp` bodies containing `arith.select` operations based on floating-point comparisons. The transformation replaces select-based logic with equivalent min/max operations, improving IR canonicalization and enabling further optimization. 
### Supported Transformations:
- `select(cmpf ogt a, b), a, b` → `arith.maxf(a, b)`
- `select(cmpf olt a, b), a, b` → `arith.minf(a, b)`
- `select((cmpf ogt a, b) || cmpf une a, a), a, b` → `arith.maximumf(a, b)`
- `select((cmpf olt a, b) || cmpf une a, a), a, b` → `arith.minimumf(a, b)`

Applying this transformation before the `ReduceOp` converter runs allows the natural lowering of `tt.reduce` to `linalg.reduce`; the motivational use case was from a torch-inductor spit out Triton kernel which consisted of this complex pattern in the reduction body and did not allow the `ReduceOp` to get lowered to the `linalg` dialect. 